### PR TITLE
Fix(ci): Repair Security Scans workflow (Sonatype + SonarCloud)

### DIFF
--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -34,7 +34,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonatype-lifecycle.yaml@2f4f1db634cdecc9af63d7946cb6b818ce590484 # v0.3.3
     with:
-      APPLICATION_ID: "bb7c7df5d19445cba258b6012b38bff3_lftools-uv"
+      APPLICATION_ID: "lftools-uv"
     secrets:
       NEXUS_IQ_PASSWORD: "${{ secrets.NEXUS_IQ_PASSWORD }}"
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-# The below are appropriate for Python projects
-# Define separate root directories for sources and tests
-sonar.organization="Release Engineering"
-sonar.projectKey=lftools-uv
-sonar.sources = lftools_uv/,shell/
-sonar.tests = tests/
+# SonarCloud project metadata
+sonar.organization=lfreleng-actions
+sonar.projectKey=lfreleng-actions_lftools-uv
+
+# Python source / test layout
+sonar.sources=lftools_uv,shell
+sonar.tests=tests
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.exclusions=**/__pycache__/**,**/.pytest_cache/**,**/.venv/**,**/dist/**


### PR DESCRIPTION
## Summary

The `Security Scans` workflow has been failing on every run (e.g.
[run 25370846728](https://github.com/lfreleng-actions/lftools-uv/actions/runs/25370846728)).
Both jobs hit configuration errors before the actual scans could
execute. This PR fixes both.

## 1. Sonatype Lifecycle / Scan

**Symptom**

```text
[ERROR] The application ID
bb7c7df5d19445cba258b6012b38bff3_lftools-uv is invalid.
Error: Sonatype CLI execution failed
```

**Cause**

The `APPLICATION_ID` input in `.github/workflows/security-scans.yaml`
was set to `<organizationId>_<publicId>` — a concatenation of the
Nexus IQ internal organization UUID and the application publicId.
The Nexus IQ CLI expects only the application **publicId**.

**Verification**

Queried the Nexus IQ v2 API
(`https://nexus-iq.wl.linuxfoundation.org`) and confirmed:

```json
{
  "id": "0fb22639d20242e2bd42c2556be70dd4",
  "publicId": "lftools-uv",
  "name": "lftools-uv",
  "organizationId": "bb7c7df5d19445cba258b6012b38bff3"
}
```

The organization (id `bb7c7df5d...`) is `Release Engineering`. The
application is already provisioned, so no admin action is needed —
just use the correct identifier.

**Fix**

```diff
-      APPLICATION_ID: "bb7c7df5d19445cba258b6012b38bff3_lftools-uv"
+      APPLICATION_ID: "lftools-uv"
```

## 2. SonarQube Cloud / Scan

**Symptom**

```text
ERROR Failed to get the scanner-engine metadata: GET
https://api.sonarcloud.io/analysis/engine failed with HTTP 403.
Please check the property sonar.token or the environment
variable SONAR_TOKEN.
```

**Cause**

Two issues in `sonar-project.properties`:

1. `sonar.organization="Release Engineering"` — SonarCloud expects
   the organization **slug**, not the display name, and properties
   files do not strip surrounding quotes from values, so the literal
   string `"Release Engineering"` (with quotes and a space) was sent
   to SonarCloud.
2. `sonar.projectKey=lftools-uv` — too generic; SonarCloud projects
   imported from a GitHub organization are keyed `<org>_<repo>`, and
   no project with the bare key `lftools-uv` existed in the
   `lfreleng-actions` SonarCloud organization.

**Verification & remediation via SonarCloud API**

- Confirmed the organization slug is `lfreleng-actions` (display name
  `Release Engineering, GitHub Actions`).
- Confirmed no `lftools-uv` project existed in that organization.
- Created the project via
  `POST /api/projects/create`:

  ```json
  {
    "key": "lfreleng-actions_lftools-uv",
    "name": "lftools-uv",
    "qualifier": "TRK",
    "visibility": "private",
    "uuid": "AZ35WM6AuLvpCwB3FaQJ"
  }
  ```

- Set the project visibility to `public` to match the GitHub
  repository (`POST /api/projects/update_visibility`).

**Fix**

```diff
-sonar.organization="Release Engineering"
-sonar.projectKey=lftools-uv
-sonar.sources = lftools_uv/,shell/
-sonar.tests = tests/
+sonar.organization=lfreleng-actions
+sonar.projectKey=lfreleng-actions_lftools-uv
+
+sonar.sources=lftools_uv,shell
+sonar.tests=tests
```

Also tidy formatting (drop quoted value, drop spaces around `=`,
drop trailing slashes on paths) for consistency with SonarCloud's
documented examples.

## Secrets / variables

No changes required. The existing org-level configuration is
sufficient:

- `vars.NEXUS_IQ_SERVER`, `vars.NEXUS_IQ_USERNAME`,
  `secrets.NEXUS_IQ_PASSWORD`
- `secrets.SONAR_TOKEN`

## Manual follow-up (optional)

In the SonarCloud UI, optionally bind the new project to the GitHub
repository (Project → Administration → General Settings → DevOps
Platform Integration) so PR decoration and check runs work. The
`set_github_binding` endpoint is not exposed on SonarCloud's public
API, hence the UI step. The scan itself does not require the
binding.

## Verification plan

After merge, re-run the `Security Scans` workflow on `main` (via
`workflow_dispatch`) and confirm both jobs succeed. The first
SonarCloud scan will populate the project; subsequent scans will
update it.
