### PR TITLE
Fix: Test failures due to archive directories and sample log files

### DIFF
--- a/tests/fixtures/deploy/workspace-patternfile/archives/pattern-test.log
+++ b/tests/fixtures/deploy/workspace-patternfile/archives/pattern-test.log
@@ -1,0 +1,6 @@
+This is a test archive log file for testing pattern-based copy_archives functionality.
+It should be copied when the deploy copy-archives command is run with patterns.
+
+Test log entry 1: Pattern matching test started
+Test log entry 2: File processing with glob patterns
+Test log entry 3: Archive pattern test completed at 2024-01-01 12:00:00

--- a/tests/fixtures/deploy/workspace/archives/test.log
+++ b/tests/fixtures/deploy/workspace/archives/test.log
@@ -1,0 +1,6 @@
+This is a test archive log file for testing the copy_archives functionality.
+It should be copied when the deploy copy-archives command is run.
+
+Test log entry 1: Application started successfully
+Test log entry 2: Processing completed
+Test log entry 3: Archive created at 2024-01-01 12:00:00


### PR DESCRIPTION
The deploy tests were failing because the test fixtures were missing the required 'archives' directories that the copy_archives function expects to exist. Added:

- tests/fixtures/deploy/workspace/archives/test.log
- tests/fixtures/deploy/workspace-patternfile/archives/pattern-test.log

These files were created using 'git add -f' since they have .log extensions which are normally ignored by .gitignore.

Fixes failing tests:
- test_copy_archive_dir
- test_copy_archive_pattern
- test_deploy_archive
- test_deploy_archive4