### PR TITLE
Fix: package name references from lftools to lftools-uv

### DIFF
--- a/docs/commands/openstack.rst
+++ b/docs/commands/openstack.rst
@@ -6,7 +6,7 @@
 OpenStack
 *********
 
-Requires a `pip install lftools[openstack]` to activate this command.
+Requires a `pip install lftools-uv[openstack]` to activate this command.
 Requires `qemu-img` binary to upload images
 
 .. program-output:: lftools-uv openstack --help

--- a/lftools_uv/cli/no_cmd.py
+++ b/lftools_uv/cli/no_cmd.py
@@ -19,8 +19,8 @@ import click
 @click.group()
 @click.pass_context
 def no_ldap(ctx):
-    """(lftools[ldap]) Provides an ldap interface.
+    """(lftools-uv[ldap]) Provides an ldap interface.
 
-    To activate this interface run `pip install lftools[ldap]`.
+    To activate this interface run `pip install lftools-uv[ldap]`.
     """
     pass

--- a/lftools_uv/openstack/no_cmd.py
+++ b/lftools_uv/openstack/no_cmd.py
@@ -19,8 +19,8 @@ import click
 @click.group()
 @click.pass_context
 def openstack(ctx, os_cloud):
-    """(lftools[openstack]) Provides an OpenStack interface.
+    """(lftools-uv[openstack]) Provides an OpenStack interface.
 
-    To activate this interface run `pip install lftools[openstack]`.
+    To activate this interface run `pip install lftools-uv[openstack]`.
     """
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ test = [
 
 # Combined extra for development work
 all = [
-    "lftools[dev,ldap,openstack,test]"
+    "lftools-uv[dev,ldap,openstack,test]"
 ]
 
 [project.urls]


### PR DESCRIPTION
The migration from lftools to lftools-uv missed several package name references that still pointed to the old 'lftools' package. This was causing dependency update workflows to fail with warnings like:

'The package lftools==0.37.3 does not have an extra named dev' 'The package lftools==0.37.3 does not have an extra named test'

Fixed references in:
- pyproject.toml: 'all' extra dependency
- docs/commands/openstack.rst: installation instructions
- lftools_uv/cli/no_cmd.py: ldap interface docstring
- lftools_uv/openstack/no_cmd.py: openstack interface docstring

All references now correctly point to 'lftools-uv' package.