### PR TITLE
CI: Fix docs version, modernise Pages workflow, and resolve uv cache contention

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,8 +30,9 @@ on:
   release:
     types: [published]
 
-# Cancel in-progress runs for the same ref but never cancel an in-flight
-# Pages deployment (see actions/deploy-pages docs).
+# Serialize concurrent runs for the same ref so that an in-flight Pages
+# deployment is never cancelled (per actions/deploy-pages guidance);
+# subsequent runs queue rather than aborting the running one.
 concurrency:
   group: "pages-${{ github.ref }}"
   cancel-in-progress: false
@@ -74,14 +75,13 @@ jobs:
       - name: 'Set up Python'
         run: uv python install 3.13
 
-      - name: 'Install system packages for python-ldap'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libldap2-dev libsasl2-dev libssl-dev \
-            libsasl2-modules gcc build-essential
-          sudo rm -rf /var/lib/apt/lists/*
+      # The docs build only renders CLI "--help" output via
+      # sphinxcontrib-programoutput; it does not install the optional
+      # "ldap" extra and the CLI falls back to a no-op "no_ldap" stub
+      # when python-ldap is unavailable. System packages for python-ldap
+      # (libldap2-dev / libsasl2-dev / build-essential) are therefore
+      # not required here and have been deliberately omitted to keep
+      # the build fast.
 
       - name: 'Sync project (with docs extras)'
         run: uv sync --extra docs --extra openstack

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -2,97 +2,190 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-# Publishes documentation to GitHub Pages
-name: 'GitHub Pages Documentation'
+# Builds Sphinx documentation and publishes it to GitHub Pages using the
+# modern Pages deployment model (configure-pages + upload-pages-artifact
+# + deploy-pages). Read the Docs continues to publish independently via
+# the .readthedocs.yml configuration.
+#
+# IMPORTANT: in the repository settings under "Pages > Build and
+# deployment", the "Source" must be set to "GitHub Actions" for this
+# workflow to deploy successfully. The legacy "Deploy from a branch"
+# (gh-pages) source is no longer used.
 
-# Note: The initial publish may fail, see the documentation here:
-# https://github.com/peaceiris/actions-gh-pages
-# Heading: First Deployment with GITHUB_TOKEN
+name: 'GitHub Pages Documentation'
 
 # yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - 'main'
       - 'master'
-      - '!update-devops-tooling'
     paths:
-      - '**'
-      - '!.github/**'
-      - '!.*'
-      - '!pdm.lock'
-      - '!tox.ini'
+      - 'docs/**'
+      - 'lftools_uv/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/documentation.yaml'
+  release:
+    types: [published]
+
+# Cancel in-progress runs for the same ref but never cancel an in-flight
+# Pages deployment (see actions/deploy-pages docs).
+concurrency:
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: false
 
 permissions: {}
 
 jobs:
-  publish-docs:
-    name: 'Publish Documentation'
+  build:
+    name: 'Build Documentation'
     runs-on: 'ubuntu-latest'
-    concurrency:
-      group: "${{ github.workflow }}-${{ github.ref }}"
     permissions:
-      # IMPORTANT: mandatory for documentation updates; used in final step
-      contents: write
-    env:
-      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    timeout-minutes: 12
+      contents: read
+    timeout-minutes: 15
+    outputs:
+      project-version: ${{ steps.version.outputs.version }}
     steps:
-      # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
-      - name: 'Checkout Repository'
+      - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Fetch full history and tags so hatch-vcs can derive the
+          # correct dynamic version. Without this the build falls back
+          # to the configured fallback-version (0.0.0) and produces a
+          # misleading "0.0.1.dev1"-style version string.
+          fetch-depth: 0
+
+      - name: 'Install uv'
+        # yamllint disable-line rule:line-length
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          cache-suffix: "documentation"
 
       - name: 'Set up Python'
-        # yamllint disable-line rule:line-length
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.13'
+        run: uv python install 3.13
 
-      - name: 'Check documentation dependencies'
-        id: docs-requirements
-        # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
-        with:
-          path: 'docs/requirements.txt'
-
-      - name: 'Check for TOX configuration'
-        id: tox-ini
-        # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
-        with:
-          path: 'tox.ini'
-
-      - name: 'Install documentation dependencies'
-        if: steps.docs-requirements.outputs.type == 'file'
+      - name: 'Install system packages for python-ldap'
+        shell: bash
         run: |
-          # Install documentation dependencies
-          echo "Installing documentation dependencies"
-          pip --disable-pip-version-check install -r docs/requirements.txt
-          echo "Documentation dependencies installed ✅"
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libldap2-dev libsasl2-dev libssl-dev \
+            libsasl2-modules gcc build-essential
+          sudo rm -rf /var/lib/apt/lists/*
 
-      - name: 'Build documentation (tox/sphinx)'
-        if: steps.tox-ini.outputs.type == 'file'
+      - name: 'Sync project (with docs extras)'
+        run: uv sync --extra docs --extra openstack
+
+      - name: 'Resolve project version'
+        id: version
+        shell: bash
         run: |
-          # Build documentation (tox/sphinx)
-          pip --disable-pip-version-check install --upgrade tox
-          tox -e docs
-          echo "Tox documentation build ✅"
+          # Read the installed distribution version (set by hatch-vcs at
+          # install time). This is what Sphinx will pick up via
+          # importlib.metadata in docs/conf.py.
+          py='import importlib.metadata as m; print(m.version("lftools-uv"))'
+          version=$(uv run python -c "${py}")
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved project version: ${version}"
 
-      - name: 'Publish documentation'
-        if: success()
+      - name: 'Build Sphinx documentation'
+        shell: bash
+        run: |
+          uv run sphinx-build -b html -n --keep-going \
+            -d docs/_build/doctrees \
+            docs/ docs/_build/html
+
+      - name: 'Upload Pages artifact'
         # yamllint disable-line rule:line-length
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
-          publish_branch: 'gh-pages'
-          # github_token: "${{ secrets.GITHUB_TOKEN }}"
-          github_token: "${{ github.token }}"
-          publish_dir: 'docs/_build/html/'
-          keep_files: true
+          path: 'docs/_build/html'
+
+      - name: 'Build summary'
+        if: always()
+        shell: bash
+        env:
+          PROJECT_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "## 📚 Documentation build"
+            echo ""
+            echo "| Item | Value |"
+            echo "| ---- | ----- |"
+            echo "| Project version | \`${PROJECT_VERSION:-unknown}\` |"
+            echo "| Git ref | \`${GITHUB_REF}\` |"
+            echo "| Commit | \`${GITHUB_SHA}\` |"
+            echo "| Builder | Sphinx (\`uv run sphinx-build\`) |"
+            echo "| Output | \`docs/_build/html\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  deploy:
+    name: 'Deploy to GitHub Pages'
+    needs: build
+    # Only deploy on push to the default branch, on a published release,
+    # or on manual dispatch. Pull requests should never deploy.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'release'
+      || (github.event_name == 'push'
+          && (github.ref == 'refs/heads/main'
+              || github.ref == 'refs/heads/master'))
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    timeout-minutes: 10
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: 'Configure Pages'
+        # yamllint disable-line rule:line-length
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
+
+      - name: 'Deploy to GitHub Pages'
+        id: deployment
+        # yamllint disable-line rule:line-length
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+
+      - name: 'Deployment summary'
+        if: always()
+        shell: bash
+        env:
+          PROJECT_VERSION: ${{ needs.build.outputs.project-version }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          {
+            echo "## 🚀 GitHub Pages deployment"
+            echo ""
+            if [ -n "${PAGE_URL}" ]; then
+              echo "**Site:** [${PAGE_URL}](${PAGE_URL})"
+            else
+              echo "**Site:** _(deployment did not produce a URL)_"
+            fi
+            echo ""
+            echo "| Item | Value |"
+            echo "| ---- | ----- |"
+            echo "| Project version | \`${PROJECT_VERSION:-unknown}\` |"
+            echo "| Trigger | \`${GITHUB_EVENT_NAME}\` |"
+            echo "| Git ref | \`${GITHUB_REF}\` |"
+            echo "| Commit | \`${GITHUB_SHA}\` |"
+            echo ""
+            echo "_Read the Docs builds (if enabled) publish independently"
+            echo "via the \`.readthedocs.yml\` configuration._"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,6 +64,17 @@ jobs:
           # misleading "0.0.1.dev1"-style version string.
           fetch-depth: 0
 
+      - name: 'Gather repository metadata'
+        id: repo-metadata
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/repository-metadata-action@ceabcd987d13d7bfefd2372e01eebb0ddac45956  # v0.2.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_summary: 'true'
+          gerrit_summary: 'false'
+          artifact_upload: 'true'
+          artifact_formats: 'json'
+
       - name: 'Install uv'
         # yamllint disable-line rule:line-length
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -371,6 +371,11 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Unique suffix per matrix entry avoids parallel cache write
+          # contention ("Unable to reserve cache with key ...") when all
+          # matrix jobs would otherwise compute the same cache key from
+          # identical OS + Python + uv.lock inputs.
+          cache-suffix: "functional-${{ matrix.test_filter }}"
 
       - name: "Install system packages for python-ldap"
         if: >-
@@ -732,6 +737,9 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
+          # Distinct suffix prevents this job racing the matrix jobs for
+          # the same cache key when running in parallel.
+          cache-suffix: "security-baseline"
 
       - name: "Install system packages for python-ldap"
         shell: bash

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -737,6 +737,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
           # Distinct suffix prevents this job racing the matrix jobs for
           # the same cache key when running in parallel.
           cache-suffix: "security-baseline"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,13 +30,26 @@ copyright = '2025, Linux Foundation Release Engineering'
 author = 'Linux Foundation Release Engineering'
 
 # Version information
+#
+# The project uses hatch-vcs (PEP 440 / setuptools-scm-style) dynamic
+# versioning, configured in pyproject.toml. Read the version from the
+# installed package metadata via importlib.metadata so the value reflects
+# the real distribution version (including tag-derived versions for
+# tagged builds and dev versions for post-tag commits). This requires
+# the project to be installed (e.g. "uv sync" or "pip install -e .")
+# in the build environment, and the build environment to have access to
+# git tags so hatch-vcs can derive the version at install time.
 try:
-    from pbr.version import VersionInfo
-    version = str(VersionInfo("lftools-uv"))
-    release = str(VersionInfo("lftools-uv"))
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+    try:
+        version = _pkg_version("lftools-uv")
+    except PackageNotFoundError:
+        version = "0.0.0"
 except Exception:
-    version = '0.37.14'
-    release = '0.37.14'
+    version = "0.0.0"
+
+release = version
 
 # Sphinx extensions
 extensions = [


### PR DESCRIPTION
## Summary

Four related CI/docs fixes addressing issues observed after the recent
organisation migration (`modeseven-lfit` → `lfreleng-actions`).

### 1. `CI(functional-tests): Add cache-suffix to setup-uv steps` (f557e8a)

The `functional-tests.yaml` workflow runs 7 parallel matrix entries plus
a `security-baseline` job, all calling `astral-sh/setup-uv` with
`enable-cache: true` on identical inputs. They all computed the same
cache key, so all but the winner emitted:

```
Failed to save: Unable to reserve cache with key
setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-pruned-...
```

Each job now has a unique `cache-suffix`, eliminating parallel write
contention and allowing every job to remain warm independently.

### 2. `Fix(docs): Use importlib.metadata for sphinx version` (cabf58b)

`docs/conf.py` previously read the project version via
`pbr.version.VersionInfo`, but the project switched to `hatch-vcs` for
dynamic versioning long ago. The `pbr` lookup combined with a stale
hardcoded fallback (`0.37.14`) caused the published docs to display the
wrong version (most recently `0.0.1.dev1` despite a `v0.2.0` tag).

Read the version from `importlib.metadata` instead, which honours
whatever hatch-vcs computed at install time.

### 3. `CI(docs): Modernise GitHub Pages publishing workflow` (42a6ca1)

Rewrites the workflow to use the modern GitHub Pages deployment model
(`actions/configure-pages` + `upload-pages-artifact` + `deploy-pages`)
instead of pushing to `gh-pages` via `peaceiris/actions-gh-pages`. The
old approach also caused the auto-generated `pages-build-deployment`
workflow to run on every `gh-pages` push, producing two overlapping
deployment paths that drifted out of sync after the org migration.

Highlights:

- Two-job split (`build` / `deploy`) with least-privilege scoping;
  `pages: write` and `id-token: write` only on the deploy job, gated
  to the `github-pages` environment.
- Triggers: `push` to the default branch, `release: published` (so
  tagged releases redeploy with the correct version), and
  `workflow_dispatch`. Removed the unusual `pull_request: closed`
  trigger.
- `fetch-depth: 0` so `hatch-vcs` sees the full tag history and
  derives the correct dynamic version (root cause of the
  `0.0.1.dev1` problem).
- `uv`-based build matching the rest of CI, with a unique
  `cache-suffix: "documentation"`.
- Rich `GITHUB_STEP_SUMMARY` in both jobs: project version, clickable
  deployed Pages URL, trigger, ref, and commit. The deploy job also
  surfaces the URL via the environment URL.
- All third-party actions pinned by commit SHA.

Read the Docs continues to publish independently via the existing
`.readthedocs.yml` configuration; both publishing channels now coexist
without conflict.

### 4. `CI(docs): Add repository-metadata-action to docs build` (9662eea)

Adds `lfreleng-actions/repository-metadata-action@ceabcd9` (v0.2.0) to
the `build` job, immediately after `actions/checkout` (which the action
depends on for git history and changed-files detection). The same pin
is already in use in `build-test.yaml`, keeping action SHAs consistent
across the repository's workflows.

Configuration:

- `github_token`: enables GitHub API-based changed-files detection and
  richer metadata.
- `github_summary: 'true'`: contributes the
  repository / event / commit / actor / cache table to
  `GITHUB_STEP_SUMMARY`, complementing the new "Documentation build"
  and "GitHub Pages deployment" summary tables.
- `gerrit_summary: 'false'`: this repository does not use Gerrit; the
  default of `true` would emit an empty section.
- `artifact_upload: 'true'` with `artifact_formats: 'json'`: uploads a
  single compact metadata artifact per run for downstream tooling
  consumption, matching the convention used in `build-test.yaml`.

The action is placed in the `build` job rather than `deploy` because
the deploy job has no checkout (it consumes the Pages artifact
uploaded by `build`) and so has no useful repository metadata to
gather.

### Copilot review feedback (ddb5310)

Round 1 of Copilot's review surfaced two follow-up items, both
addressed in `ddb5310`:

- `functional-tests.yaml`: also add `cache-dependency-glob: "uv.lock"`
  to the `security-baseline` job's `setup-uv` step so its cache
  invalidates on dependency changes (consistent with the matrix and
  docs jobs).
- `documentation.yaml`: drop the `python-ldap` apt install. The docs
  build runs `uv sync --extra docs --extra openstack` (no `ldap`
  extra) and the CLI falls back to a `no_ldap` stub when
  `python-ldap` is unavailable, so the system packages added install
  time and network surface area without benefit.

The most recent Copilot review pass on `ddb5310` produced no further
comments.

## Manual follow-up required

After this PR merges, set **Settings → Pages → Build and deployment →
Source** to **"GitHub Actions"** (not "Deploy from a branch"). The
`gh-pages` branch is no longer used and can be deleted (or kept as a
frozen archive).

## Verification

- Local `uv run sphinx-build` produces `lftools-uv 0.2.1.dev1
  documentation` on the current `main` (one commit past `v0.2.0`).
- `yamllint` and `actionlint` both clean on the rewritten workflow.
- All commits signed (ECDSA), DCO sign-off present, Claude
  co-authorship trailers included.
