### PR TITLE
Fix: remove pygments constraint conflicting with Sigstore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,8 +292,6 @@ constraint-dependencies = [
     "cryptography>=46.0.5",
     # Fixes CVE-2025-14009 (Zip Slip) and CVE-2026-33230 (XSS)
     "nltk>=3.9.4",
-    # Bump transitive dependency to latest stable
-    "pygments>=2.20.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,6 @@ constraints = [
     { name = "authlib", specifier = ">=1.6.9" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "nltk", specifier = ">=3.9.4" },
-    { name = "pygments", specifier = ">=2.20.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The `pygments>=2.20.0` entry in `[tool.uv] constraint-dependencies` conflicts with the Sigstore signing action (`sigstore/gh-action-sigstore-python`), which pins `pygments==2.19.2` in its own environment. Since the action runs `uv` from the project directory, it picks up the local constraints and fails with:

```
Because you require pygments==2.19.2 and pygments>=2.20.0, we can
conclude that your requirements are unsatisfiable.
```

## Fix

Remove the `pygments>=2.20.0` constraint. Unlike the other entries in that section (authlib, cryptography, nltk), this was not a security fix — it was simply bumping a transitive dependency to latest stable.