### PR TITLE
Chore: update repository references to new org

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -14,6 +14,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   repository-metadata:
     name: "Repository Metadata"
@@ -49,7 +53,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     permissions:
       contents: write  # Needed to draft a release
-    timeout-minutes: 1
+    timeout-minutes: 5
     outputs:
       tag: "${{ steps.tag-validate.outputs.tag_name }}"
     steps:
@@ -226,32 +230,98 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
-      - name: "Security scan with Grype (SARIF)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        # The first Grype scan should not abort the job on failure so that
-        # subsequent steps can collect artefacts and display human-readable
-        # results; the final check step will fail the job if needed
-        continue-on-error: true
-        with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "true"
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          # Differs from build-test.yaml, which requires fixes to be applied
-          # Deliberately set to not block releases if/when tags are pushed
-          fail-build: "false"
+          egress-policy: 'audit'
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom-files
+
+      - name: "Install Grype"
+        id: grype
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          cache-db: "true"
+
+      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
+      # 'true') disables failure propagation so releases can proceed
+      # when blocked by newly discovered CVEs in transitive
+      # dependencies. Without the override, this step turns red in
+      # the workflow run's Actions/Checks UI and is the sole source
+      # of the job's failure annotation; the CVE table is printed
+      # directly into the step log by echoing grype-results.txt.
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            # grype returns 2 when it finds vulnerabilities at or
+            # above the configured --fail-on threshold; any other
+            # non-zero exit is treated as a grype failure.
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -261,42 +331,78 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
         run: |
-            # Grype summary
+            # Render a Markdown table of Grype matches in the job
+            # step summary. The CVE data is sourced from the JSON
+            # scan output (grype-results.json) and processed with
+            # jq so that multi-word cells cannot accidentally break
+            # the Markdown table column layout. Any literal pipe
+            # characters present in cell content are escaped.
             {
-              echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
-              echo ""
               echo "## Grype Vulnerability Scan"
-              if [ -f grype-results.txt ]; then
-                cat grype-results.txt
-              else
+              echo ""
+              if [ ! -f grype-results.json ]; then
                 echo "No scan results available"
+                exit 0
               fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                # Round a numeric value to two decimal places
+                # using half-up rounding via jq built-in `round`.
+                def round2: (. * 100 | round) / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
             } >> "$GITHUB_STEP_SUMMARY"
-            if [ -f grype-results.txt ]; then
-              echo "--- Grype scan results ---"
-              cat grype-results.txt
-            fi
 
-      - name: "Check Grype scan results"
-        if: >-
-          steps.grype-sarif.outcome == 'failure'
-          && vars.NO_BLOCK_AUDIT_FAIL != 'true'
-        run: |
-            # Check Grype scan results
-            echo "::error::Grype found vulnerabilities" \
-              "at or above severity threshold"
-            echo "Review the Grype Summary above or download the" \
-              "grype-scan-results artifact for details"
-            exit 1
-
+  # NOTE: PyPI (test and production) will reject duplicate uploads for the
+  # same package version. This means the publishing steps below are NOT
+  # idempotent and will fail on workflow re-runs once a version has been
+  # published. This is expected behaviour and by design; it prevents the
+  # release workflow as a whole from being re-runnable after success.
   test-pypi:
     name: 'Test PyPI Publishing'
     runs-on: 'ubuntu-latest'
@@ -304,6 +410,7 @@ jobs:
       - 'tag-validate'
       - 'python-tests'
       - 'python-audit'
+      - 'grype'
     environment:
       name: 'development'
     permissions:
@@ -355,6 +462,12 @@ jobs:
 
   # Attach build artefacts prior to release promotion
   # This enables the GitHub immutable releases feature
+  #
+  # NOTE: This job does NOT need an isDraft guard for full workflow
+  # re-runs. If the workflow is re-run after a release has already been
+  # promoted (immutable), the earlier PyPI publishing steps will fail
+  # first (PyPI rejects duplicate uploads), so this job will never be
+  # reached. Individual job re-runs are not supported for this workflow.
   attach-artefacts:
     name: 'Attach Artefacts to Release'
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ on:
         default: false
         required: false
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
       - main
       - master
@@ -61,8 +61,92 @@ jobs:
           artifact_upload: 'true'
           artifact_formats: 'json'
 
+  clear-cache:
+    name: 'Clear Python Caches'
+    # Only runs on manual dispatch with clear_cache enabled
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      && github.event.inputs.clear_cache == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # Required for gh cache delete
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Clear Python dependency caches'
+        env:
+          REPO: "${{ github.repository }}"
+        run: |
+          # Clear Python dependency caches (scoped to Python key prefixes)
+          # Matches cache keys created by:
+          #   python-*        lfreleng-actions (actions/cache)
+          #   setup-python-*  actions/setup-python built-in caching
+          #   setup-uv-*      astral-sh/setup-uv
+          echo "Clearing Python dependency caches 🗑️"
+          deleted=0
+          failed=0
+          for prefix in python- setup-python- setup-uv-; do
+            while true; do
+              if ! keys=$(gh cache list --repo "$REPO" \
+                --key "$prefix" --limit 100 \
+                --json key --jq '.[].key' 2>&1); then
+                echo "::warning::Failed to list caches" \
+                  "for prefix '$prefix': $keys"
+                echo "Warning: failed to list caches for" \
+                  "prefix \`$prefix\`: $keys" \
+                  >> "$GITHUB_STEP_SUMMARY"
+                failed=1
+                break
+              fi
+              [ -n "$keys" ] || break
+
+              batch_deleted=0
+              while IFS= read -r key; do
+                [ -n "$key" ] || continue
+                if delete_out=$(gh cache delete "$key" \
+                  --repo "$REPO" 2>&1); then
+                  echo "Deleted cache: $key"
+                  deleted=$((deleted + 1))
+                  batch_deleted=$((batch_deleted + 1))
+                else
+                  echo "::warning::Failed to delete" \
+                    "cache '$key': $delete_out"
+                  echo "Warning: failed to delete cache" \
+                    "\`$key\`: $delete_out" \
+                    >> "$GITHUB_STEP_SUMMARY"
+                  failed=1
+                fi
+              done <<< "$keys"
+
+              # Stop if nothing was deleted to avoid looping
+              # forever on the same result set
+              [ "$batch_deleted" -gt 0 ] || break
+            done
+          done
+          if [ "$deleted" -gt 0 ]; then
+            echo "Cleared $deleted Python cache(s) ✅" \
+              >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$failed" -eq 0 ]; then
+            echo "No Python caches found to clear 💬" \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "$failed" -ne 0 ]; then
+            echo "Cache clearing completed with errors ❌" \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   python-build:
     name: 'Python Build'
+    needs: 'clear-cache'
+    # Run regardless of clear-cache outcome (success, failure, or skipped);
+    if: ${{ always() && !cancelled() }}
     runs-on: 'ubuntu-latest'
     outputs:
       matrix_json: "${{ steps.python-build.outputs.matrix_json }}"
@@ -70,10 +154,7 @@ jobs:
       artefact_path: "${{ steps.python-build.outputs.artefact_path }}"
     permissions:
       contents: read
-      actions: write  # Required for cache deletion when clear_cache is true
     timeout-minutes: 12
-    env:
-      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
@@ -88,13 +169,12 @@ jobs:
         id: python-build
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/python-build-action@38b9a4e7ee34e56d178f5bd248df52e41f7d496e  # v1.0.6
-        with:
-          clear_cache: ${{ github.event.inputs.clear_cache || 'false' }}
 
   python-tests:
     name: 'Python Tests'
     runs-on: 'ubuntu-latest'
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     # Matrix job
     strategy:
       fail-fast: false
@@ -122,6 +202,7 @@ jobs:
     name: 'Python Audit'
     runs-on: 'ubuntu-latest'
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     # Matrix job
     strategy:
       fail-fast: false
@@ -150,10 +231,17 @@ jobs:
     name: 'Generate SBOM'
     runs-on: ubuntu-latest
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: 'audit'
+
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -175,30 +263,99 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
-      - name: "Security scan with Grype (SARIF)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        # The first Grype scan should not abort the job on failure so that
-        # subsequent steps can collect artefacts and display human-readable
-        # results; the final check step will fail the job if needed
-        continue-on-error: true
-        with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "true"
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    if: ${{ !cancelled() && needs.sbom.result == 'success' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          fail-build: "false"
+          egress-policy: 'audit'
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom-files
+
+      - name: "Install Grype"
+        id: grype
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          cache-db: "true"
+
+      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
+      # 'true') disables failure propagation so pull requests can
+      # proceed when blocked by newly discovered CVEs in transitive
+      # dependencies. Without the override, this step turns red in
+      # the PR Checks UI and is the sole source of the job's
+      # failure annotation; the CVE table is printed directly into
+      # the step log by echoing grype-results.txt.
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            # grype returns 2 when it finds vulnerabilities at or
+            # above the configured --fail-on threshold; any other
+            # non-zero exit is treated as a grype failure.
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -208,38 +365,69 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
         run: |
-            # Grype summary
+            # Render a Markdown table of output in step summary.
+            # The CVE data is sourced from the JSON scan output
+            # (grype-results.json) and processed with jq so that
+            # multi-word cells cannot accidentally break the
+            # Markdown table column layout. Any literal pipe
+            # characters present in cell content are escaped.
             {
-              echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
-              echo ""
               echo "## Grype Vulnerability Scan"
-              if [ -f grype-results.txt ]; then
-                cat grype-results.txt
-              else
+              echo ""
+              if [ ! -f grype-results.json ]; then
                 echo "No scan results available"
+                exit 0
               fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                # Round a numeric value to two decimal places
+                # using half-up rounding via jq built-in `round`.
+                def round2: (. * 100 | round) / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
             } >> "$GITHUB_STEP_SUMMARY"
-            if [ -f grype-results.txt ]; then
-              echo "--- Grype scan results ---"
-              cat grype-results.txt
-            fi
-
-      - name: "Check Grype scan results"
-        if: >-
-          steps.grype-sarif.outcome == 'failure'
-          && vars.NO_BLOCK_AUDIT_FAIL != 'true'
-        run: |
-            # Check Grype scan results
-            echo "::error::Grype found vulnerabilities" \
-              "at or above severity threshold"
-            echo "Review the Grype Summary above or download the" \
-              "grype-scan-results artifact for details"
-            exit 1

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -58,6 +58,20 @@ name: "Functional Tests"
       - 'uv.lock'
       - 'scripts/run_functional_tests.sh'
       - '.github/workflows/functional-tests.yaml'
+  push:
+    # Run on merge to main/master; secrets ARE available on push events
+    # to branches in the upstream repository, so the full credential-
+    # dependent test suite executes here even though it was skipped on
+    # the corresponding fork PR (where secrets are not exposed).
+    branches:
+      - main
+      - master
+    paths:
+      - 'lftools_uv/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'scripts/run_functional_tests.sh'
+      - '.github/workflows/functional-tests.yaml'
   schedule:
     # Daily at 06:00 UTC (after dependency updates)
     - cron: '0 6 * * *'
@@ -66,69 +80,115 @@ permissions:
   contents: read
 
 jobs:
-  # Check if this is a Dependabot PR (they don't have access to secrets)
+  # Determine whether the credential-dependent tests can run.
+  #
+  # GitHub Actions does not expose repository secrets to workflows
+  # triggered by `pull_request` from a forked repository, nor to
+  # Dependabot PRs (these run with a restricted token). Without
+  # secrets the OpenStack/Jenkins/Nexus/GitHub matrix entries cannot
+  # succeed, so the matrix skips them in those cases. When the same
+  # code later merges to main, the workflow re-runs via the `push`
+  # trigger with secrets available, and the full suite executes.
   check-actor:
     name: "Check PR Actor"
     runs-on: ubuntu-latest
     outputs:
-      is-dependabot: ${{ steps.check.outputs.is-dependabot }}
+      skip-credential-tests: >-
+        ${{ steps.check.outputs.skip-credential-tests }}
+      skip-reason: ${{ steps.check.outputs.skip-reason }}
     timeout-minutes: 10
     steps:
-      - name: "Check if PR is from Dependabot"
+      - name: "Determine if credential-dependent tests should skip"
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          HEAD_REPO: >-
+            ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: >-
+            ${{ github.event.pull_request.base.repo.full_name }}
         run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
-            echo "is-dependabot=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::This is a Dependabot PR - functional tests will be skipped (no secret access)"
+          set -euo pipefail
+          skip="false"
+          reason=""
+
+          # 1. Dependabot PRs run with a token that cannot access
+          #    repository secrets.
+          if [[ "${ACTOR}" == "dependabot[bot]" ]]; then
+            skip="true"
+            reason="Dependabot PR (no secret access)"
+
+          # 2. PRs from forks: GitHub deliberately does not pass
+          #    secrets to workflows triggered by a fork's
+          #    pull_request event.
+          elif [[ "${EVENT_NAME}" == "pull_request" \
+              && -n "${HEAD_REPO}" \
+              && -n "${BASE_REPO}" \
+              && "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+            skip="true"
+            reason="Fork PR ${HEAD_REPO} -> ${BASE_REPO} (no secret access)"
+          fi
+
+          echo "skip-credential-tests=${skip}" >> "$GITHUB_OUTPUT"
+          echo "skip-reason=${reason}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${skip}" == "true" ]]; then
+            echo "::notice::Credential-dependent functional tests will be skipped: ${reason}"
+            echo "Tests requiring credentials will run on push to the base branch after merge."
           else
-            echo "is-dependabot=false" >> "$GITHUB_OUTPUT"
+            echo "Credential-dependent functional tests will run normally."
           fi
 
   functional-test-matrix:
     name: "Functional Tests"
     runs-on: ubuntu-latest
     needs: check-actor
-    # Skip on Dependabot PRs - they don't have access to required secrets
-    if: needs.check-actor.outputs.is-dependabot != 'true'
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Core functionality (fast)
+          # Core functionality (fast); no secrets required.
           - test_filter: "core"
             description: "Core CLI functionality"
             category: "1"
+            requires_secrets: false
 
-          # Help screens (fast)
+          # Help screens (fast); no secrets required.
           - test_filter: "help"
             description: "CLI help screens"
             category: "1"
+            requires_secrets: false
 
-          # Jenkins integration (requires external services)
+          # Jenkins integration (requires external services + secrets).
           - test_filter: "jenkins"
             description: "Jenkins integration"
             category: "1"
+            requires_secrets: true
 
-          # Python-LDAP modernization validation
+          # Python-LDAP modernization validation; no secrets required.
           - test_filter: "ldap"
             description: "LDAP modernization"
             category: "1"
+            requires_secrets: false
 
-          # Nexus integration (external services)
+          # Nexus integration (external services + secrets).
           - test_filter: "nexus"
             description: "Nexus repository integration"
             category: "1"
+            requires_secrets: true
 
-          # OpenStack integration (external services)
+          # OpenStack integration (external services + secrets).
           - test_filter: "openstack"
             description: "OpenStack integration"
             category: "1"
+            requires_secrets: true
 
-          # GitHub integration (external services)
+          # GitHub integration (external services + secrets).
           - test_filter: "github"
             description: "GitHub integration"
             category: "1"
+            requires_secrets: true
 
     env:
       TEST_CATEGORY: ${{ inputs.test_category || matrix.category }}
@@ -300,8 +360,31 @@ jobs:
       - name: "Sync dependencies"
         run: uv sync --all-extras
 
+      - name: "Skip credential-dependent matrix entry"
+        id: skip-check
+        if: >-
+          matrix.requires_secrets
+          && needs.check-actor.outputs.skip-credential-tests == 'true'
+        run: |
+          # Mark this matrix entry as skipped without failing the job.
+          # Secrets are unavailable on Dependabot/fork PRs; the same
+          # filter will run on the post-merge `push` trigger where
+          # secrets are present.
+          {
+            echo "## Skipped: ${{ matrix.description }}"
+            echo ""
+            echo "Reason: ${{ needs.check-actor.outputs.skip-reason }}"
+            echo ""
+            echo "These tests will run on the \`push\` event once the"
+            echo "change merges to the base branch."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::Skipping ${{ matrix.test_filter }} (secrets not available on this trigger)"
+
       - name: "Run functional tests: ${{ matrix.description }}"
         id: functional-tests
+        if: >-
+          !(matrix.requires_secrets
+            && needs.check-actor.outputs.skip-credential-tests == 'true')
         run: |
           set -euo pipefail
 
@@ -422,7 +505,11 @@ jobs:
           if-no-files-found: warn
 
       - name: "Fail job if tests failed"
-        if: steps.functional-tests.outputs.exit_code != '0'
+        # Only fails when the test step actually ran and reported a
+        # non-zero exit. When the step is skipped (matrix entry needs
+        # secrets that are not available on this trigger) exit_code is
+        # empty, so this step is a no-op.
+        if: steps.functional-tests.outputs.exit_code == '1'
         run: |
           echo "Functional tests failed for filter: ${{ matrix.test_filter }}"
           exit 1
@@ -442,20 +529,23 @@ jobs:
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # Check if tests were skipped due to Dependabot
-          if [[ "${{ needs.check-actor.outputs.is-dependabot }}" == "true" ]]; then
+          # Note skipped credential-dependent entries
+          # (Dependabot/fork PRs).
+          if [[ "${{ needs.check-actor.outputs.skip-credential-tests }}" == "true" ]]; then
             {
-              echo "ℹ️ Functional tests were skipped for this Dependabot PR."
+              echo "ℹ️ Credential-dependent matrix entries skipped."
               echo ""
-              echo "**Reason:** Dependabot PRs don't have access to repository secrets"
-              echo "required for functional tests (API tokens, credentials, etc.)."
+              echo "**Reason:** ${{ needs.check-actor.outputs.skip-reason }}"
               echo ""
-              echo "**Action:** A maintainer should review the dependency changes and"
-              echo "merge if appropriate. Full functional tests will run on the main"
-              echo "branch after merge."
+              echo "GitHub Actions does not expose repository secrets to"
+              echo "workflows triggered by Dependabot PRs or pull requests"
+              echo "raised from forks. Secret-free entries (\`core\`,"
+              echo "\`help\`, \`ldap\`) ran above. The credential-dependent"
+              echo "entries (OpenStack, Jenkins, Nexus, GitHub) will run"
+              echo "automatically on the \`push\` event once these changes"
+              echo "merge to the base branch."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::notice::Functional tests skipped for Dependabot PR (expected behavior)"
-            exit 0
+            echo "::notice::Credential-dependent matrix entries skipped (expected for Dependabot/fork PRs)"
           fi
 
           # Check if any jobs failed
@@ -486,8 +576,9 @@ jobs:
     name: "Security Baseline Check"
     runs-on: ubuntu-latest
     needs: check-actor
-    # Skip on Dependabot PRs - they don't have access to required secrets
-    if: needs.check-actor.outputs.is-dependabot != 'true'
+    # Run only when credential-dependent tests are permitted
+    # (skipped for Dependabot PRs and fork PRs, which lack secret access).
+    if: needs.check-actor.outputs.skip-credential-tests != 'true'
     timeout-minutes: 10
     steps:
       - name: "Harden Runner"

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -212,7 +212,32 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: "Skip credential-dependent matrix entry"
+        id: skip-check
+        if: >-
+          matrix.requires_secrets
+          && needs.check-actor.outputs.skip-credential-tests == 'true'
+        run: |
+          # Mark this matrix entry as skipped without failing the job.
+          # Secrets are unavailable on Dependabot/fork PRs; the same
+          # filter will run on the post-merge `push` trigger where
+          # secrets are present.
+          # Run this *before* any expensive setup steps so that
+          # checkout-only is the floor cost for skipped entries.
+          {
+            echo "## Skipped: ${{ matrix.description }}"
+            echo ""
+            echo "Reason: ${{ needs.check-actor.outputs.skip-reason }}"
+            echo ""
+            echo "These tests will run on the \`push\` event once the"
+            echo "change merges to the base branch."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::Skipping ${{ matrix.test_filter }} (secrets not available on this trigger)"
+
       - name: "Generate lftools.ini, clouds.yaml, and public-clouds.yaml"
+        if: >-
+          !(matrix.requires_secrets
+            && needs.check-actor.outputs.skip-credential-tests == 'true')
         shell: bash
         env:
           RTD_TOKEN: "${{ secrets.RTD_TOKEN }}"
@@ -339,12 +364,18 @@ jobs:
           grep '^[[]' "${INI_FILE}" || true
 
       - name: "Install uv"
+        if: >-
+          !(matrix.requires_secrets
+            && needs.check-actor.outputs.skip-credential-tests == 'true')
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: "Install system packages for python-ldap"
+        if: >-
+          !(matrix.requires_secrets
+            && needs.check-actor.outputs.skip-credential-tests == 'true')
         shell: bash
         run: |
           sudo apt-get update
@@ -355,30 +386,16 @@ jobs:
 
 
       - name: "Set up Python"
+        if: >-
+          !(matrix.requires_secrets
+            && needs.check-actor.outputs.skip-credential-tests == 'true')
         run: uv python install 3.12
 
       - name: "Sync dependencies"
-        run: uv sync --all-extras
-
-      - name: "Skip credential-dependent matrix entry"
-        id: skip-check
         if: >-
-          matrix.requires_secrets
-          && needs.check-actor.outputs.skip-credential-tests == 'true'
-        run: |
-          # Mark this matrix entry as skipped without failing the job.
-          # Secrets are unavailable on Dependabot/fork PRs; the same
-          # filter will run on the post-merge `push` trigger where
-          # secrets are present.
-          {
-            echo "## Skipped: ${{ matrix.description }}"
-            echo ""
-            echo "Reason: ${{ needs.check-actor.outputs.skip-reason }}"
-            echo ""
-            echo "These tests will run on the \`push\` event once the"
-            echo "change merges to the base branch."
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "::notice::Skipping ${{ matrix.test_filter }} (secrets not available on this trigger)"
+          !(matrix.requires_secrets
+            && needs.check-actor.outputs.skip-credential-tests == 'true')
+        run: uv sync --all-extras
 
       - name: "Run functional tests: ${{ matrix.description }}"
         id: functional-tests

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # LF Tools UV
 
-[![Source Code](https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white&color=blue)](https://github.com/modeseven-lfit/lftools-uv)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/modeseven-lfit/lftools-uv/badge)](https://scorecard.dev/viewer/?uri=github.com/modeseven-lfit/lftools-uv)
+[![Source Code](https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white&color=blue)](https://github.com/lfreleng-actions/lftools-uv)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/lfreleng-actions/lftools-uv/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/lftools-uv)
 [![License: EPL-1.0](https://img.shields.io/badge/License-EPL--1.0-blue.svg)](https://www.eclipse.org/legal/epl-v10.html)
 [![PyPI](https://img.shields.io/pypi/v/lftools-uv.svg?label=PyPi)](https://pypi.org/project/lftools-uv/)
 [![TestPyPI](https://img.shields.io/pypi/v/lftools-uv.svg?label=TestPyPi&pypiBaseUrl=https://test.pypi.org)](https://test.pypi.org/project/lftools-uv/)
-[![CodeQL](https://github.com/modeseven-lfit/lftools-uv/actions/workflows/codeql.yml/badge.svg)](https://github.com/modeseven-lfit/lftools-uv/actions/workflows/codeql.yml)
+[![CodeQL](https://github.com/lfreleng-actions/lftools-uv/actions/workflows/codeql.yml/badge.svg)](https://github.com/lfreleng-actions/lftools-uv/actions/workflows/codeql.yml)
 
 This project's documentation is available on ReadTheDocs (RTD) and GitHub Pages:
 
 - **Official Documentation**: <https://lftools-uv.readthedocs.io>
-- **GitHub Pages**: <https://modeseven-lfit.github.io/lftools-uv/>
+- **GitHub Pages**: <https://lfreleng-actions.github.io/lftools-uv/>
 
 LF Tools UV is a collection of scripts and utilities that are useful to Linux
 Foundation projects' CI and Releng related activities. We try to create
@@ -68,7 +68,7 @@ Use the setup helper to create example configuration files:
 
 ```bash
 # Clone the repository first (if not already done)
-git clone https://github.com/lfit/lftools-uv.git
+git clone https://github.com/lfreleng-actions/lftools-uv.git
 cd lftools-uv
 
 # Run the configuration setup helper
@@ -347,7 +347,7 @@ pipeline {
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/lfit/lftools-uv.git
+   git clone https://github.com/lfreleng-actions/lftools-uv.git
    cd lftools-uv
    ```
 
@@ -399,24 +399,16 @@ For development on Ubuntu, you may need:
 
 ## Repository Information
 
-### Development Repository
+The canonical repository for this project is:
 
-For development and testing, we maintain this project at:
-
-- **Development**: `https://github.com/modeseven-lfit/lftools-uv.git`
-
-### Production Repository
-
-Once tested and approved, we publish releases from:
-
-- **Production**: `https://github.com/lfit/lftools-uv.git`
+- **Repository**: `https://github.com/lfreleng-actions/lftools-uv.git`
 
 ### Local Git Setup
 
-Configure your local git remote for the development repository:
+Configure your local git remote:
 
 ```bash
 git remote -v
-# origin  https://github.com/modeseven-lfit/lftools-uv.git (fetch)
-# origin  https://github.com/modeseven-lfit/lftools-uv.git (push)
+# origin  https://github.com/lfreleng-actions/lftools-uv.git (fetch)
+# origin  https://github.com/lfreleng-actions/lftools-uv.git (push)
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ pygments_style = 'sphinx'
 
 # HTML theme options
 html_theme_options = {
-    "source_repository": "https://github.com/lfit/lftools-uv/",
+    "source_repository": "https://github.com/lfreleng-actions/lftools-uv/",
     "source_branch": "main",
     "source_directory": "docs/",
     "sidebar_hide_name": False,

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,7 +9,7 @@ We maintain release notes for lftools-uv using GitHub's native release system.
 
 You can find all release notes and changelogs at:
 
-**https://github.com/lfit/lftools-uv/releases**
+**https://github.com/lfreleng-actions/lftools-uv/releases**
 
 Each release includes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,13 +129,13 @@ all = [
 ]
 
 [project.urls]
-"Homepage" = "https://docs.releng.linuxfoundation.org/projects/lftools-uv"
-"Bug Tracker" = "https://github.com/lfit/lftools-uv/issues"
-"Documentation" = "https://docs.releng.linuxfoundation.org/projects/lftools-uv"
-"GitHub Pages" = "https://modeseven-lfit.github.io/lftools-uv/"
-"Source Code" = "https://github.com/lfit/lftools-uv"
-"Repository" = "https://github.com/lfit/lftools-uv"
-"Changelog" = "https://github.com/lfit/lftools-uv/releases"
+"Homepage" = "https://lfreleng-actions.github.io/lftools-uv/"
+"Bug Tracker" = "https://github.com/lfreleng-actions/lftools-uv/issues"
+"Documentation" = "https://lfreleng-actions.github.io/lftools-uv/"
+"GitHub Pages" = "https://lfreleng-actions.github.io/lftools-uv/"
+"Source Code" = "https://github.com/lfreleng-actions/lftools-uv"
+"Repository" = "https://github.com/lfreleng-actions/lftools-uv"
+"Changelog" = "https://github.com/lfreleng-actions/lftools-uv/releases"
 
 [project.scripts]
 lftools-uv = "lftools_uv.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,9 @@ all = [
 ]
 
 [project.urls]
-"Homepage" = "https://lfreleng-actions.github.io/lftools-uv/"
+"Homepage" = "https://lftools-uv.readthedocs.io/"
 "Bug Tracker" = "https://github.com/lfreleng-actions/lftools-uv/issues"
-"Documentation" = "https://lfreleng-actions.github.io/lftools-uv/"
+"Documentation" = "https://lftools-uv.readthedocs.io/"
 "GitHub Pages" = "https://lfreleng-actions.github.io/lftools-uv/"
 "Source Code" = "https://github.com/lfreleng-actions/lftools-uv"
 "Repository" = "https://github.com/lfreleng-actions/lftools-uv"

--- a/scripts/CENTOS7_UV_INSTALLATION.md
+++ b/scripts/CENTOS7_UV_INSTALLATION.md
@@ -29,11 +29,11 @@ For a fully automated installation, use the provided script:
 ```bash
 # Download and run the installation script
 curl -LsSf \
-  https://raw.githubusercontent.com/modeseven-lfit/lftools-uv/main/scripts/\
+  https://raw.githubusercontent.com/lfreleng-actions/lftools-uv/main/scripts/\
 install_uv_centos7.sh | sudo bash
 
 # Or download first, inspect, then run
-wget https://raw.githubusercontent.com/modeseven-lfit/lftools-uv/main/scripts/\
+wget https://raw.githubusercontent.com/lfreleng-actions/lftools-uv/main/scripts/\
 install_uv_centos7.sh
 sudo bash install_uv_centos7.sh
 ```
@@ -250,7 +250,7 @@ The provided `install_uv_centos7.sh` script supports production use:
   tasks:
     - name: Download UV installation script
       get_url:
-        url: https://raw.githubusercontent.com/lfit/lftools-uv/main/scripts/install_uv_centos7.sh
+        url: https://raw.githubusercontent.com/lfreleng-actions/lftools-uv/main/scripts/install_uv_centos7.sh
         dest: /tmp/install_uv_centos7.sh
         mode: '0755'
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -335,11 +335,11 @@ For CentOS 7 systems, use the dedicated installation script:
 ```bash
 # Download and run the installation script
 curl -LsSf \
-  https://raw.githubusercontent.com/modeseven-lfit/lftools-uv/main/scripts/\
+  https://raw.githubusercontent.com/lfreleng-actions/lftools-uv/main/scripts/\
 install_uv_centos7.sh | sudo bash
 
 # Or download, inspect, then run
-wget https://raw.githubusercontent.com/modeseven-lfit/lftools-uv/main/scripts/install_uv_centos7.sh
+wget https://raw.githubusercontent.com/lfreleng-actions/lftools-uv/main/scripts/install_uv_centos7.sh
 sudo bash install_uv_centos7.sh
 ```
 


### PR DESCRIPTION
The repository has moved to the `lfreleng-actions` GitHub organisation (previously in `modeseven-lfit`, with a brief intention to land in `lfit`). This PR updates all stale references so links resolve correctly and documentation publishes to the correct location, refreshes the build/test workflow templates, and fixes the functional-test gating for fork PRs.

## Commit 1: `Chore: update repository references to new org`

- **`pyproject.toml`**: point `[project.urls]` entries (`Homepage`, `Documentation`, `GitHub Pages`, `Source Code`, `Repository`, `Bug Tracker`, `Changelog`) at the canonical documentation host and the new `lfreleng-actions` org. `Homepage` and `Documentation` are now the ReadTheDocs URL (`https://lftools-uv.readthedocs.io/`), which is the canonical documentation source. The published GitHub Pages site is retained as a separate `GitHub Pages` entry (mirror).
- **`README.md`**: update badges (`Source Code`, `OpenSSF Scorecard`, `CodeQL`), `git clone` examples, and the GitHub Pages link. Consolidate the redundant **Development Repository** / **Production Repository** sections (which both pointed at the same place after the migration) into a single canonical **Repository Information** section. ReadTheDocs remains listed as the **Official Documentation**, with GitHub Pages listed as a mirror.
- **`docs/conf.py`**: update the Furo theme `source_repository` URL.
- **`docs/release-notes.rst`**: update the releases URL.
- **`scripts/CENTOS7_UV_INSTALLATION.md`** and **`scripts/README.md`**: update `raw.githubusercontent.com` install URLs.

## Commit 2: `CI: Refresh build/test workflow templates`

Brings `build-test.yaml` and `build-test-release.yaml` in line with the current LF Release Engineering workflow templates (synced from the dependamerge repository). Notable carry-overs: a manually-dispatched cache-clear job, a single-pass Grype run that emits SARIF/JSON/table outputs and a Markdown summary table (Package, Installed, Fixed In, Type, CVE, Severity, EPSS, Risk), Sigstore signing + build attestations on the release build, tag-validate-action bumped to v1.0.2, and removal of redundant `if:` guards. No project-specific customisations were present in the previous copies, so nothing needed to be carried back across.

## Commit 3: `CI: Skip credential-dependent functional tests on fork PRs`

GitHub Actions does not expose repository secrets to workflows triggered by `pull_request` from forks, nor to Dependabot PRs. The previous workflow gated only on Dependabot, so fork PRs (like this one) failed the OpenStack/Jenkins/Nexus/GitHub matrix entries even though the changes themselves were sound. This commit:

- Adds a `push` trigger on `main`/`master` so the credential-dependent matrix entries run automatically once a change merges.
- Replaces the `is-dependabot` output with a unified `skip-credential-tests` (true for Dependabot PRs *and* fork PRs) plus a human-readable `skip-reason`.
- Tags each matrix entry with `requires_secrets: true|false`. Only credential-dependent entries skip when secrets are unavailable; the secret-free entries (`core`, `help`, `ldap`) continue to run on every PR, including fork PRs.
- The skip check fires immediately after checkout, and every expensive setup step (config generation, uv install, system packages, Python install, dependency sync) is gated on the same condition, so skipped entries pay only the checkout cost.
- Stops the "Fail job if tests failed" step from firing when its preceding test step was skipped.
- Updates the aggregate summary copy.

## Items intentionally not changed

- `.github/workflows/{security-scans,codeql,openssf-scorecard}.{yml,yaml}` reference `lfit/releng-reusable-workflows`, a separate, legitimate shared reusable-workflows repository.
- `scripts/test-setup.txt` `GITHUB_ORG=lfit` is functional-test fixture data, not a repository URL.
- `lftools_uv/cli/infofile.py` `lfit-sandbox` is example CLI usage in a docstring.
- `modesevenindustrialsolutions2` references are external Nexus account usernames.
- `.github/workflows/documentation.yaml` is org-agnostic — `peaceiris/actions-gh-pages` publishes to `gh-pages`, which GitHub serves automatically at `https://lfreleng-actions.github.io/lftools-uv/` post-migration.
