### PR TITLE
Fix: drop tox package_env override for docs build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ envlist =
 minversion = 4.0
 skip_missing_interpreters = true
 ignore_basepython_conflict = true
-package_env = build
 
 # pytest configuration is now in pyproject.toml
 


### PR DESCRIPTION
## Problem

The GitHub Pages documentation workflow ([example failing run](https://github.com/lfreleng-actions/lftools-uv/actions/runs/25009995553/job/73242919178)) fails on every invocation with:

```
docs: failed with PEP-517 packaging environment 'build' does not support
the deps configuration. Build dependencies should be specified in the
[build-system] table of pyproject.toml or by the build backend via
get_requires_for_build hooks
```

`tox` 4.53.0 tightened validation of PEP-517 packaging environments. Our `tox.ini` pinned `package_env = build` in `[tox]`, which redirects PEP-517 build orchestration through the existing `[testenv:build]` env. That env exists to drive `python -m build` / packaging uploads and declares its own `deps = build[virtualenv]`. tox 4.53 now refuses to use it for PEP-517 builds because a packaging env must source its build requirements from `[build-system]` in `pyproject.toml` (hatchling + hatch-vcs in our case), not from a `deps =` line.

## Fix

Drop the `package_env = build` override so tox uses its default `.pkg` environment for PEP-517 builds. `.pkg` reads `[build-system]` directly, which is exactly what the new validation expects. The dedicated `[testenv:build]` env is unchanged and still available for explicit packaging work via `tox -e build`.

## Verification

Locally reproduced with tox 4.53.0 (via `uvx --from 'tox>=4.53' tox`):

- Before: `docs: FAIL code 1` with the message above.
- After: `tox -e docs --notest` provisions `.pkg`, builds the sdist via hatchling, resolves docs dependencies, and exits `OK`.