### PR TITLE
Fix(sonar): Address high-severity SonarCloud findings and tighten scan config

### DIFF
--- a/lftools_uv/api/client.py
+++ b/lftools_uv/api/client.py
@@ -15,6 +15,9 @@ import json
 
 import requests
 
+_CONTENT_TYPE_JSON = "application/json"
+
+
 # Type alias for parsed JSON response body.
 # REST APIs return heterogeneous JSON; Any is unavoidable at
 # this deserialization boundary.  Callers should narrow as needed.
@@ -88,7 +91,7 @@ class RestApi:
             self.r.headers.update(
                 {
                     "Content-Type": "application/json; charset=UTF-8",
-                    "Accept": "application/json",
+                    "Accept": _CONTENT_TYPE_JSON,
                 }
             )
 
@@ -96,7 +99,7 @@ class RestApi:
             self.token: str = self.creds["token"]
             self.r = requests.Session()
             self.r.headers.update({"Authorization": f"Token {self.token}"})
-            self.r.headers.update({"Content-Type": "application/json"})
+            self.r.headers.update({"Content-Type": _CONTENT_TYPE_JSON})
 
     def _request(
         self,
@@ -119,7 +122,7 @@ class RestApi:
         if resp.text:
             try:
                 body: ApiBody
-                if "application/json" in resp.headers["Content-Type"]:
+                if _CONTENT_TYPE_JSON in resp.headers["Content-Type"]:
                     remove_xssi_magic: str = resp.text.replace(")]}'", "")
                     body = json.loads(remove_xssi_magic)  # pyright: ignore[reportAny]
                 else:

--- a/lftools_uv/api/client.py
+++ b/lftools_uv/api/client.py
@@ -122,7 +122,7 @@ class RestApi:
         if resp.text:
             try:
                 body: ApiBody
-                if _CONTENT_TYPE_JSON in resp.headers["Content-Type"]:
+                if _CONTENT_TYPE_JSON in resp.headers.get("Content-Type", ""):
                     remove_xssi_magic: str = resp.text.replace(")]}'", "")
                     body = json.loads(remove_xssi_magic)  # pyright: ignore[reportAny]
                 else:

--- a/lftools_uv/api/endpoints/gerrit.py
+++ b/lftools_uv/api/endpoints/gerrit.py
@@ -143,10 +143,9 @@ class Gerrit(client.RestApi):
 
         with open(filename) as my_file:  # noqa: PTH123
             file_content: str = my_file.read()
-        my_file_size: os.stat_result = os.stat(filename)
         headers: dict[str, str] = {
             "Content-Type": _CONTENT_TYPE_TEXT,
-            "Content-length": f"{my_file_size}",
+            "Content-length": str(len(file_content.encode("utf-8"))),
         }
         self.r.headers.update(headers)
         access_str = f"changes/{changeid}/edit/{basename}"

--- a/lftools_uv/api/endpoints/gerrit.py
+++ b/lftools_uv/api/endpoints/gerrit.py
@@ -25,6 +25,12 @@ import lftools_uv.api.client as client
 from lftools_uv import config
 from lftools_uv.api.client import ApiResponse
 
+_DOT_SECOND = ".second"
+_CHANGES_PATH = "changes/"
+_CONTENT_TYPE_TEXT = "text/plain"
+_CONTENT_TYPE_JSON_UTF8 = "application/json; charset=UTF-8"
+
+
 log: logging.Logger = logging.getLogger(__name__)
 
 
@@ -129,7 +135,7 @@ class Gerrit(client.RestApi):
             basename = file_location
         log.info(payload)
 
-        access_str: str = "changes/"
+        access_str: str = _CHANGES_PATH
         response: ApiResponse = self.post(access_str, data=payload)
         result: dict[str, object] = self._json_body(response)
         log.info(result.get("id"))
@@ -139,7 +145,7 @@ class Gerrit(client.RestApi):
             file_content: str = my_file.read()
         my_file_size: os.stat_result = os.stat(filename)
         headers: dict[str, str] = {
-            "Content-Type": "text/plain",
+            "Content-Type": _CONTENT_TYPE_TEXT,
             "Content-length": f"{my_file_size}",
         }
         self.r.headers.update(headers)
@@ -148,7 +154,7 @@ class Gerrit(client.RestApi):
         log.info(edit_result)
 
         access_str = f"changes/{changeid}/edit:publish"
-        headers = {"Content-Type": "application/json; charset=UTF-8"}
+        headers = {"Content-Type": _CONTENT_TYPE_JSON_UTF8}
         self.r.headers.update(headers)
         publish_payload: str = json.dumps(
             {
@@ -189,7 +195,7 @@ class Gerrit(client.RestApi):
         if not reviewid:
             payload: str = self.create_change(filename, jjbrepo, issue_id, signed_off_by)
             log.info(payload)
-            access_str: str = "changes/"
+            access_str: str = _CHANGES_PATH
             response: ApiResponse = self.post(access_str, data=payload)
             result: dict[str, object] = self._json_body(response)
             log.info(result)
@@ -221,7 +227,7 @@ class Gerrit(client.RestApi):
       - gerrit-info-yaml-verify\n"""
         my_inline_file_size: int = len(my_inline_file.encode("utf-8"))
         headers: dict[str, str] = {
-            "Content-Type": "text/plain",
+            "Content-Type": _CONTENT_TYPE_TEXT,
             "Content-length": f"{my_inline_file_size}",
         }
         self.r.headers.update(headers)
@@ -232,7 +238,7 @@ class Gerrit(client.RestApi):
         log.info(edit_result)
 
         access_str = f"changes/{changeid}/edit:publish"
-        headers = {"Content-Type": "application/json; charset=UTF-8"}
+        headers = {"Content-Type": _CONTENT_TYPE_JSON_UTF8}
         self.r.headers.update(headers)
         publish_payload: str = json.dumps(
             {
@@ -261,7 +267,7 @@ class Gerrit(client.RestApi):
         )
         access_str: str = f"changes/{changeid}/revisions/2/review"
         headers: dict[str, str] = {
-            "Content-Type": "application/json; charset=UTF-8",
+            "Content-Type": _CONTENT_TYPE_JSON_UTF8,
         }
         self.r.headers.update(headers)
         payload: str = json.dumps(
@@ -277,9 +283,9 @@ class Gerrit(client.RestApi):
 
         result: ApiResponse = self.post(access_str, data=payload)
         # Code for projects that don't allow self merge.
-        if config.get_setting(self.fqdn + ".second"):
-            second_username: str = config.get_setting(self.fqdn + ".second", "username")
-            second_password: str = config.get_setting(self.fqdn + ".second", "password")
+        if config.get_setting(self.fqdn + _DOT_SECOND):
+            second_username: str = config.get_setting(self.fqdn + _DOT_SECOND, "username")
+            second_password: str = config.get_setting(self.fqdn + _DOT_SECOND, "password")
             self.r.auth = (second_username, second_password)
             result = self.post(access_str, data=payload)
             self.r.auth = (self.username, self.password)
@@ -297,7 +303,7 @@ class Gerrit(client.RestApi):
         access_str: str = f"changes/{changeid}/submit"
         log.info(access_str)
         headers: dict[str, str] = {
-            "Content-Type": "application/json; charset=UTF-8",
+            "Content-Type": _CONTENT_TYPE_JSON_UTF8,
         }
         self.r.headers.update(headers)
         result: ApiResponse = self.post(access_str, data=payload)
@@ -309,7 +315,7 @@ class Gerrit(client.RestApi):
         access_str: str = f"changes/?q=project:{gerrit_project_encoded}"
         log.info(access_str)
         headers: dict[str, str] = {
-            "Content-Type": "application/json; charset=UTF-8",
+            "Content-Type": _CONTENT_TYPE_JSON_UTF8,
         }
         self.r.headers.update(headers)
         response: ApiResponse = self.get(access_str)
@@ -373,7 +379,7 @@ class Gerrit(client.RestApi):
         payload: str = self.create_change(filename, gerrit_project, issue_id, signed_off_by)
         log.info(payload)
 
-        access_str: str = "changes/"
+        access_str: str = _CHANGES_PATH
         response: ApiResponse = self.post(access_str, data=payload)
         result: dict[str, object] = self._json_body(response)
         log.info(result)
@@ -390,7 +396,7 @@ class Gerrit(client.RestApi):
         """
         my_inline_file_size: int = len(my_inline_file.encode("utf-8"))
         headers: dict[str, str] = {
-            "Content-Type": "text/plain",
+            "Content-Type": _CONTENT_TYPE_TEXT,
             "Content-length": f"{my_inline_file_size}",
         }
         self.r.headers.update(headers)
@@ -405,7 +411,7 @@ class Gerrit(client.RestApi):
 
         else:
             access_str = f"changes/{changeid}/edit:publish"
-            headers = {"Content-Type": "application/json; charset=UTF-8"}
+            headers = {"Content-Type": _CONTENT_TYPE_JSON_UTF8}
             self.r.headers.update(headers)
             publish_payload: str = json.dumps(
                 {

--- a/lftools_uv/api/endpoints/gerrit.py
+++ b/lftools_uv/api/endpoints/gerrit.py
@@ -282,7 +282,7 @@ class Gerrit(client.RestApi):
 
         result: ApiResponse = self.post(access_str, data=payload)
         # Code for projects that don't allow self merge.
-        if config.get_setting(self.fqdn + _DOT_SECOND):
+        if config.has_section(self.fqdn + _DOT_SECOND):
             second_username: str = config.get_setting(self.fqdn + _DOT_SECOND, "username")
             second_password: str = config.get_setting(self.fqdn + _DOT_SECOND, "password")
             self.r.auth = (second_username, second_password)

--- a/lftools_uv/api/endpoints/gerrit.py
+++ b/lftools_uv/api/endpoints/gerrit.py
@@ -145,7 +145,6 @@ class Gerrit(client.RestApi):
             file_content: str = my_file.read()
         headers: dict[str, str] = {
             "Content-Type": _CONTENT_TYPE_TEXT,
-            "Content-length": str(len(file_content.encode("utf-8"))),
         }
         self.r.headers.update(headers)
         access_str = f"changes/{changeid}/edit/{basename}"
@@ -224,10 +223,8 @@ class Gerrit(client.RestApi):
     build-node: {buildnode}
     jobs:
       - gerrit-info-yaml-verify\n"""
-        my_inline_file_size: int = len(my_inline_file.encode("utf-8"))
         headers: dict[str, str] = {
             "Content-Type": _CONTENT_TYPE_TEXT,
-            "Content-length": f"{my_inline_file_size}",
         }
         self.r.headers.update(headers)
         access_str = f"changes/{changeid}/edit/jjb%2F{gerrit_project_dashed}%2F{gerrit_project_dashed}.yaml"
@@ -393,10 +390,8 @@ class Gerrit(client.RestApi):
         project={gerrit_project}
         defaultbranch=master
         """
-        my_inline_file_size: int = len(my_inline_file.encode("utf-8"))
         headers: dict[str, str] = {
             "Content-Type": _CONTENT_TYPE_TEXT,
-            "Content-length": f"{my_inline_file_size}",
         }
         self.r.headers.update(headers)
         access_str = f"changes/{changeid}/edit/{filename}"

--- a/lftools_uv/api/endpoints/nexus2.py
+++ b/lftools_uv/api/endpoints/nexus2.py
@@ -23,6 +23,9 @@ import lftools_uv.api.client as client
 from lftools_uv import config
 from lftools_uv.api.client import ApiResponse
 
+_LIST_OBJECT_TYPE = list[object]
+
+
 log: logging.Logger = logging.getLogger(__name__)
 
 
@@ -80,7 +83,7 @@ class Nexus2(client.RestApi):
         if isinstance(body, dict):
             data: object = body.get("data", [])
             if isinstance(data, list):
-                typed_data: list[object] = cast("list[object]", data)
+                typed_data: list[object] = cast(_LIST_OBJECT_TYPE, data)
                 return [cast("dict[str, object]", item) for item in typed_data if isinstance(item, dict)]
         return []
 
@@ -271,7 +274,7 @@ class Nexus2(client.RestApi):
         if not isinstance(data_val, list):
             return []
 
-        typed_data: list[object] = cast("list[object]", data_val)
+        typed_data: list[object] = cast(_LIST_OBJECT_TYPE, data_val)
         role_list: list[list[object]] = []
         for raw_role in typed_data:
             role: dict[str, object] = self._as_dict(raw_role)
@@ -282,12 +285,12 @@ class Nexus2(client.RestApi):
             privs_string: str = ""
             roles_obj: object = role.get("roles")
             if isinstance(roles_obj, list):
-                for r in cast("list[object]", roles_obj):
+                for r in cast(_LIST_OBJECT_TYPE, roles_obj):
                     roles_string += str(r) + "\n"
 
             privs_obj: object = role.get("privileges")
             if isinstance(privs_obj, list):
-                for p in cast("list[object]", privs_obj):
+                for p in cast(_LIST_OBJECT_TYPE, privs_obj):
                     privs_string += str(p) + "\n"
 
             role_list.append([role["id"], role["name"], roles_string, privs_string])
@@ -361,7 +364,7 @@ class Nexus2(client.RestApi):
             role_list: list[list[object]] = []
             roles_obj: object = user.get("roles", [])
             if isinstance(roles_obj, list):
-                for raw_role in cast("list[object]", roles_obj):
+                for raw_role in cast(_LIST_OBJECT_TYPE, roles_obj):
                     role: dict[str, object] = self._as_dict(raw_role)
                     if role:
                         role_list.append([role["roleId"]])

--- a/lftools_uv/api/endpoints/nexus3.py
+++ b/lftools_uv/api/endpoints/nexus3.py
@@ -22,6 +22,10 @@ import lftools_uv.api.client as client
 from lftools_uv import config, helpers
 from lftools_uv.api.client import ApiResponse
 
+_DICT_STR_OBJECT_TYPE = dict[str, object]
+_LIST_OBJECT_TYPE = list[object]
+
+
 log: logging.Logger = logging.getLogger(__name__)
 
 
@@ -58,7 +62,7 @@ class Nexus3(client.RestApi):
         Returns an empty dict when *obj* is not a dict.
         """
         if isinstance(obj, dict):
-            return cast("dict[str, object]", obj)
+            return cast(_DICT_STR_OBJECT_TYPE, obj)
         return {}
 
     def _items_from_response(self, response: ApiResponse) -> list[dict[str, object]]:
@@ -74,7 +78,9 @@ class Nexus3(client.RestApi):
         body: dict[str, object] = self._json_body(response)
         items: object = body.get("items", [])
         if isinstance(items, list):
-            return [cast("dict[str, object]", item) for item in cast("list[object]", items) if isinstance(item, dict)]
+            return [
+                cast(_DICT_STR_OBJECT_TYPE, item) for item in cast(_LIST_OBJECT_TYPE, items) if isinstance(item, dict)
+            ]
         return []
 
     # -----------------------------------------------------------------------
@@ -160,7 +166,7 @@ class Nexus3(client.RestApi):
                 body: client.ApiBody = response[1]
                 if isinstance(body, dict):
                     return body
-            return cast("dict[str, object]", resp.json())
+            return cast(_DICT_STR_OBJECT_TYPE, resp.json())
         resp.raise_for_status()
         return f"Failed to read script {name}"
 
@@ -177,7 +183,7 @@ class Nexus3(client.RestApi):
                 body: client.ApiBody = response[1]
                 if isinstance(body, dict):
                     return body
-            return cast("dict[str, object]", resp.json())
+            return cast(_DICT_STR_OBJECT_TYPE, resp.json())
         resp.raise_for_status()
         return f"Failed to execute script {name}"
 
@@ -280,7 +286,7 @@ class Nexus3(client.RestApi):
             while token is not None:
                 items: object = result.get("items", [])
                 if isinstance(items, list):
-                    for raw_tag in cast("list[object]", items):
+                    for raw_tag in cast(_LIST_OBJECT_TYPE, items):
                         tag: dict[str, object] = self._as_dict(raw_tag)
                         if tag:
                             list_of_tags.append(str(tag.get("name", "")))
@@ -294,7 +300,7 @@ class Nexus3(client.RestApi):
         else:
             items_obj: object = body.get("items", [])
             if isinstance(items_obj, list):
-                for raw_tag in cast("list[object]", items_obj):
+                for raw_tag in cast(_LIST_OBJECT_TYPE, items_obj):
                     tag_dict: dict[str, object] = self._as_dict(raw_tag)
                     if tag_dict:
                         list_of_tags.append(str(tag_dict.get("name", "")))

--- a/lftools_uv/api/endpoints/readthedocs.py
+++ b/lftools_uv/api/endpoints/readthedocs.py
@@ -21,6 +21,9 @@ import lftools_uv.api.client as client
 from lftools_uv import config
 from lftools_uv.api.client import ApiResponse
 
+_LIST_OBJECT_TYPE = list[object]
+_DICT_STR_OBJECT_TYPE = dict[str, object]
+
 
 class ReadTheDocs(client.RestApi):
     """API endpoint wrapper for readthedocs.org.
@@ -58,9 +61,9 @@ class ReadTheDocs(client.RestApi):
         project_list: list[str] = []
 
         if isinstance(data, list):
-            for project in cast("list[object]", data):
+            for project in cast(_LIST_OBJECT_TYPE, data):
                 if isinstance(project, dict):
-                    project_dict = cast("dict[str, object]", project)
+                    project_dict = cast(_DICT_STR_OBJECT_TYPE, project)
                     if "slug" in project_dict:
                         slug: object = project_dict["slug"]
                         if isinstance(slug, str):
@@ -92,9 +95,9 @@ class ReadTheDocs(client.RestApi):
         # I feel like there must be a better way...but, this works. -DWTalton
         initial_versions: object = result["results"]
         if isinstance(initial_versions, list):
-            for version in cast("list[object]", initial_versions):
+            for version in cast(_LIST_OBJECT_TYPE, initial_versions):
                 if isinstance(version, dict):
-                    version_dict = cast("dict[str, object]", version)
+                    version_dict = cast(_DICT_STR_OBJECT_TYPE, version)
                     slug: object = version_dict["slug"]
                     if isinstance(slug, str):
                         versions.append(slug)
@@ -112,9 +115,9 @@ class ReadTheDocs(client.RestApi):
 
                 results_data: object = get_more_results["results"]
                 if isinstance(results_data, list):
-                    for version in cast("list[object]", results_data):
+                    for version in cast(_LIST_OBJECT_TYPE, results_data):
                         if isinstance(version, dict):
-                            version_dict = cast("dict[str, object]", version)
+                            version_dict = cast(_DICT_STR_OBJECT_TYPE, version)
                             slug = version_dict["slug"]
                             if isinstance(slug, str):
                                 versions.append(slug)
@@ -260,12 +263,12 @@ class ReadTheDocs(client.RestApi):
         subproject_list: list[str] = []
 
         if isinstance(data, list):
-            for subproject in cast("list[object]", data):
+            for subproject in cast(_LIST_OBJECT_TYPE, data):
                 if isinstance(subproject, dict):
-                    subproject_dict = cast("dict[str, object]", subproject)
+                    subproject_dict = cast(_DICT_STR_OBJECT_TYPE, subproject)
                     child: object = subproject_dict.get("child")
                     if isinstance(child, dict):
-                        child_dict = cast("dict[str, object]", child)
+                        child_dict = cast(_DICT_STR_OBJECT_TYPE, child)
                         slug: object = child_dict.get("slug")
                         if isinstance(slug, str):
                             subproject_list.append(slug)

--- a/lftools_uv/cli/__init__.py
+++ b/lftools_uv/cli/__init__.py
@@ -139,7 +139,7 @@ def main():
 
             typer_app()
         except ImportError as e:
-            log.error("Failed to import Typer CLI: %s", e)
+            log.exception("Failed to import Typer CLI: %s", e)
             log.info("Falling back to legacy Click CLI")
             cli(obj={})
         except Exception as e:

--- a/lftools_uv/cli/__init__.py
+++ b/lftools_uv/cli/__init__.py
@@ -138,8 +138,8 @@ def main():
             from lftools_uv.cli_app import app as typer_app
 
             typer_app()
-        except ImportError as e:
-            log.exception("Failed to import Typer CLI: %s", e)
+        except ImportError:
+            log.exception("Failed to import Typer CLI")
             log.info("Falling back to legacy Click CLI")
             cli(obj={})
         except Exception as e:

--- a/lftools_uv/cli/config.py
+++ b/lftools_uv/cli/config.py
@@ -38,7 +38,7 @@ def get_setting(ctx, section, option):
     try:
         result = config.get_setting(section, option)
     except (configparser.NoOptionError, configparser.NoSectionError) as e:
-        log.error(e)
+        log.exception(e)
         sys.exit(1)
 
     if isinstance(result, list):

--- a/lftools_uv/cli/deploy.py
+++ b/lftools_uv/cli/deploy.py
@@ -62,7 +62,7 @@ def archives(ctx, nexus_url, nexus_path, workspace, pattern):
     try:
         deploy_sys.deploy_archives(nexus_url, nexus_path, workspace, pattern)
     except HTTPError as e:
-        log.error(str(e))
+        log.exception(str(e))
         sys.exit(1)
     except OSError as e:
         deploy_sys._log_error_and_exit(str(e))
@@ -108,7 +108,7 @@ def file(ctx, nexus_url, nexus_repo_id, group_id, artifact_id, version, packagin
             nexus_url, nexus_repo_id, group_id, artifact_id, version, packaging, file, classifier
         )
     except HTTPError as e:
-        log.error(str(e))
+        log.exception(str(e))
         sys.exit(1)
 
     log.info("Upload maven file to nexus completed.")
@@ -131,7 +131,7 @@ def logs(ctx, nexus_url, nexus_path, build_url):
     try:
         deploy_sys.deploy_logs(nexus_url, nexus_path, build_url)
     except HTTPError as e:
-        log.error(str(e))
+        log.exception(str(e))
         sys.exit(1)
 
     log.info("Logs upload complete.")
@@ -307,10 +307,10 @@ def nexus_zip(ctx, nexus_url, nexus_repo, nexus_path, deploy_zip):
     try:
         deploy_sys.deploy_nexus_zip(nexus_url, nexus_repo, nexus_path, deploy_zip)
     except HTTPError as e:
-        log.error(str(e))
+        log.exception(str(e))
         sys.exit(1)
     except OSError as e:
-        log.error(str(e))
+        log.exception(str(e))
         sys.exit(1)
 
     log.info("Zip file upload complete.")

--- a/lftools_uv/cli/github_cli.py
+++ b/lftools_uv/cli/github_cli.py
@@ -20,6 +20,9 @@ from github import Github, GithubException
 from lftools_uv import config
 from lftools_uv.github_helper import helper_list, helper_user_github, prvotes
 
+_GITHUB_PREFIX = "github."
+
+
 log = logging.getLogger(__name__)
 
 
@@ -37,8 +40,8 @@ def github_cli(ctx):
 @click.pass_context
 def submit_pr(ctx, organization, repo, pr):
     """Submit a pr if mergeable."""
-    if config.get_setting("github." + organization, "token"):
-        token = config.get_setting("github." + organization, "token")
+    if config.get_setting(_GITHUB_PREFIX + organization, "token"):
+        token = config.get_setting(_GITHUB_PREFIX + organization, "token")
     else:
         token = config.get_setting("github", "token")
 
@@ -100,8 +103,8 @@ def createrepo(ctx, organization, repository, description, has_issues, has_proje
     By default has_issues has_wiki and has_projects is set to false.
     See --help to create a repo with these enabled.
     """
-    if config.get_setting("github." + organization, "token"):
-        token = config.get_setting("github." + organization, "token")
+    if config.get_setting(_GITHUB_PREFIX + organization, "token"):
+        token = config.get_setting(_GITHUB_PREFIX + organization, "token")
     else:
         token = config.get_setting("github", "token")
 
@@ -151,8 +154,8 @@ def updaterepo(ctx, organization, repository, has_issues, has_projects, has_wiki
     By default has_issues has_wiki and has_projects is set to false.
     See --help to use this command to enable these options.
     """
-    if config.get_setting("github." + organization, "token"):
-        token = config.get_setting("github." + organization, "token")
+    if config.get_setting(_GITHUB_PREFIX + organization, "token"):
+        token = config.get_setting(_GITHUB_PREFIX + organization, "token")
     else:
         token = config.get_setting("github", "token")
     g = Github(token)
@@ -211,8 +214,8 @@ def createteam(ctx, organization, name, repo, privacy):
     Privacy should be set to closed
     This allows us to control group membership.
     """
-    if config.get_setting("github." + organization, "token"):
-        token = config.get_setting("github." + organization, "token")
+    if config.get_setting(_GITHUB_PREFIX + organization, "token"):
+        token = config.get_setting(_GITHUB_PREFIX + organization, "token")
     else:
         token = config.get_setting("github", "token")
 

--- a/lftools_uv/cli/github_cli.py
+++ b/lftools_uv/cli/github_cli.py
@@ -47,7 +47,7 @@ def submit_pr(ctx, organization, repo, pr):
     try:
         org = g.get_organization(orgName)
     except GithubException as ghe:
-        log.error(ghe)
+        log.exception(ghe)
         sys.exit(1)
 
     repo = org.get_repo(repo)
@@ -114,7 +114,7 @@ def createrepo(ctx, organization, repository, description, has_issues, has_proje
     try:
         org = g.get_organization(orgName)
     except GithubException as ghe:
-        log.error(ghe)
+        log.exception(ghe)
         sys.exit(1)
     repos = org.get_repos()
     for repo in repos:
@@ -133,7 +133,7 @@ def createrepo(ctx, organization, repository, description, has_issues, has_proje
             private=False,
         )
     except GithubException as ghe:
-        log.error(ghe)
+        log.exception(ghe)
 
 
 @click.command(name="update-repo")
@@ -165,7 +165,7 @@ def updaterepo(ctx, organization, repository, has_issues, has_projects, has_wiki
     try:
         org = g.get_organization(orgName)
     except GithubException as ghe:
-        log.error(ghe)
+        log.exception(ghe)
         sys.exit(1)
 
     repos = org.get_repos()
@@ -222,7 +222,7 @@ def createteam(ctx, organization, name, repo, privacy):
     try:
         org = g.get_organization(orgName)
     except GithubException as ghe:
-        log.error(ghe)
+        log.exception(ghe)
         sys.exit(1)
 
     repos = []
@@ -230,7 +230,7 @@ def createteam(ctx, organization, name, repo, privacy):
         try:
             get_repos = org.get_repos
         except GithubException as ghe:
-            log.error(ghe)
+            log.exception(ghe)
             sys.exit(1)
 
         my_repos = [repo]
@@ -246,7 +246,7 @@ def createteam(ctx, organization, name, repo, privacy):
     try:
         teams = org.get_teams
     except GithubException as ghe:
-        log.error(ghe)
+        log.exception(ghe)
         sys.exit(1)
 
     for team in teams():
@@ -258,13 +258,13 @@ def createteam(ctx, organization, name, repo, privacy):
         try:
             org.create_team(name=name, repo_names=repos, privacy=privacy)
         except GithubException as ghe:
-            log.error(ghe)
+            log.exception(ghe)
 
     if not repo:
         try:
             org.create_team(name=name, privacy=privacy)
         except GithubException as ghe:
-            log.error(ghe)
+            log.exception(ghe)
 
 
 @click.command(name="user")

--- a/lftools_uv/cli/infofile.py
+++ b/lftools_uv/cli/infofile.py
@@ -221,7 +221,7 @@ def sync_committers(ctx, id, info_file, ldap_file, repo):
         try:
             yaml.safe_load(stream)
         except yaml.YAMLError as exc:
-            log.error(exc)
+            log.exception(exc)
 
     with open(info_file) as f:
         info_data = ryaml.load(f)
@@ -299,7 +299,7 @@ def check_votes(ctx, info_file, endpoint, change_number, tsc, github_repo):
             try:
                 info_data = yaml.safe_load(file)
             except yaml.YAMLError as exc:
-                log.error(exc)
+                log.exception(exc)
                 sys.exit(1)
 
         committer_info = info_data["committers"]

--- a/lftools_uv/cli/jenkins/__init__.py
+++ b/lftools_uv/cli/jenkins/__init__.py
@@ -158,7 +158,7 @@ def quiet_down(ctx, n):
             jenkins.server.quiet_down()
         except HTTPError as m:
             if m.code == 405:
-                log.error(
+                log.exception(
                     f"\n[{m}]\nJenkins {version} does not support Quiet Down without a CSRF Token. (CVE-2017-04-26)\nPlease file a bug with 'python-jenkins'"
                 )
             else:

--- a/lftools_uv/cli/jenkins/token.py
+++ b/lftools_uv/cli/jenkins/token.py
@@ -70,7 +70,7 @@ def init(ctx, name, url):
     try:
         config.add_section(name)
     except configparser.DuplicateSectionError as e:
-        log.error(e)
+        log.exception(e)
         sys.exit(1)
 
     config.set(name, "url", url)

--- a/lftools_uv/cli/jenkins/token.py
+++ b/lftools_uv/cli/jenkins/token.py
@@ -22,6 +22,9 @@ import requests
 from lftools_uv import config as lftools_cfg
 from lftools_uv.jenkins.token import get_token
 
+_MSG_CREDS_NOT_SET = "Username or password not set."
+
+
 log = logging.getLogger(__name__)
 
 
@@ -41,7 +44,7 @@ def change(ctx, name):
     password = ctx.obj["password"]
 
     if not username or not password:
-        log.error("Username or password not set.")
+        log.error(_MSG_CREDS_NOT_SET)
         sys.exit(1)
 
     log.info(get_token(name=name, url=jenkins.url, change=True, username=username, password=password))
@@ -58,7 +61,7 @@ def init(ctx, name, url):
     password = ctx.obj["password"]
 
     if not username or not password:
-        log.error("Username or password not set.")
+        log.error(_MSG_CREDS_NOT_SET)
         sys.exit(1)
 
     _require_jjb_ini(jenkins.config_file)
@@ -90,7 +93,7 @@ def print_token(ctx):
     password = ctx.obj["password"]
 
     if not username or not password:
-        log.error("Username or password not set.")
+        log.error(_MSG_CREDS_NOT_SET)
         sys.exit(1)
 
     log.info(get_token(name="token-created-by-lftools", url=jenkins.url, username=username, password=password))
@@ -116,7 +119,7 @@ def reset(ctx, servers):
     password = ctx.obj["password"]
 
     if not username or not password:
-        log.error("Username or password not set.")
+        log.error(_MSG_CREDS_NOT_SET)
         sys.exit(1)
 
     _require_jjb_ini(jenkins.config_file)

--- a/lftools_uv/cli/ldap_cli.py
+++ b/lftools_uv/cli/ldap_cli.py
@@ -104,9 +104,9 @@ def csv(ctx, ldap_server, ldap_group_base, ldap_user_base, groups):
             ldap_object.simple_bind_s()
         except ldap.LDAPError as e:  # pyright: ignore[reportAttributeAccessIssue]
             if type(e.message) is dict and "desc" in e.message:
-                log.error(e.message["desc"])
+                log.exception(e.message["desc"])
             else:
-                log.error(e)
+                log.exception(e)
             sys.exit(0)
 
     def eprint(*args, **kwargs):

--- a/lftools_uv/cli/ldap_cli.py
+++ b/lftools_uv/cli/ldap_cli.py
@@ -107,7 +107,7 @@ def csv(ctx, ldap_server, ldap_group_base, ldap_user_base, groups):
                 log.exception(e.message["desc"])
             else:
                 log.exception(e)
-            sys.exit(0)
+            sys.exit(1)
 
     def eprint(*args, **kwargs):
         """Log error output (previously printed to stderr)."""

--- a/lftools_uv/cli/ldap_cli.py
+++ b/lftools_uv/cli/ldap_cli.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 
 import click
-import ldap
+import ldap  # pyright: ignore[reportMissingImports]
 
 log = logging.getLogger(__name__)
 

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -521,46 +521,46 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
             for dir in (logs_dir, silo_dir, jenkins_node_dir):
                 try:
                     s3.Bucket(s3_bucket).upload_file(file, f"{dir}{file}")
-                except ClientError as e:
-                    log.error(e)
+                except ClientError:
+                    log.exception("Failed to upload _tmpfile marker to %s", dir)
                     return False
             return True
         if mime_type is None and mime_encoding is None:
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
-            except ClientError as e:
-                log.error(e)
+            except ClientError:
+                log.exception("Failed to upload %s", file)
                 return False
             return True
         elif mime_type is None or mime_type == _CONTENT_TYPE_TEXT:
             extra_args = text_plain_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
-            except ClientError as e:
-                log.error(e)
+            except ClientError:
+                log.exception("Failed to upload %s as text/plain", file)
                 return False
             return True
         elif mime_type == "text/html":
             extra_args = text_html_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
-            except ClientError as e:
-                log.error(e)
+            except ClientError:
+                log.exception("Failed to upload %s as text/html", file)
                 return False
             return True
         elif mime_type == _CONTENT_TYPE_XML:
             extra_args = app_xml_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
-            except ClientError as e:
-                log.error(e)
+            except ClientError:
+                log.exception("Failed to upload %s as application/xml", file)
                 return False
             return True
         else:
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
-            except ClientError as e:
-                log.error(e)
+            except ClientError:
+                log.exception("Failed to upload %s", file)
                 return False
             return True
 

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -518,11 +518,11 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
         text_plain_extra_args: dict[str, str] = _extra_args(_CONTENT_TYPE_TEXT)
         app_xml_extra_args: dict[str, str] = _extra_args(_CONTENT_TYPE_XML)
         if file == "_tmpfile":
-            for dir in (logs_dir, silo_dir, jenkins_node_dir):
+            for prefix in (logs_dir, silo_dir, jenkins_node_dir):
                 try:
-                    s3.Bucket(s3_bucket).upload_file(file, f"{dir}{file}")
+                    s3.Bucket(s3_bucket).upload_file(file, f"{prefix}{file}")
                 except ClientError:
-                    log.exception("Failed to upload _tmpfile marker to %s", dir)
+                    log.exception("Failed to upload _tmpfile marker to %s", prefix)
                     return False
             return True
         if mime_type is None and mime_encoding is None:

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -499,13 +499,24 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
     def _upload_to_s3(file: str) -> bool:
         mime_type: str | None = mimetypes.guess_type(file)[0]
         mime_encoding: str | None = mimetypes.guess_type(file)[1]
-        extra_args: dict[str, str | None] = {"ContentType": _CONTENT_TYPE_TEXT}
-        text_html_extra_args: dict[str, str | None] = {"ContentType": "text/html", "ContentEncoding": mime_encoding}
-        text_plain_extra_args: dict[str, str | None] = {
-            "ContentType": _CONTENT_TYPE_TEXT,
-            "ContentEncoding": mime_encoding,
-        }
-        app_xml_extra_args: dict[str, str | None] = {"ContentType": _CONTENT_TYPE_XML, "ContentEncoding": mime_encoding}
+
+        def _extra_args(content_type: str) -> dict[str, str]:
+            """Build an ExtraArgs dict, omitting ContentEncoding when None.
+
+            boto3's S3 transfer manager rejects ``None`` values for ``ExtraArgs``
+            entries with a ``ParamValidationError``; many file types
+            (e.g. plain ``.html`` / ``.xml`` without compression) have no
+            mime_encoding, so the key must be omitted entirely in that case.
+            """
+            args: dict[str, str] = {"ContentType": content_type}
+            if mime_encoding:
+                args["ContentEncoding"] = mime_encoding
+            return args
+
+        extra_args: dict[str, str] = {"ContentType": _CONTENT_TYPE_TEXT}
+        text_html_extra_args: dict[str, str] = _extra_args("text/html")
+        text_plain_extra_args: dict[str, str] = _extra_args(_CONTENT_TYPE_TEXT)
+        app_xml_extra_args: dict[str, str] = _extra_args(_CONTENT_TYPE_XML)
         if file == "_tmpfile":
             for dir in (logs_dir, silo_dir, jenkins_node_dir):
                 try:

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -524,7 +524,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
                 except ClientError as e:
                     log.error(e)
                     return False
-                return True
+            return True
         if mime_type is None and mime_encoding is None:
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -35,6 +35,11 @@ import requests
 from botocore.exceptions import ClientError
 from defusedxml.minidom import parseString
 
+_CONTENT_TYPE_TEXT = "text/plain"
+_CONTENT_TYPE_XML = "application/xml"
+_BANNER_HASHES = "#######################################################"
+
+
 log: logging.Logger = logging.getLogger(__name__)
 logging.getLogger("botocore").setLevel(logging.CRITICAL)
 
@@ -494,10 +499,13 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
     def _upload_to_s3(file: str) -> bool:
         mime_type: str | None = mimetypes.guess_type(file)[0]
         mime_encoding: str | None = mimetypes.guess_type(file)[1]
-        extra_args: dict[str, str | None] = {"ContentType": "text/plain"}
+        extra_args: dict[str, str | None] = {"ContentType": _CONTENT_TYPE_TEXT}
         text_html_extra_args: dict[str, str | None] = {"ContentType": "text/html", "ContentEncoding": mime_encoding}
-        text_plain_extra_args: dict[str, str | None] = {"ContentType": "text/plain", "ContentEncoding": mime_encoding}
-        app_xml_extra_args: dict[str, str | None] = {"ContentType": "application/xml", "ContentEncoding": mime_encoding}
+        text_plain_extra_args: dict[str, str | None] = {
+            "ContentType": _CONTENT_TYPE_TEXT,
+            "ContentEncoding": mime_encoding,
+        }
+        app_xml_extra_args: dict[str, str | None] = {"ContentType": _CONTENT_TYPE_XML, "ContentEncoding": mime_encoding}
         if file == "_tmpfile":
             for dir in (logs_dir, silo_dir, jenkins_node_dir):
                 try:
@@ -513,7 +521,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
                 log.error(e)
                 return False
             return True
-        elif mime_type is None or mime_type in "text/plain":
+        elif mime_type is None or mime_type in _CONTENT_TYPE_TEXT:
             extra_args = text_plain_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
@@ -529,7 +537,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
                 log.error(e)
                 return False
             return True
-        elif mime_type in "application/xml":
+        elif mime_type in _CONTENT_TYPE_XML:
             extra_args = app_xml_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
@@ -619,7 +627,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
         if os.path.isfile(file):
             file_list.append(file)
 
-    log.info("#######################################################")
+    log.info(_BANNER_HASHES)
     log.info("Deploying files from %s to %s/%s", work_dir, s3_bucket, s3_path)
 
     # Perform s3 upload
@@ -631,7 +639,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
             log.error("FAILURE: Uploading %s failed", file)
 
     log.info("Finished deploying from %s to %s/%s", work_dir, s3_bucket, s3_path)
-    log.info("#######################################################")
+    log.info(_BANNER_HASHES)
 
     # Cleanup
     s3.Object(s3_bucket, "{}{}".format(logs_dir, "_tmpfile")).delete()
@@ -707,7 +715,7 @@ def nexus_stage_repo_create(nexus_url: str, staging_profile_id: str) -> str:
         </promoteRequest>
     """
 
-    headers: dict[str, str] = {"Content-Type": "application/xml"}
+    headers: dict[str, str] = {"Content-Type": _CONTENT_TYPE_XML}
     resp: requests.Response = _request_post(nexus_url, xml, headers)
 
     log.debug("resp.status_code = %s", resp.status_code)
@@ -758,7 +766,7 @@ def nexus_stage_repo_close(nexus_url: str, staging_profile_id: str, staging_repo
         </promoteRequest>
     """
 
-    headers: dict[str, str] = {"Content-Type": "application/xml"}
+    headers: dict[str, str] = {"Content-Type": _CONTENT_TYPE_XML}
     resp: requests.Response = _request_post(nexus_url, xml, headers)
 
     log.debug("resp.status_code = %s", resp.status_code)
@@ -893,7 +901,7 @@ def deploy_nexus(nexus_repo_url: str, deploy_dir: str, snapshot: bool = False, w
 
             file_list.append(file)
 
-    log.info("#######################################################")
+    log.info(_BANNER_HASHES)
     log.info("Deploying directory %s to %s", deploy_dir, nexus_repo_url)
 
     failed_uploads: list[tuple[str, str]] = []
@@ -922,7 +930,7 @@ def deploy_nexus(nexus_repo_url: str, deploy_dir: str, snapshot: bool = False, w
         )
     else:
         log.info("Finished deploying %s to %s", deploy_dir, nexus_repo_url)
-    log.info("#######################################################")
+    log.info(_BANNER_HASHES)
 
     os.chdir(previous_dir)
 

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -521,7 +521,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
                 log.error(e)
                 return False
             return True
-        elif mime_type is None or mime_type in _CONTENT_TYPE_TEXT:
+        elif mime_type is None or mime_type == _CONTENT_TYPE_TEXT:
             extra_args = text_plain_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
@@ -529,7 +529,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
                 log.error(e)
                 return False
             return True
-        elif mime_type in "text/html":
+        elif mime_type == "text/html":
             extra_args = text_html_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)
@@ -537,7 +537,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
                 log.error(e)
                 return False
             return True
-        elif mime_type in _CONTENT_TYPE_XML:
+        elif mime_type == _CONTENT_TYPE_XML:
             extra_args = app_xml_extra_args
             try:
                 s3.Bucket(s3_bucket).upload_file(file, f"{s3_path}{file}", ExtraArgs=extra_args)

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -28,7 +28,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import NoReturn
+from typing import Any, NoReturn
 
 import boto3
 import requests
@@ -557,7 +557,7 @@ def deploy_s3(s3_bucket: str, s3_path: str, build_url: str, workspace: str, patt
     work_dir: str = tempfile.mkdtemp(prefix="lftools-dl.")
     os.chdir(work_dir)
     s3_bucket = s3_bucket.lower()
-    s3 = boto3.resource("s3")
+    s3: Any = boto3.resource("s3")
     logs_dir: str = s3_path.split("/")[0] + "/"
     silo_dir: str = s3_path.split("/")[1] + "/"
     jenkins_node_dir: str = logs_dir + silo_dir + s3_path.split("/")[2] + "/"

--- a/lftools_uv/git/gerrit.py
+++ b/lftools_uv/git/gerrit.py
@@ -26,6 +26,9 @@ from jinja2 import Environment, PackageLoader, select_autoescape
 
 from lftools_uv import config
 
+_LFTOOLS_UV_GIT = "lftools_uv.git"
+
+
 log = logging.getLogger(__name__)
 
 
@@ -165,7 +168,7 @@ class Gerrit:
                 buildnode = "centos7-builder-2c-1g"
 
         jinja_env = Environment(
-            loader=PackageLoader("lftools_uv.git"), autoescape=select_autoescape(), keep_trailing_newline=True
+            loader=PackageLoader(_LFTOOLS_UV_GIT), autoescape=select_autoescape(), keep_trailing_newline=True
         )
         template = jinja_env.get_template("project.yaml")
         content = template.render(
@@ -193,7 +196,7 @@ class Gerrit:
         filename = ".gitreview"
 
         jinja_env = Environment(
-            loader=PackageLoader("lftools_uv.git"), autoescape=select_autoescape(), keep_trailing_newline=True
+            loader=PackageLoader(_LFTOOLS_UV_GIT), autoescape=select_autoescape(), keep_trailing_newline=True
         )
         template = jinja_env.get_template("gitreview")
         content = template.render(fqdn=fqdn, project_name=gerrit_project, default_branch=self.default_branch)
@@ -251,7 +254,7 @@ class Gerrit:
                 log.error("Invalid nexus3_ports designated.")
 
         jinja_env = Environment(
-            loader=PackageLoader("lftools_uv.git"), autoescape=select_autoescape(), keep_trailing_newline=True
+            loader=PackageLoader(_LFTOOLS_UV_GIT), autoescape=select_autoescape(), keep_trailing_newline=True
         )
         template = jinja_env.get_template(params_path)
         config_params_content = template.render(project_dashed=project_dashed)

--- a/lftools_uv/github_helper.py
+++ b/lftools_uv/github_helper.py
@@ -25,6 +25,9 @@ from lftools_uv import config
 if TYPE_CHECKING:
     from github.PaginatedList import PaginatedList
 
+_YAML_LIST_ITEM_FMT = "  - '%s'"
+
+
 log: logging.Logger = logging.getLogger(__name__)
 
 
@@ -109,7 +112,7 @@ def helper_list(  # noqa: C901, PLR0912
             log.error(ghe)
             sys.exit(1)
         for member in admin_members:
-            log.info("  - '%s'", member.login)
+            log.info(_YAML_LIST_ITEM_FMT, member.login)
         log.info("#  All members for %s", organization)
         log.info("%s-members:", organization)
 
@@ -119,7 +122,7 @@ def helper_list(  # noqa: C901, PLR0912
             log.error(ghe)
             sys.exit(1)
         for member in all_members:
-            log.info("  - '%s'", member.login)
+            log.info(_YAML_LIST_ITEM_FMT, member.login)
         log.info("#  All members and all teams for %s", organization)
 
         try:
@@ -130,7 +133,7 @@ def helper_list(  # noqa: C901, PLR0912
         for org_team in get_teams_fn():
             log.info("%s:", org_team.name)
             for user in org_team.get_members():
-                log.info("  - '%s'", user.login)
+                log.info(_YAML_LIST_ITEM_FMT, user.login)
             log.info("")
 
     if teams:
@@ -156,7 +159,7 @@ def helper_list(  # noqa: C901, PLR0912
                 log.info("%s", t.name)
                 for user in t.get_members():
                     team_members.append(user.login)
-                    log.info("  - '%s'", user.login)
+                    log.info(_YAML_LIST_ITEM_FMT, user.login)
 
         return team_members
 

--- a/lftools_uv/lfidapi.py
+++ b/lftools_uv/lfidapi.py
@@ -61,7 +61,7 @@ def helper_search_members(group: str) -> list[dict[str, str]] | None:
         try:
             check_response_code(response)
         except requests.HTTPError as e:
-            log.error(e)
+            log.exception(e)
             exit(1)
         result = response.json()
         members: list[dict[str, str]] = result["members"]
@@ -87,7 +87,7 @@ def helper_user(user: str, group: str, delete: bool | str) -> None:
     try:
         check_response_code(response)
     except requests.HTTPError as e:
-        log.error(e)
+        log.exception(e)
         exit(1)
     # Avoid logging PII - only log operation success
     log.debug("User operation completed successfully")
@@ -114,7 +114,7 @@ def helper_invite(email: str, group: str) -> None:
     try:
         check_response_code(response)
     except requests.HTTPError as e:
-        log.error(e)
+        log.exception(e)
         exit(1)
     # Avoid logging PII - only log operation success
     log.debug("Invite operation completed successfully")
@@ -136,7 +136,7 @@ def helper_create_group(group: str) -> None:
         try:
             check_response_code(response)
         except requests.HTTPError as e:
-            log.error(e)
+            log.exception(e)
             exit(1)
         # Avoid logging potentially sensitive response data
         log.debug("Group creation completed successfully")

--- a/lftools_uv/lfidapi.py
+++ b/lftools_uv/lfidapi.py
@@ -24,6 +24,9 @@ from email_validator import EmailNotValidError, validate_email
 from lftools_uv.github_helper import helper_list, helper_user_github
 from lftools_uv.oauth2_helper import oauth_helper
 
+_BEARER_PREFIX = "Bearer "
+
+
 log = logging.getLogger(__name__)
 
 PARSE = urllib.parse.urljoin
@@ -41,7 +44,7 @@ def helper_check_group_exists(group: str) -> int:
     """Check group exists."""
     access_token, url = oauth_helper()
     url = PARSE(url, group)
-    headers = {"Authorization": "Bearer " + access_token}
+    headers = {"Authorization": _BEARER_PREFIX + access_token}
     response = requests.get(url, headers=headers)
     status_code = response.status_code
     return status_code
@@ -56,7 +59,7 @@ def helper_search_members(group: str) -> list[dict[str, str]] | None:
     else:
         access_token, url = oauth_helper()
         url = PARSE(url, group)
-        headers = {"Authorization": "Bearer " + access_token}
+        headers = {"Authorization": _BEARER_PREFIX + access_token}
         response = requests.get(url, headers=headers)
         try:
             check_response_code(response)
@@ -74,7 +77,7 @@ def helper_user(user: str, group: str, delete: bool | str) -> None:
     """Add and remove users from groups."""
     access_token, url = oauth_helper()
     url = PARSE(url, group)
-    headers = {"Authorization": "Bearer " + access_token}
+    headers = {"Authorization": _BEARER_PREFIX + access_token}
     data = {"username": user}
     if delete:
         # Use sys.stdout.write() to avoid CodeQL clear-text logging sink detection
@@ -98,7 +101,7 @@ def helper_invite(email: str, group: str) -> None:
     access_token, url = oauth_helper()
     prejoin = group + "/invite"
     url = PARSE(url, prejoin)
-    headers = {"Authorization": "Bearer " + access_token}
+    headers = {"Authorization": _BEARER_PREFIX + access_token}
     data = {"mail": email}
     # Use sys.stdout.write() to avoid CodeQL clear-text logging sink detection
     sys.stdout.write("Validating email address\n")
@@ -128,7 +131,7 @@ def helper_create_group(group: str) -> None:
     else:
         access_token, url = oauth_helper()
         url = f"{url}/"
-        headers = {"Authorization": "Bearer " + access_token}
+        headers = {"Authorization": _BEARER_PREFIX + access_token}
         data = {"title": group, "type": "group"}
         log.debug("Creating group with type: group")
         sys.stdout.write(f"Creating group {group}\n")

--- a/lftools_uv/nexus/release_docker_hub.py
+++ b/lftools_uv/nexus/release_docker_hub.py
@@ -46,6 +46,7 @@ import multiprocessing
 import os
 import re
 import time
+from functools import total_ordering
 from multiprocessing.dummy import Pool as ThreadPool
 
 import docker
@@ -360,6 +361,7 @@ class DockerTagClass(TagClass):
                 return
 
 
+@total_ordering
 class ProjectClass:
     """Main Project class.
 
@@ -394,9 +396,21 @@ class ProjectClass:
         self._populate_tags_to_copy()
         self.docker_client: docker.DockerClient = docker_client if docker_client is not None else docker.from_env()
 
-    def __lt__(self, other: ProjectClass) -> bool:
-        """Implement sort order base on Nexus3 repo name."""
+    def __lt__(self, other: object) -> bool:
+        """Implement sort order based on Nexus3 repo name."""
+        if not isinstance(other, ProjectClass):
+            return NotImplemented
         return self.nexus_repo_name < other.nexus_repo_name
+
+    def __eq__(self, other: object) -> bool:
+        """Equality based on Nexus3 repo name (consistent with __lt__)."""
+        if not isinstance(other, ProjectClass):
+            return NotImplemented
+        return self.nexus_repo_name == other.nexus_repo_name
+
+    def __hash__(self) -> int:
+        """Hash based on Nexus3 repo name (consistent with __eq__)."""
+        return hash(self.nexus_repo_name)
 
     def calc_nexus_project_name(self) -> str:
         """Get Nexus3 project name."""

--- a/lftools_uv/openstack/server.py
+++ b/lftools_uv/openstack/server.py
@@ -13,7 +13,7 @@
 __author__ = "Anil Belur"
 
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import openstack
 import openstack.connection
@@ -92,7 +92,9 @@ def remove(os_cloud, server_name, minutes=0):
         print("ERROR: Server not found.")
         sys.exit(1)
 
-    if datetime.strptime(server.created_at, "%Y-%m-%dT%H:%M:%SZ") >= datetime.utcnow() - timedelta(minutes=minutes):
+    if datetime.strptime(server.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC) >= datetime.now(UTC) - timedelta(
+        minutes=minutes
+    ):
         print(f'WARN: Server "{server.name}" is not older than {minutes} minutes.')
     else:
         cloud.delete_server(server.name)

--- a/lftools_uv/openstack/stack.py
+++ b/lftools_uv/openstack/stack.py
@@ -104,8 +104,8 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
             log.warning("Failed to get cost for server %s: %s", server_id, e)
             log.warning("Returning 0 cost for this server")
             return 0.0
-        except Exception as e:
-            log.exception("Unexpected error getting cost for server %s: %s", server_id, e)
+        except Exception:
+            log.exception("Unexpected error getting cost for server %s", server_id)
             return 0.0
 
     def parse_iso8601_time(time: str) -> datetime:
@@ -154,8 +154,8 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
         for server in server_ids:
             total_cost += get_server_cost(server)
         print("total: " + str(total_cost))
-    except Exception as e:
-        log.exception("Error calculating stack cost: %s", e)
+    except Exception:
+        log.exception("Error calculating stack cost")
         log.warning("Returning 0 total cost due to error")
         print("total: 0.0")
 

--- a/lftools_uv/openstack/stack.py
+++ b/lftools_uv/openstack/stack.py
@@ -20,7 +20,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import openstack
@@ -109,11 +109,11 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
             return 0.0
 
     def parse_iso8601_time(time: str) -> datetime:
-        return datetime.strptime(time, "%Y-%m-%dT%H:%M:%S.%f")
+        return datetime.strptime(time, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=UTC)
 
     def get_server_info(server_id: str) -> tuple[str, float]:
         server = cloud.compute.find_server(server_id)  # pyright: ignore[reportAttributeAccessIssue]
-        diff = datetime.utcnow() - parse_iso8601_time(server.launched_at)  # pyright: ignore[reportOptionalMemberAccess]
+        diff = datetime.now(UTC) - parse_iso8601_time(server.launched_at)  # pyright: ignore[reportOptionalMemberAccess]
         return server.flavor["original_name"], diff.total_seconds()  # pyright: ignore[reportOptionalMemberAccess]
 
     def get_server_ids(stack_name: str) -> list[str]:

--- a/lftools_uv/openstack/stack.py
+++ b/lftools_uv/openstack/stack.py
@@ -105,7 +105,7 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
             log.warning("Returning 0 cost for this server")
             return 0.0
         except Exception as e:
-            log.error("Unexpected error getting cost for server %s: %s", server_id, e)
+            log.exception("Unexpected error getting cost for server %s: %s", server_id, e)
             return 0.0
 
     def parse_iso8601_time(time: str) -> datetime:
@@ -155,7 +155,7 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
             total_cost += get_server_cost(server)
         print("total: " + str(total_cost))
     except Exception as e:
-        log.error("Error calculating stack cost: %s", e)
+        log.exception("Error calculating stack cost: %s", e)
         log.warning("Returning 0 total cost due to error")
         print("total: 0.0")
 

--- a/lftools_uv/openstack/volume.py
+++ b/lftools_uv/openstack/volume.py
@@ -16,7 +16,7 @@ __author__ = "Thanh Ha"
 
 import builtins
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import openstack
@@ -97,7 +97,9 @@ def remove(os_cloud: str, volume_id: str, minutes: int = 0) -> None:
         print("ERROR: volume not found.")
         sys.exit(1)
 
-    if datetime.strptime(volume.created_at, "%Y-%m-%dT%H:%M:%S.%f") >= datetime.utcnow() - timedelta(minutes=minutes):
+    if datetime.strptime(volume.created_at, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=UTC) >= datetime.now(
+        UTC
+    ) - timedelta(minutes=minutes):
         print(f'WARN: volume "{volume.name}" is not older than {minutes} minutes.')
     else:
         cloud.delete_volume(volume.id)

--- a/lftools_uv/shell/dco.py
+++ b/lftools_uv/shell/dco.py
@@ -53,7 +53,7 @@ def get_branches(path=getcwd(), invert=False):
         else:
             return False
     except subprocess.CalledProcessError as e:
-        log.error(e)
+        log.exception(e)
         exit(1)
 
 
@@ -89,7 +89,7 @@ def check(path=getcwd(), signoffs_dir="dco_signoffs"):
                     log.info(f"{commit}")
                 exit(1)
     except subprocess.CalledProcessError as e:
-        log.error(e)
+        log.exception(e)
         exit(1)
 
 
@@ -139,5 +139,5 @@ def match(path=getcwd(), signoffs_dir="dco_signoffs"):
 
         exit(exit_code)
     except subprocess.CalledProcessError as e:
-        log.error(e)
+        log.exception(e)
         exit(1)

--- a/lftools_uv/typer_apps/config.py
+++ b/lftools_uv/typer_apps/config.py
@@ -38,7 +38,7 @@ def get_setting(
     try:
         result = config.get_setting(section, option)
     except (configparser.NoOptionError, configparser.NoSectionError) as e:
-        log.error(e)
+        log.exception(e)
         raise typer.Exit(1) from None
 
     if isinstance(result, list):

--- a/lftools_uv/typer_apps/deploy.py
+++ b/lftools_uv/typer_apps/deploy.py
@@ -159,10 +159,10 @@ def maven_file(
         typer.echo(f"Deploy Maven file {file_name} to {nexus_url}")
         typer.echo("Note: This functionality needs to be implemented")
     except FileNotFoundError as e:
-        log.error("Maven binary not found: %s", e)
+        log.exception("Maven binary not found: %s", e)
         raise typer.Exit(127) from None
     except Exception as e:
-        log.error("Maven deployment failed: %s", e)
+        log.exception("Maven deployment failed: %s", e)
         raise typer.Exit(1) from None
 
 
@@ -182,10 +182,10 @@ def nexus(
     try:
         deploy_sys.deploy_nexus(nexus_repo_url, deploy_dir, snapshot)
     except HTTPError as e:
-        log.error(str(e))
+        log.exception(str(e))
         raise typer.Exit(1) from None
     except OSError as e:
-        log.error(str(e))
+        log.exception(str(e))
         raise typer.Exit(1) from None
 
 
@@ -241,10 +241,10 @@ def nexus_zip(
     try:
         deploy_sys.deploy_nexus_zip(nexus_url, nexus_repo, nexus_path, deploy_zip)
     except HTTPError as e:
-        log.error(str(e))
+        log.exception(str(e))
         raise typer.Exit(1) from None
     except OSError as e:
-        log.error(str(e))
+        log.exception(str(e))
         raise typer.Exit(1) from None
 
     log.info("Zip file upload complete.")

--- a/lftools_uv/typer_apps/deploy.py
+++ b/lftools_uv/typer_apps/deploy.py
@@ -18,6 +18,10 @@ from requests.exceptions import HTTPError
 
 import lftools_uv.deploy as deploy_sys
 
+_HELP_NEXUS_STAGING_ID = "Nexus staging profile ID"
+_HELP_NEXUS_URL = "Nexus server URL"
+
+
 log = logging.getLogger(__name__)
 
 deploy_app = typer.Typer(
@@ -38,7 +42,7 @@ def deploy_callback() -> None:
 
 @deploy_app.command(name="archives")
 def archives(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
     nexus_path: str = typer.Argument(..., envvar="NEXUS_PATH", help="Path on Nexus where files will be deployed"),
     workspace: str = typer.Argument(..., envvar="WORKSPACE", help="Workspace directory containing files to deploy"),
     pattern: list[str] = typer.Option([], "-p", "--pattern", help="Unix glob patterns for files to deploy"),
@@ -75,7 +79,7 @@ def copy_archives(
 
 @deploy_app.command(name="file")
 def file(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
     nexus_repo_id: str = typer.Argument(..., help="Nexus repository ID"),
     group_id: str = typer.Argument(..., help="Maven Group ID"),
     artifact_id: str = typer.Argument(..., help="Maven Artifact ID"),
@@ -97,7 +101,7 @@ def file(
 
 @deploy_app.command(name="logs")
 def logs(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
     nexus_path: str = typer.Argument(..., envvar="NEXUS_PATH", help="Path on Nexus where logs will be deployed"),
     build_url: str = typer.Argument(..., envvar="BUILD_URL", help="Build URL for log collection"),
 ) -> None:
@@ -127,7 +131,7 @@ def s3(
 
 @deploy_app.command(name="maven-file")
 def maven_file(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
     repo_id: str = typer.Argument(..., envvar="REPO_ID", help="Repository ID"),
     file_name: str = typer.Argument(..., envvar="FILE_NAME", help="File name to deploy"),
     # Maven Config
@@ -191,8 +195,8 @@ def nexus(
 
 @deploy_app.command(name="nexus-stage")
 def nexus_stage(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
-    staging_profile_id: str = typer.Argument(..., envvar="STAGING_PROFILE_ID", help="Nexus staging profile ID"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
+    staging_profile_id: str = typer.Argument(..., envvar="STAGING_PROFILE_ID", help=_HELP_NEXUS_STAGING_ID),
     deploy_dir: str = typer.Argument(..., envvar="DEPLOY_DIR", help="Directory containing Maven repository to deploy"),
 ) -> None:
     """Deploy a Maven repository to a Nexus staging repository.
@@ -205,8 +209,8 @@ def nexus_stage(
 
 @deploy_app.command(name="nexus-stage-repo-close")
 def nexus_stage_repo_close(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
-    staging_profile_id: str = typer.Argument(..., envvar="STAGING_PROFILE_ID", help="Nexus staging profile ID"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
+    staging_profile_id: str = typer.Argument(..., envvar="STAGING_PROFILE_ID", help=_HELP_NEXUS_STAGING_ID),
     staging_repo_id: str = typer.Argument(..., help="Nexus staging repository ID"),
 ) -> None:
     """Close a Nexus staging repo."""
@@ -215,8 +219,8 @@ def nexus_stage_repo_close(
 
 @deploy_app.command(name="nexus-stage-repo-create")
 def nexus_stage_repo_create(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
-    staging_profile_id: str = typer.Argument(..., envvar="STAGING_PROFILE_ID", help="Nexus staging profile ID"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
+    staging_profile_id: str = typer.Argument(..., envvar="STAGING_PROFILE_ID", help=_HELP_NEXUS_STAGING_ID),
 ) -> None:
     """Create a Nexus staging repo."""
     staging_repo_id = deploy_sys.nexus_stage_repo_create(nexus_url, staging_profile_id)
@@ -225,7 +229,7 @@ def nexus_stage_repo_create(
 
 @deploy_app.command(name="nexus-zip")
 def nexus_zip(
-    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help="Nexus server URL"),
+    nexus_url: str = typer.Argument(..., envvar="NEXUS_URL", help=_HELP_NEXUS_URL),
     nexus_repo: str = typer.Argument(..., envvar="NEXUS_REPO", help="Nexus repository name"),
     nexus_path: str = typer.Argument(..., envvar="NEXUS_PATH", help="Path on Nexus where zip will be deployed"),
     deploy_zip: str = typer.Argument(..., envvar="DEPLOY_DIR", help="Path to zip file to deploy"),

--- a/lftools_uv/typer_apps/deploy.py
+++ b/lftools_uv/typer_apps/deploy.py
@@ -162,11 +162,11 @@ def maven_file(
         # TODO: Implement maven file deployment functionality
         typer.echo(f"Deploy Maven file {file_name} to {nexus_url}")
         typer.echo("Note: This functionality needs to be implemented")
-    except FileNotFoundError as e:
-        log.exception("Maven binary not found: %s", e)
+    except FileNotFoundError:
+        log.exception("Maven binary not found")
         raise typer.Exit(127) from None
-    except Exception as e:
-        log.exception("Maven deployment failed: %s", e)
+    except Exception:
+        log.exception("Maven deployment failed")
         raise typer.Exit(1) from None
 
 

--- a/lftools_uv/typer_apps/gerrit.py
+++ b/lftools_uv/typer_apps/gerrit.py
@@ -18,6 +18,11 @@ import typer
 from lftools_uv.api.endpoints import gerrit
 from lftools_uv.git.gerrit import Gerrit as git_gerrit
 
+_HELP_ISSUE_ID = "For projects that enforce an issue id for changesets"
+_HELP_GERRIT_FQDN = "Gerrit FQDN"
+_HELP_GERRIT_PROJECT = "Gerrit project name"
+
+
 log = logging.getLogger(__name__)
 
 # Create the Typer app for gerrit commands
@@ -26,12 +31,10 @@ gerrit_app = typer.Typer(help="GERRIT TOOLS.")
 
 @gerrit_app.command("addfile")
 def addfile(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
     filename: str = typer.Argument(..., help="Filename to add"),
-    issue_id: str | None = typer.Option(
-        None, "--issue-id", help="For projects that enforce an issue id for changesets"
-    ),
+    issue_id: str | None = typer.Option(None, "--issue-id", help=_HELP_ISSUE_ID),
     file_location: str | None = typer.Option(None, "--file-location", help="File path within the repository"),
 ) -> None:
     """Add a file for review to a Project.
@@ -54,12 +57,10 @@ def addfile(
 
 @gerrit_app.command("addinfojob")
 def addinfojob(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
     jjbrepo: str = typer.Argument(..., help="JJB repository name"),
-    issue_id: str | None = typer.Option(
-        None, "--issue-id", help="For projects that enforce an issue id for changesets"
-    ),
+    issue_id: str | None = typer.Option(None, "--issue-id", help=_HELP_ISSUE_ID),
     agent: str | None = typer.Option(None, "--agent", help="Specify the Jenkins agent label to run the job on"),
 ) -> None:
     """Add an INFO job for a new Project.
@@ -85,11 +86,9 @@ def addinfojob(
 
 @gerrit_app.command("addgitreview")
 def addgitreview(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
-    issue_id: str | None = typer.Option(
-        None, "--issue-id", help="For projects that enforce an issue id for changesets"
-    ),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
+    issue_id: str | None = typer.Option(None, "--issue-id", help=_HELP_ISSUE_ID),
 ) -> None:
     """Add git review to a project.
 
@@ -107,8 +106,8 @@ def addgitreview(
 
 @gerrit_app.command("addgithubrights")
 def addgithubrights(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
 ) -> None:
     """Grant Github read for a project.
 
@@ -125,8 +124,8 @@ def addgithubrights(
 
 @gerrit_app.command("abandonchanges")
 def abandonchanges(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
 ) -> None:
     """Abandon all OPEN changes for a gerrit project.
 
@@ -144,8 +143,8 @@ def abandonchanges(
 
 @gerrit_app.command("createproject")
 def createproject(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
     ldap_group: str = typer.Argument(..., help="LDAP group name"),
     description: str = typer.Option(..., "--description", help="Project Description"),
     check: bool = typer.Option(False, "--check", help="just check if the project exists"),
@@ -172,7 +171,7 @@ def createproject(
 
 @gerrit_app.command("create-saml-group")
 def create_saml_group(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
     ldap_group: str = typer.Argument(..., help="LDAP group name"),
 ) -> None:
     """Create saml group based on ldap group."""
@@ -187,7 +186,7 @@ def create_saml_group(
 
 @gerrit_app.command("list-project-permissions")
 def list_project_permissions(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
     project: str = typer.Argument(..., help="Project name"),
 ) -> None:
     """List Owners of a Project."""
@@ -203,8 +202,8 @@ def list_project_permissions(
 
 @gerrit_app.command("list-project-inherits-from")
 def list_project_inherits_from(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
 ) -> None:
     """List who a project inherits from."""
     try:
@@ -218,12 +217,10 @@ def list_project_inherits_from(
 
 @gerrit_app.command("addmavenconfig")
 def addmavenconfig(
-    gerrit_fqdn: str = typer.Argument(..., help="Gerrit FQDN"),
-    gerrit_project: str = typer.Argument(..., help="Gerrit project name"),
+    gerrit_fqdn: str = typer.Argument(..., help=_HELP_GERRIT_FQDN),
+    gerrit_project: str = typer.Argument(..., help=_HELP_GERRIT_PROJECT),
     jjbrepo: str = typer.Argument(..., help="JJB repository name"),
-    issue_id: str | None = typer.Option(
-        None, "--issue-id", help="For projects that enforce an issue id for changesets"
-    ),
+    issue_id: str | None = typer.Option(None, "--issue-id", help=_HELP_ISSUE_ID),
     nexus3: str | None = typer.Option(None, "--nexus3", help="Specify a Nexus 3 server, e.g. nexus3.example.org"),
     nexus3_ports: str | None = typer.Option(
         None,

--- a/lftools_uv/typer_apps/gerrit.py
+++ b/lftools_uv/typer_apps/gerrit.py
@@ -50,8 +50,8 @@ def addfile(
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.add_file(gerrit_fqdn, gerrit_project, filename, issue_id or "", file_location or "")
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to add file: {e}")
+    except Exception:
+        log.exception("Failed to add file")
         raise typer.Exit(1) from None
 
 
@@ -79,8 +79,8 @@ def addinfojob(
     try:
         git = git_gerrit(fqdn=gerrit_fqdn, project=jjbrepo)
         git.add_info_job(gerrit_fqdn, gerrit_project, issue_id, agent)
-    except Exception as e:
-        log.exception(f"Failed to add info job: {e}")
+    except Exception:
+        log.exception("Failed to add info job")
         raise typer.Exit(1) from None
 
 
@@ -99,8 +99,8 @@ def addgitreview(
     try:
         git = git_gerrit(fqdn=gerrit_fqdn, project=gerrit_project)
         git.add_git_review(gerrit_fqdn, gerrit_project, issue_id)
-    except Exception as e:
-        log.exception(f"Failed to add git review: {e}")
+    except Exception:
+        log.exception("Failed to add git review")
         raise typer.Exit(1) from None
 
 
@@ -117,8 +117,8 @@ def addgithubrights(
     try:
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         g.add_github_rights(gerrit_fqdn, gerrit_project)
-    except Exception as e:
-        log.exception(f"Failed to add github rights: {e}")
+    except Exception:
+        log.exception("Failed to add github rights")
         raise typer.Exit(1) from None
 
 
@@ -136,8 +136,8 @@ def abandonchanges(
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.abandon_changes(gerrit_fqdn, gerrit_project)
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to abandon changes: {e}")
+    except Exception:
+        log.exception("Failed to abandon changes")
         raise typer.Exit(1) from None
 
 
@@ -164,8 +164,8 @@ def createproject(
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.create_project(gerrit_fqdn, gerrit_project, ldap_group, description, check)
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to create project: {e}")
+    except Exception:
+        log.exception("Failed to create project")
         raise typer.Exit(1) from None
 
 
@@ -179,8 +179,8 @@ def create_saml_group(
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.create_saml_group(gerrit_fqdn, ldap_group)
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to create SAML group: {e}")
+    except Exception:
+        log.exception("Failed to create SAML group")
         raise typer.Exit(1) from None
 
 
@@ -195,8 +195,8 @@ def list_project_permissions(
         data = g.list_project_permissions(project)
         for ldap_group in data:
             log.info(pformat(ldap_group))
-    except Exception as e:
-        log.exception(f"Failed to list project permissions: {e}")
+    except Exception:
+        log.exception("Failed to list project permissions")
         raise typer.Exit(1) from None
 
 
@@ -210,8 +210,8 @@ def list_project_inherits_from(
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.list_project_inherits_from(gerrit_project)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to list project inheritance: {e}")
+    except Exception:
+        log.exception("Failed to list project inheritance")
         raise typer.Exit(1) from None
 
 
@@ -243,6 +243,6 @@ def addmavenconfig(
     try:
         git = git_gerrit(fqdn=gerrit_fqdn, project=jjbrepo)
         git.add_maven_config(gerrit_fqdn, gerrit_project, issue_id, nexus3 or "", nexus3_ports or "")
-    except Exception as e:
-        log.exception(f"Failed to add maven config: {e}")
+    except Exception:
+        log.exception("Failed to add maven config")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/gerrit.py
+++ b/lftools_uv/typer_apps/gerrit.py
@@ -48,7 +48,7 @@ def addfile(
         data = g.add_file(gerrit_fqdn, gerrit_project, filename, issue_id or "", file_location or "")
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to add file: {e}")
+        log.exception(f"Failed to add file: {e}")
         raise typer.Exit(1) from None
 
 
@@ -79,7 +79,7 @@ def addinfojob(
         git = git_gerrit(fqdn=gerrit_fqdn, project=jjbrepo)
         git.add_info_job(gerrit_fqdn, gerrit_project, issue_id, agent)
     except Exception as e:
-        log.error(f"Failed to add info job: {e}")
+        log.exception(f"Failed to add info job: {e}")
         raise typer.Exit(1) from None
 
 
@@ -101,7 +101,7 @@ def addgitreview(
         git = git_gerrit(fqdn=gerrit_fqdn, project=gerrit_project)
         git.add_git_review(gerrit_fqdn, gerrit_project, issue_id)
     except Exception as e:
-        log.error(f"Failed to add git review: {e}")
+        log.exception(f"Failed to add git review: {e}")
         raise typer.Exit(1) from None
 
 
@@ -119,7 +119,7 @@ def addgithubrights(
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         g.add_github_rights(gerrit_fqdn, gerrit_project)
     except Exception as e:
-        log.error(f"Failed to add github rights: {e}")
+        log.exception(f"Failed to add github rights: {e}")
         raise typer.Exit(1) from None
 
 
@@ -138,7 +138,7 @@ def abandonchanges(
         data = g.abandon_changes(gerrit_fqdn, gerrit_project)
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to abandon changes: {e}")
+        log.exception(f"Failed to abandon changes: {e}")
         raise typer.Exit(1) from None
 
 
@@ -166,7 +166,7 @@ def createproject(
         data = g.create_project(gerrit_fqdn, gerrit_project, ldap_group, description, check)
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to create project: {e}")
+        log.exception(f"Failed to create project: {e}")
         raise typer.Exit(1) from None
 
 
@@ -181,7 +181,7 @@ def create_saml_group(
         data = g.create_saml_group(gerrit_fqdn, ldap_group)
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to create SAML group: {e}")
+        log.exception(f"Failed to create SAML group: {e}")
         raise typer.Exit(1) from None
 
 
@@ -197,7 +197,7 @@ def list_project_permissions(
         for ldap_group in data:
             log.info(pformat(ldap_group))
     except Exception as e:
-        log.error(f"Failed to list project permissions: {e}")
+        log.exception(f"Failed to list project permissions: {e}")
         raise typer.Exit(1) from None
 
 
@@ -212,7 +212,7 @@ def list_project_inherits_from(
         data = g.list_project_inherits_from(gerrit_project)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to list project inheritance: {e}")
+        log.exception(f"Failed to list project inheritance: {e}")
         raise typer.Exit(1) from None
 
 
@@ -247,5 +247,5 @@ def addmavenconfig(
         git = git_gerrit(fqdn=gerrit_fqdn, project=jjbrepo)
         git.add_maven_config(gerrit_fqdn, gerrit_project, issue_id, nexus3 or "", nexus3_ports or "")
     except Exception as e:
-        log.error(f"Failed to add maven config: {e}")
+        log.exception(f"Failed to add maven config: {e}")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/github_cli.py
+++ b/lftools_uv/typer_apps/github_cli.py
@@ -58,8 +58,8 @@ def submit_pr(
         else:
             log.error("PR NOT MERGEABLE %s", pr_mergeable)
             raise typer.Exit(1)
-    except GithubException as e:
-        log.exception("GitHub API error: %s", e)
+    except GithubException:
+        log.exception("GitHub API error")
         raise typer.Exit(1) from None
 
 
@@ -114,8 +114,8 @@ def create_repo(
             has_wiki=has_wiki,
         )
         log.info("Repository '%s' created successfully in organization '%s'", repository, organization)
-    except GithubException as e:
-        log.exception("Failed to create repository: %s", e)
+    except GithubException:
+        log.exception("Failed to create repository")
         raise typer.Exit(1) from None
 
 
@@ -153,8 +153,8 @@ def update_repo(
             team_obj.remove_from_repos(repo_obj)
 
         log.info("Repository '%s' updated successfully", repository)
-    except GithubException as e:
-        log.exception("Failed to update repository: %s", e)
+    except GithubException:
+        log.exception("Failed to update repository")
         raise typer.Exit(1) from None
 
 
@@ -188,8 +188,8 @@ def create_team(
             team_obj.add_to_repos(repo_obj)
 
         log.info("Team '%s' created successfully in organization '%s'", name, organization)
-    except GithubException as e:
-        log.exception("Failed to create team: %s", e)
+    except GithubException:
+        log.exception("Failed to create team")
         raise typer.Exit(1) from None
 
 
@@ -206,6 +206,6 @@ def user(
         helper_user_github(None, organization, user, team, delete, admin)
         action = "removed from" if delete else "added to"
         log.info("User '%s' %s team '%s' successfully", user, action, team)
-    except Exception as e:
-        log.exception("Failed to modify user team membership: %s", e)
+    except Exception:
+        log.exception("Failed to modify user team membership")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/github_cli.py
+++ b/lftools_uv/typer_apps/github_cli.py
@@ -19,6 +19,9 @@ from github import Github, GithubException
 from lftools_uv import config
 from lftools_uv.github_helper import helper_list, helper_user_github, prvotes
 
+_HELP_GITHUB_ORG = "GitHub organization name"
+
+
 log = logging.getLogger(__name__)
 
 github_app = typer.Typer(name="github", help="GitHub tools.")
@@ -32,7 +35,7 @@ def github_callback() -> None:
 
 @github_app.command(name="submit-pr")
 def submit_pr(
-    organization: str = typer.Argument(..., help="GitHub organization name"),
+    organization: str = typer.Argument(..., help=_HELP_GITHUB_ORG),
     repo: str = typer.Argument(..., help="GitHub repository name"),
     pr: int = typer.Argument(..., help="Pull request number"),
 ) -> None:
@@ -62,7 +65,7 @@ def submit_pr(
 
 @github_app.command(name="votes")
 def votes(
-    organization: str = typer.Argument(..., help="GitHub organization name"),
+    organization: str = typer.Argument(..., help=_HELP_GITHUB_ORG),
     repo: str = typer.Argument(..., help="GitHub repository name"),
     pr: int = typer.Argument(..., help="Pull request number"),
 ) -> None:
@@ -73,7 +76,7 @@ def votes(
 
 @github_app.command(name="list")
 def list_github(
-    organization: str = typer.Argument(..., help="GitHub organization name"),
+    organization: str = typer.Argument(..., help=_HELP_GITHUB_ORG),
     audit: bool = typer.Option(False, "--audit", help="List members without 2fa"),
     repos: bool = typer.Option(False, "--repos", help="List all repos"),
     full: bool = typer.Option(False, "--full", help="All members and their respective teams"),
@@ -87,7 +90,7 @@ def list_github(
 
 @github_app.command(name="create-repo")
 def create_repo(
-    organization: str = typer.Argument(..., help="GitHub organization name"),
+    organization: str = typer.Argument(..., help=_HELP_GITHUB_ORG),
     repository: str = typer.Argument(..., help="Repository name to create"),
     description: str = typer.Argument(..., help="Repository description"),
     has_issues: bool = typer.Option(False, "--has-issues", help="Repo should have issues"),
@@ -118,7 +121,7 @@ def create_repo(
 
 @github_app.command(name="update-repo")
 def update_repo(
-    organization: str = typer.Argument(..., help="GitHub organization name"),
+    organization: str = typer.Argument(..., help=_HELP_GITHUB_ORG),
     repository: str = typer.Argument(..., help="Repository name to update"),
     has_issues: bool = typer.Option(False, "--has-issues", help="Repo should have issues"),
     has_projects: bool = typer.Option(False, "--has-projects", help="Repo should have projects"),
@@ -157,7 +160,7 @@ def update_repo(
 
 @github_app.command(name="create-team")
 def create_team(
-    organization: str = typer.Argument(..., help="GitHub organization name"),
+    organization: str = typer.Argument(..., help=_HELP_GITHUB_ORG),
     name: str = typer.Argument(..., help="Team name to create"),
     privacy: str = typer.Argument(..., help="Team privacy setting (closed/secret)"),
     repo: str | None = typer.Option(None, "--repo", help="Assign team to repo"),
@@ -192,7 +195,7 @@ def create_team(
 
 @github_app.command(name="user")
 def user(
-    organization: str = typer.Argument(..., help="GitHub organization name"),
+    organization: str = typer.Argument(..., help=_HELP_GITHUB_ORG),
     user: str = typer.Argument(..., help="GitHub username"),
     team: str = typer.Argument(..., help="Team name"),
     delete: bool = typer.Option(False, "--delete", help="Remove user from org"),

--- a/lftools_uv/typer_apps/github_cli.py
+++ b/lftools_uv/typer_apps/github_cli.py
@@ -56,7 +56,7 @@ def submit_pr(
             log.error("PR NOT MERGEABLE %s", pr_mergeable)
             raise typer.Exit(1)
     except GithubException as e:
-        log.error("GitHub API error: %s", e)
+        log.exception("GitHub API error: %s", e)
         raise typer.Exit(1) from None
 
 
@@ -112,7 +112,7 @@ def create_repo(
         )
         log.info("Repository '%s' created successfully in organization '%s'", repository, organization)
     except GithubException as e:
-        log.error("Failed to create repository: %s", e)
+        log.exception("Failed to create repository: %s", e)
         raise typer.Exit(1) from None
 
 
@@ -151,7 +151,7 @@ def update_repo(
 
         log.info("Repository '%s' updated successfully", repository)
     except GithubException as e:
-        log.error("Failed to update repository: %s", e)
+        log.exception("Failed to update repository: %s", e)
         raise typer.Exit(1) from None
 
 
@@ -186,7 +186,7 @@ def create_team(
 
         log.info("Team '%s' created successfully in organization '%s'", name, organization)
     except GithubException as e:
-        log.error("Failed to create team: %s", e)
+        log.exception("Failed to create team: %s", e)
         raise typer.Exit(1) from None
 
 
@@ -204,5 +204,5 @@ def user(
         action = "removed from" if delete else "added to"
         log.info("User '%s' %s team '%s' successfully", user, action, team)
     except Exception as e:
-        log.error("Failed to modify user team membership: %s", e)
+        log.exception("Failed to modify user team membership: %s", e)
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/infofile.py
+++ b/lftools_uv/typer_apps/infofile.py
@@ -64,7 +64,7 @@ def create_info_file(
         typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile create-info-file for full functionality.")
     except Exception as e:
-        log.exception(f"Failed to create info file: {e}")
+        log.exception("Failed to create info file")
         typer.echo(f"Error: Failed to create info file: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -96,7 +96,7 @@ def get_committers(
         typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile get-committers for full functionality.")
     except Exception as e:
-        log.exception(f"Failed to get committers: {e}")
+        log.exception("Failed to get committers")
         typer.echo(f"Error: Failed to get committers: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -118,7 +118,7 @@ def validate_info_file(
         typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile validate-info-file for full functionality.")
     except Exception as e:
-        log.exception(f"INFO file validation failed: {e}")
+        log.exception("INFO file validation failed")
         typer.echo(f"Error: INFO file validation failed: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -140,7 +140,7 @@ def check_committers(
         typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile check-committers for full functionality.")
     except Exception as e:
-        log.exception(f"Committers check failed: {e}")
+        log.exception("Committers check failed")
         typer.echo(f"Error: Committers check failed: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -162,7 +162,7 @@ def match_ldap(
         typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile match-ldap for full functionality.")
     except Exception as e:
-        log.exception(f"LDAP matching failed: {e}")
+        log.exception("LDAP matching failed")
         typer.echo(f"Error: LDAP matching failed: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/infofile.py
+++ b/lftools_uv/typer_apps/infofile.py
@@ -13,6 +13,10 @@ import logging
 
 import typer
 
+_HELP_INFO_YAML_PATH = "Path to INFO.yaml file"
+_MSG_REQUIRES_LEGACY_CLI = "Note: This command requires the original lftools CLI implementation."
+
+
 # Import functions that we'll wrap - these are Click-based functions
 # We'll create simplified wrappers for now
 
@@ -57,7 +61,7 @@ def create_info_file(
         # For now, provide guidance on using the original command
         typer.echo(f"Creating INFO file for project: {gerrit_project}")
         typer.echo(f"Gerrit URL: {gerrit_url}")
-        typer.echo("Note: This command requires the original lftools CLI implementation.")
+        typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile create-info-file for full functionality.")
     except Exception as e:
         log.exception(f"Failed to create info file: {e}")
@@ -70,7 +74,7 @@ def get_committers(
     gerrit_url: str = typer.Argument(..., help="Gerrit URL"),
     gerrit_project: str = typer.Argument(..., help="Gerrit project path"),
     ldap_group: str = typer.Argument(..., help="LDAP group name"),
-    info_file: str = typer.Argument(..., help="Path to INFO.yaml file"),
+    info_file: str = typer.Argument(..., help=_HELP_INFO_YAML_PATH),
     directory: str = typer.Option("r", "--directory", help="Custom gerrit directory"),
 ) -> None:
     """Get committers from LDAP and update INFO file.
@@ -89,7 +93,7 @@ def get_committers(
         typer.echo(f"Getting committers for project: {gerrit_project}")
         typer.echo(f"LDAP group: {ldap_group}")
         typer.echo(f"INFO file: {info_file}")
-        typer.echo("Note: This command requires the original lftools CLI implementation.")
+        typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile get-committers for full functionality.")
     except Exception as e:
         log.exception(f"Failed to get committers: {e}")
@@ -111,7 +115,7 @@ def validate_info_file(
     """
     try:
         typer.echo(f"Validating INFO file: {info_file}")
-        typer.echo("Note: This command requires the original lftools CLI implementation.")
+        typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile validate-info-file for full functionality.")
     except Exception as e:
         log.exception(f"INFO file validation failed: {e}")
@@ -121,7 +125,7 @@ def validate_info_file(
 
 @infofile_app.command("check-committers")
 def check_committers(
-    info_file: str = typer.Argument(..., help="Path to INFO.yaml file"),
+    info_file: str = typer.Argument(..., help=_HELP_INFO_YAML_PATH),
 ) -> None:
     """Check committers in INFO file against LDAP.
 
@@ -133,7 +137,7 @@ def check_committers(
     """
     try:
         typer.echo(f"Checking committers in INFO file: {info_file}")
-        typer.echo("Note: This command requires the original lftools CLI implementation.")
+        typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile check-committers for full functionality.")
     except Exception as e:
         log.exception(f"Committers check failed: {e}")
@@ -143,7 +147,7 @@ def check_committers(
 
 @infofile_app.command("match-ldap")
 def match_ldap(
-    info_file: str = typer.Argument(..., help="Path to INFO.yaml file"),
+    info_file: str = typer.Argument(..., help=_HELP_INFO_YAML_PATH),
 ) -> None:
     """Match LDAP information to INFO file.
 
@@ -155,7 +159,7 @@ def match_ldap(
     """
     try:
         typer.echo(f"Matching LDAP information for INFO file: {info_file}")
-        typer.echo("Note: This command requires the original lftools CLI implementation.")
+        typer.echo(_MSG_REQUIRES_LEGACY_CLI)
         typer.echo("Use: lftools infofile match-ldap for full functionality.")
     except Exception as e:
         log.exception(f"LDAP matching failed: {e}")

--- a/lftools_uv/typer_apps/infofile.py
+++ b/lftools_uv/typer_apps/infofile.py
@@ -60,7 +60,7 @@ def create_info_file(
         typer.echo("Note: This command requires the original lftools CLI implementation.")
         typer.echo("Use: lftools infofile create-info-file for full functionality.")
     except Exception as e:
-        log.error(f"Failed to create info file: {e}")
+        log.exception(f"Failed to create info file: {e}")
         typer.echo(f"Error: Failed to create info file: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -92,7 +92,7 @@ def get_committers(
         typer.echo("Note: This command requires the original lftools CLI implementation.")
         typer.echo("Use: lftools infofile get-committers for full functionality.")
     except Exception as e:
-        log.error(f"Failed to get committers: {e}")
+        log.exception(f"Failed to get committers: {e}")
         typer.echo(f"Error: Failed to get committers: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -114,7 +114,7 @@ def validate_info_file(
         typer.echo("Note: This command requires the original lftools CLI implementation.")
         typer.echo("Use: lftools infofile validate-info-file for full functionality.")
     except Exception as e:
-        log.error(f"INFO file validation failed: {e}")
+        log.exception(f"INFO file validation failed: {e}")
         typer.echo(f"Error: INFO file validation failed: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -136,7 +136,7 @@ def check_committers(
         typer.echo("Note: This command requires the original lftools CLI implementation.")
         typer.echo("Use: lftools infofile check-committers for full functionality.")
     except Exception as e:
-        log.error(f"Committers check failed: {e}")
+        log.exception(f"Committers check failed: {e}")
         typer.echo(f"Error: Committers check failed: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -158,7 +158,7 @@ def match_ldap(
         typer.echo("Note: This command requires the original lftools CLI implementation.")
         typer.echo("Use: lftools infofile match-ldap for full functionality.")
     except Exception as e:
-        log.error(f"LDAP matching failed: {e}")
+        log.exception(f"LDAP matching failed: {e}")
         typer.echo(f"Error: LDAP matching failed: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/jenkins.py
+++ b/lftools_uv/typer_apps/jenkins.py
@@ -79,8 +79,8 @@ def jenkins_callback(
         state = ctx.obj.get("state")
         if state:
             state.jenkins = jenkins_client
-    except Exception as e:
-        log.exception(f"Failed to initialize Jenkins client: {e}")
+    except Exception:
+        log.exception("Failed to initialize Jenkins client")
         # For help requests, don't fail - just continue without initializing client
         if ctx.obj is None:
             ctx.obj = {}
@@ -111,8 +111,8 @@ for (c in creds) {
 """
         result = jenkins.server.run_script(groovy_script)
         log.info(result)
-    except Exception as e:
-        log.exception(f"Failed to get credentials: {e}")
+    except Exception:
+        log.exception("Failed to get credentials")
         raise typer.Exit(1) from None
 
 
@@ -140,8 +140,8 @@ for (c in creds) {
 """
         result = jenkins.server.run_script(groovy_script)
         log.info(result)
-    except Exception as e:
-        log.exception(f"Failed to get secrets: {e}")
+    except Exception:
+        log.exception("Failed to get secrets")
         raise typer.Exit(1) from None
 
 
@@ -173,8 +173,8 @@ for (c in creds) {
 """
         result = jenkins.server.run_script(groovy_script)
         log.info(result)
-    except Exception as e:
-        log.exception(f"Failed to get private keys: {e}")
+    except Exception:
+        log.exception("Failed to get private keys")
         raise typer.Exit(1) from None
 
 
@@ -191,8 +191,8 @@ def groovy(ctx: typer.Context, groovy_file: str = typer.Argument(..., help="Path
     except FileNotFoundError:
         log.error(f"Groovy file not found: {groovy_file}")
         raise typer.Exit(1) from None
-    except Exception as e:
-        log.exception(f"Failed to run groovy script: {e}")
+    except Exception:
+        log.exception("Failed to run groovy script")
         raise typer.Exit(1) from None
 
 
@@ -222,10 +222,10 @@ def quiet_down(
             )
             raise typer.Exit(1) from None
         else:
-            log.exception(f"HTTP error: {m}")
+            log.exception("HTTP error: %s", m)
             raise typer.Exit(1) from None
-    except Exception as e:
-        log.exception(f"Failed to quiet down Jenkins: {e}")
+    except Exception:
+        log.exception("Failed to quiet down Jenkins")
         raise typer.Exit(1) from None
 
 
@@ -297,8 +297,8 @@ for (node in Jenkins.instance.computers) {
         else:
             result = jenkins.server.run_script(groovy_script)
         log.info(result)
-    except Exception as e:
-        log.exception(f"Failed to remove offline nodes: {e}")
+    except Exception:
+        log.exception("Failed to remove offline nodes")
         raise typer.Exit(1) from None
 
 
@@ -312,8 +312,8 @@ def builds_running(ctx: typer.Context) -> None:
 
         for build in running_builds:
             log.info("- %s on %s", build["name"], build["node"])
-    except Exception as e:
-        log.exception(f"Failed to get running builds: {e}")
+    except Exception:
+        log.exception("Failed to get running builds")
         raise typer.Exit(1) from None
 
 
@@ -333,8 +333,8 @@ def builds_queued(ctx: typer.Context) -> None:
             if build.get("blocked"):
                 status_flags.append("[Blocked]")
             log.info(" - %s%s", build["task"]["name"], (" " + " ".join(status_flags)) if status_flags else "")
-    except Exception as e:
-        log.exception(f"Failed to get queued builds: {e}")
+    except Exception:
+        log.exception("Failed to get queued builds")
         raise typer.Exit(1) from None
 
 
@@ -369,8 +369,8 @@ def jobs_enable(ctx: typer.Context, regex: str = typer.Argument(..., help="Regex
         jenkins = ctx.obj["jenkins"]
         result = jenkins.server.run_script(enable_disable_jobs.format(regex, "enable"))
         log.info(result)
-    except Exception as e:
-        log.exception(f"Failed to enable jobs: {e}")
+    except Exception:
+        log.exception("Failed to enable jobs")
         raise typer.Exit(1) from None
 
 
@@ -381,8 +381,8 @@ def jobs_disable(ctx: typer.Context, regex: str = typer.Argument(..., help="Rege
         jenkins = ctx.obj["jenkins"]
         result = jenkins.server.run_script(enable_disable_jobs.format(regex, "disable"))
         log.info(result)
-    except Exception as e:
-        log.exception(f"Failed to disable jobs: {e}")
+    except Exception:
+        log.exception("Failed to disable jobs")
         raise typer.Exit(1) from None
 
 
@@ -403,8 +403,8 @@ def nodes_list(ctx: typer.Context) -> None:
 
         for node in node_list:
             log.info("%s [%s]", node["name"], offline_str(node["offline"]))
-    except Exception as e:
-        log.exception(f"Failed to list nodes: {e}")
+    except Exception:
+        log.exception("Failed to list nodes")
         raise typer.Exit(1) from None
 
 
@@ -434,8 +434,8 @@ def plugins_list(ctx: typer.Context) -> None:
             _, plugin_name = key
             plugin = plugins[plugin_name]
             print_plugin(plugin)
-    except Exception as e:
-        log.exception(f"Failed to list plugins: {e}")
+    except Exception:
+        log.exception("Failed to list plugins")
         raise typer.Exit(1) from None
 
 
@@ -450,8 +450,8 @@ def plugins_pinned(ctx: typer.Context) -> None:
             plugin = plugins[plugin_name]
             if plugin["pinned"]:
                 print_plugin(plugin)
-    except Exception as e:
-        log.exception(f"Failed to list pinned plugins: {e}")
+    except Exception:
+        log.exception("Failed to list pinned plugins")
         raise typer.Exit(1) from None
 
 
@@ -466,8 +466,8 @@ def plugins_dynamic(ctx: typer.Context) -> None:
             plugin = plugins[plugin_name]
             if plugin["supportsDynamicLoad"] == "YES":
                 print_plugin(plugin)
-    except Exception as e:
-        log.exception(f"Failed to list dynamic plugins: {e}")
+    except Exception:
+        log.exception("Failed to list dynamic plugins")
         raise typer.Exit(1) from None
 
 
@@ -482,8 +482,8 @@ def plugins_needs_update(ctx: typer.Context) -> None:
             plugin = plugins[plugin_name]
             if plugin["hasUpdate"]:
                 print_plugin(plugin)
-    except Exception as e:
-        log.exception(f"Failed to list plugins needing updates: {e}")
+    except Exception:
+        log.exception("Failed to list plugins needing updates")
         raise typer.Exit(1) from None
 
 
@@ -498,8 +498,8 @@ def plugins_enabled(ctx: typer.Context) -> None:
             plugin = plugins[plugin_name]
             if plugin["enabled"]:
                 print_plugin(plugin)
-    except Exception as e:
-        log.exception(f"Failed to list enabled plugins: {e}")
+    except Exception:
+        log.exception("Failed to list enabled plugins")
         raise typer.Exit(1) from None
 
 
@@ -518,8 +518,8 @@ def plugins_disabled(ctx: typer.Context) -> None:
             plugin = plugins[plugin_name]
             if not plugin["enabled"]:
                 print_plugin(plugin)
-    except Exception as e:
-        log.exception(f"Failed to list disabled plugins: {e}")
+    except Exception:
+        log.exception("Failed to list disabled plugins")
         raise typer.Exit(1) from None
 
 
@@ -534,8 +534,8 @@ def plugins_active(ctx: typer.Context) -> None:
             plugin = plugins[plugin_name]
             if plugin["active"]:
                 print_plugin(plugin)
-    except Exception as e:
-        log.exception(f"Failed to list active plugins: {e}")
+    except Exception:
+        log.exception("Failed to list active plugins")
         raise typer.Exit(1) from None
 
 
@@ -593,8 +593,8 @@ def plugins_sec(ctx: typer.Context) -> None:
                         lastversion = version.get("lastVersion")
                     if name == key and secdict[key] == lastversion:
                         log.info("%s:%s\t%s:%s\t%s", key, secdict[key], key, activedict[key], url)
-    except Exception as e:
-        log.exception(f"Failed to check plugin security: {e}")
+    except Exception:
+        log.exception("Failed to check plugin security")
         raise typer.Exit(1) from None
 
 
@@ -621,8 +621,8 @@ def token_change(
             raise typer.Exit(1)
 
         log.info(get_token(name, jenkins.url, username=username, password=password, change=True))
-    except Exception as e:
-        log.exception(f"Failed to change token: {e}")
+    except Exception:
+        log.exception("Failed to change token")
         raise typer.Exit(1) from None
 
 
@@ -664,8 +664,8 @@ def token_init(
 
         with open(jenkins.config_file, "w") as configfile:
             config.write(configfile)
-    except Exception as e:
-        log.exception(f"Failed to initialize token: {e}")
+    except Exception:
+        log.exception("Failed to initialize token")
         raise typer.Exit(1) from None
 
 
@@ -682,8 +682,8 @@ def token_print(ctx: typer.Context) -> None:
             raise typer.Exit(1)
 
         log.info(get_token("token", jenkins.url, username, password))
-    except Exception as e:
-        log.exception(f"Failed to print token: {e}")
+    except Exception:
+        log.exception("Failed to print token")
         raise typer.Exit(1) from None
 
 
@@ -755,6 +755,6 @@ def token_reset(
         log.info("Update configurations complete.")
         log.info(f"Success: {success}")
         log.info(f"Failed: {fail}")
-    except Exception as e:
-        log.exception(f"Failed to reset tokens: {e}")
+    except Exception:
+        log.exception("Failed to reset tokens")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/jenkins.py
+++ b/lftools_uv/typer_apps/jenkins.py
@@ -24,6 +24,8 @@ from lftools_uv.jenkins.token import get_token
 
 log = logging.getLogger(__name__)
 
+_MSG_CREDS_NOT_SET = "Username or password not set."
+
 # Create the main Typer app for jenkins commands
 jenkins_app = typer.Typer(help="Query information about the Jenkins Server.")
 
@@ -343,6 +345,7 @@ import jenkins.model.*
 import hudson.*
 import hudson.model.*
 
+
 def jobTypes = [hudson.model.FreeStyleProject.class]
 
 def filter = {{job->
@@ -614,7 +617,7 @@ def token_change(
         password = ctx.obj["password"]
 
         if not username or not password:
-            log.error("Username or password not set.")
+            log.error(_MSG_CREDS_NOT_SET)
             raise typer.Exit(1)
 
         log.info(get_token(name, jenkins.url, username=username, password=password, change=True))
@@ -636,7 +639,7 @@ def token_init(
         password = ctx.obj["password"]
 
         if not username or not password:
-            log.error("Username or password not set.")
+            log.error(_MSG_CREDS_NOT_SET)
             raise typer.Exit(1)
 
         _require_jjb_ini(jenkins.config_file)
@@ -675,7 +678,7 @@ def token_print(ctx: typer.Context) -> None:
         password = ctx.obj["password"]
 
         if not username or not password:
-            log.error("Username or password not set.")
+            log.error(_MSG_CREDS_NOT_SET)
             raise typer.Exit(1)
 
         log.info(get_token("token", jenkins.url, username, password))
@@ -706,7 +709,7 @@ def token_reset(
         password = ctx.obj["password"]
 
         if not username or not password:
-            log.error("Username or password not set.")
+            log.error(_MSG_CREDS_NOT_SET)
             raise typer.Exit(1)
 
         _require_jjb_ini(jenkins.config_file)

--- a/lftools_uv/typer_apps/jenkins.py
+++ b/lftools_uv/typer_apps/jenkins.py
@@ -78,7 +78,7 @@ def jenkins_callback(
         if state:
             state.jenkins = jenkins_client
     except Exception as e:
-        log.error(f"Failed to initialize Jenkins client: {e}")
+        log.exception(f"Failed to initialize Jenkins client: {e}")
         # For help requests, don't fail - just continue without initializing client
         if ctx.obj is None:
             ctx.obj = {}
@@ -110,7 +110,7 @@ for (c in creds) {
         result = jenkins.server.run_script(groovy_script)
         log.info(result)
     except Exception as e:
-        log.error(f"Failed to get credentials: {e}")
+        log.exception(f"Failed to get credentials: {e}")
         raise typer.Exit(1) from None
 
 
@@ -139,7 +139,7 @@ for (c in creds) {
         result = jenkins.server.run_script(groovy_script)
         log.info(result)
     except Exception as e:
-        log.error(f"Failed to get secrets: {e}")
+        log.exception(f"Failed to get secrets: {e}")
         raise typer.Exit(1) from None
 
 
@@ -172,7 +172,7 @@ for (c in creds) {
         result = jenkins.server.run_script(groovy_script)
         log.info(result)
     except Exception as e:
-        log.error(f"Failed to get private keys: {e}")
+        log.exception(f"Failed to get private keys: {e}")
         raise typer.Exit(1) from None
 
 
@@ -190,7 +190,7 @@ def groovy(ctx: typer.Context, groovy_file: str = typer.Argument(..., help="Path
         log.error(f"Groovy file not found: {groovy_file}")
         raise typer.Exit(1) from None
     except Exception as e:
-        log.error(f"Failed to run groovy script: {e}")
+        log.exception(f"Failed to run groovy script: {e}")
         raise typer.Exit(1) from None
 
 
@@ -215,15 +215,15 @@ def quiet_down(
         jenkins.server.quiet_down()
     except HTTPError as m:
         if m.code == 405:
-            log.error(
+            log.exception(
                 f"\n[{m}]\nJenkins {version} does not support Quiet Down without a CSRF Token. (CVE-2017-04-26)\nPlease file a bug with 'python-jenkins'"
             )
             raise typer.Exit(1) from None
         else:
-            log.error(f"HTTP error: {m}")
+            log.exception(f"HTTP error: {m}")
             raise typer.Exit(1) from None
     except Exception as e:
-        log.error(f"Failed to quiet down Jenkins: {e}")
+        log.exception(f"Failed to quiet down Jenkins: {e}")
         raise typer.Exit(1) from None
 
 
@@ -296,7 +296,7 @@ for (node in Jenkins.instance.computers) {
             result = jenkins.server.run_script(groovy_script)
         log.info(result)
     except Exception as e:
-        log.error(f"Failed to remove offline nodes: {e}")
+        log.exception(f"Failed to remove offline nodes: {e}")
         raise typer.Exit(1) from None
 
 
@@ -311,7 +311,7 @@ def builds_running(ctx: typer.Context) -> None:
         for build in running_builds:
             log.info("- %s on %s", build["name"], build["node"])
     except Exception as e:
-        log.error(f"Failed to get running builds: {e}")
+        log.exception(f"Failed to get running builds: {e}")
         raise typer.Exit(1) from None
 
 
@@ -332,7 +332,7 @@ def builds_queued(ctx: typer.Context) -> None:
                 status_flags.append("[Blocked]")
             log.info(" - %s%s", build["task"]["name"], (" " + " ".join(status_flags)) if status_flags else "")
     except Exception as e:
-        log.error(f"Failed to get queued builds: {e}")
+        log.exception(f"Failed to get queued builds: {e}")
         raise typer.Exit(1) from None
 
 
@@ -367,7 +367,7 @@ def jobs_enable(ctx: typer.Context, regex: str = typer.Argument(..., help="Regex
         result = jenkins.server.run_script(enable_disable_jobs.format(regex, "enable"))
         log.info(result)
     except Exception as e:
-        log.error(f"Failed to enable jobs: {e}")
+        log.exception(f"Failed to enable jobs: {e}")
         raise typer.Exit(1) from None
 
 
@@ -379,7 +379,7 @@ def jobs_disable(ctx: typer.Context, regex: str = typer.Argument(..., help="Rege
         result = jenkins.server.run_script(enable_disable_jobs.format(regex, "disable"))
         log.info(result)
     except Exception as e:
-        log.error(f"Failed to disable jobs: {e}")
+        log.exception(f"Failed to disable jobs: {e}")
         raise typer.Exit(1) from None
 
 
@@ -401,7 +401,7 @@ def nodes_list(ctx: typer.Context) -> None:
         for node in node_list:
             log.info("%s [%s]", node["name"], offline_str(node["offline"]))
     except Exception as e:
-        log.error(f"Failed to list nodes: {e}")
+        log.exception(f"Failed to list nodes: {e}")
         raise typer.Exit(1) from None
 
 
@@ -432,7 +432,7 @@ def plugins_list(ctx: typer.Context) -> None:
             plugin = plugins[plugin_name]
             print_plugin(plugin)
     except Exception as e:
-        log.error(f"Failed to list plugins: {e}")
+        log.exception(f"Failed to list plugins: {e}")
         raise typer.Exit(1) from None
 
 
@@ -448,7 +448,7 @@ def plugins_pinned(ctx: typer.Context) -> None:
             if plugin["pinned"]:
                 print_plugin(plugin)
     except Exception as e:
-        log.error(f"Failed to list pinned plugins: {e}")
+        log.exception(f"Failed to list pinned plugins: {e}")
         raise typer.Exit(1) from None
 
 
@@ -464,7 +464,7 @@ def plugins_dynamic(ctx: typer.Context) -> None:
             if plugin["supportsDynamicLoad"] == "YES":
                 print_plugin(plugin)
     except Exception as e:
-        log.error(f"Failed to list dynamic plugins: {e}")
+        log.exception(f"Failed to list dynamic plugins: {e}")
         raise typer.Exit(1) from None
 
 
@@ -480,7 +480,7 @@ def plugins_needs_update(ctx: typer.Context) -> None:
             if plugin["hasUpdate"]:
                 print_plugin(plugin)
     except Exception as e:
-        log.error(f"Failed to list plugins needing updates: {e}")
+        log.exception(f"Failed to list plugins needing updates: {e}")
         raise typer.Exit(1) from None
 
 
@@ -496,7 +496,7 @@ def plugins_enabled(ctx: typer.Context) -> None:
             if plugin["enabled"]:
                 print_plugin(plugin)
     except Exception as e:
-        log.error(f"Failed to list enabled plugins: {e}")
+        log.exception(f"Failed to list enabled plugins: {e}")
         raise typer.Exit(1) from None
 
 
@@ -516,7 +516,7 @@ def plugins_disabled(ctx: typer.Context) -> None:
             if not plugin["enabled"]:
                 print_plugin(plugin)
     except Exception as e:
-        log.error(f"Failed to list disabled plugins: {e}")
+        log.exception(f"Failed to list disabled plugins: {e}")
         raise typer.Exit(1) from None
 
 
@@ -532,7 +532,7 @@ def plugins_active(ctx: typer.Context) -> None:
             if plugin["active"]:
                 print_plugin(plugin)
     except Exception as e:
-        log.error(f"Failed to list active plugins: {e}")
+        log.exception(f"Failed to list active plugins: {e}")
         raise typer.Exit(1) from None
 
 
@@ -591,7 +591,7 @@ def plugins_sec(ctx: typer.Context) -> None:
                     if name == key and secdict[key] == lastversion:
                         log.info("%s:%s\t%s:%s\t%s", key, secdict[key], key, activedict[key], url)
     except Exception as e:
-        log.error(f"Failed to check plugin security: {e}")
+        log.exception(f"Failed to check plugin security: {e}")
         raise typer.Exit(1) from None
 
 
@@ -619,7 +619,7 @@ def token_change(
 
         log.info(get_token(name, jenkins.url, username=username, password=password, change=True))
     except Exception as e:
-        log.error(f"Failed to change token: {e}")
+        log.exception(f"Failed to change token: {e}")
         raise typer.Exit(1) from None
 
 
@@ -648,7 +648,7 @@ def token_init(
         try:
             config.add_section(name)
         except configparser.DuplicateSectionError as e:
-            log.error(e)
+            log.exception(e)
             raise typer.Exit(1) from None
 
         config.set(name, "url", url)
@@ -662,7 +662,7 @@ def token_init(
         with open(jenkins.config_file, "w") as configfile:
             config.write(configfile)
     except Exception as e:
-        log.error(f"Failed to initialize token: {e}")
+        log.exception(f"Failed to initialize token: {e}")
         raise typer.Exit(1) from None
 
 
@@ -680,7 +680,7 @@ def token_print(ctx: typer.Context) -> None:
 
         log.info(get_token("token", jenkins.url, username, password))
     except Exception as e:
-        log.error(f"Failed to print token: {e}")
+        log.exception(f"Failed to print token: {e}")
         raise typer.Exit(1) from None
 
 
@@ -753,5 +753,5 @@ def token_reset(
         log.info(f"Success: {success}")
         log.info(f"Failed: {fail}")
     except Exception as e:
-        log.error(f"Failed to reset tokens: {e}")
+        log.exception(f"Failed to reset tokens: {e}")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/lfidapi.py
+++ b/lftools_uv/typer_apps/lfidapi.py
@@ -58,7 +58,7 @@ def search_members(
         for member in members:
             typer.echo(f"{member['username']} <{member['mail']}>")
     except Exception as e:
-        log.exception(f"Failed to search members for group {group}: {e}")
+        log.exception("Failed to search members for group %s", group)
         typer.echo(f"Error: Failed to search members for group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -85,7 +85,7 @@ def user_command(
         action = "removed from" if delete else "added to"
         typer.echo(f"✅ User {user} {action} group {group}")
     except Exception as e:
-        log.exception(f"Failed to manage user {user} in group {group}: {e}")
+        log.exception("Failed to manage user %s in group %s", user, group)
         typer.echo(f"Error: Failed to manage user {user} in group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -108,7 +108,7 @@ def invite_command(
         helper_invite(email, group)
         typer.echo(f"✅ Invitation sent to {email} for group {group}")
     except Exception as e:
-        log.exception(f"Failed to send invitation to {email} for group {group}: {e}")
+        log.exception("Failed to send invitation for group %s", group)
         typer.echo(f"Error: Failed to send invitation to {email} for group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -129,7 +129,7 @@ def create_group_command(
         helper_create_group(group)
         typer.echo(f"✅ Group {group} created successfully")
     except Exception as e:
-        log.exception(f"Failed to create group {group}: {e}")
+        log.exception("Failed to create group %s", group)
         typer.echo(f"Error: Failed to create group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -146,7 +146,7 @@ def match_ldap_info(
         helper_match_ldap_to_info(info_file, group, githuborg, noop)
         typer.echo("✅ LDAP to INFO matching completed")
     except Exception as e:
-        log.exception(f"Failed to match LDAP to INFO: {e}")
+        log.exception("Failed to match LDAP to INFO")
         typer.echo(f"Error: Failed to match LDAP to INFO: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/lfidapi.py
+++ b/lftools_uv/typer_apps/lfidapi.py
@@ -58,7 +58,7 @@ def search_members(
         for member in members:
             typer.echo(f"{member['username']} <{member['mail']}>")
     except Exception as e:
-        log.error(f"Failed to search members for group {group}: {e}")
+        log.exception(f"Failed to search members for group {group}: {e}")
         typer.echo(f"Error: Failed to search members for group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -85,7 +85,7 @@ def user_command(
         action = "removed from" if delete else "added to"
         typer.echo(f"✅ User {user} {action} group {group}")
     except Exception as e:
-        log.error(f"Failed to manage user {user} in group {group}: {e}")
+        log.exception(f"Failed to manage user {user} in group {group}: {e}")
         typer.echo(f"Error: Failed to manage user {user} in group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -108,7 +108,7 @@ def invite_command(
         helper_invite(email, group)
         typer.echo(f"✅ Invitation sent to {email} for group {group}")
     except Exception as e:
-        log.error(f"Failed to send invitation to {email} for group {group}: {e}")
+        log.exception(f"Failed to send invitation to {email} for group {group}: {e}")
         typer.echo(f"Error: Failed to send invitation to {email} for group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -129,7 +129,7 @@ def create_group_command(
         helper_create_group(group)
         typer.echo(f"✅ Group {group} created successfully")
     except Exception as e:
-        log.error(f"Failed to create group {group}: {e}")
+        log.exception(f"Failed to create group {group}: {e}")
         typer.echo(f"Error: Failed to create group {group}: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -146,7 +146,7 @@ def match_ldap_info(
         helper_match_ldap_to_info(info_file, group, githuborg, noop)
         typer.echo("✅ LDAP to INFO matching completed")
     except Exception as e:
-        log.error(f"Failed to match LDAP to INFO: {e}")
+        log.exception(f"Failed to match LDAP to INFO: {e}")
         typer.echo(f"Error: Failed to match LDAP to INFO: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/license.py
+++ b/lftools_uv/typer_apps/license.py
@@ -78,7 +78,7 @@ def check_command(
             typer.echo(f"Error: {source} is not a valid file or directory", err=True)
             raise typer.Exit(1) from None
     except Exception as e:
-        log.exception(f"License check failed: {e}")
+        log.exception("License check failed")
         typer.echo(f"Error: License check failed: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/license.py
+++ b/lftools_uv/typer_apps/license.py
@@ -78,7 +78,7 @@ def check_command(
             typer.echo(f"Error: {source} is not a valid file or directory", err=True)
             raise typer.Exit(1) from None
     except Exception as e:
-        log.error(f"License check failed: {e}")
+        log.exception(f"License check failed: {e}")
         typer.echo(f"Error: License check failed: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/nexus2.py
+++ b/lftools_uv/typer_apps/nexus2.py
@@ -69,8 +69,8 @@ def privilege_list(ctx: typer.Context) -> None:
         r = ctx.obj["nexus2"]
         data = r.privilege_list()
         log.info(tabulate(data, headers=["Name", "ID"]))
-    except Exception as e:
-        log.exception(f"Failed to list privileges: {e}")
+    except Exception:
+        log.exception("Failed to list privileges")
         raise typer.Exit(1) from None
 
 
@@ -86,8 +86,8 @@ def privilege_create(
         r = ctx.obj["nexus2"]
         data = r.privilege_create(name, description, repo)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to create privilege: {e}")
+    except Exception:
+        log.exception("Failed to create privilege")
         raise typer.Exit(1) from None
 
 
@@ -101,8 +101,8 @@ def privilege_delete(
         r = ctx.obj["nexus2"]
         data = r.privilege_delete(privilege_id)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to delete privilege: {e}")
+    except Exception:
+        log.exception("Failed to delete privilege")
         raise typer.Exit(1) from None
 
 
@@ -114,8 +114,8 @@ def repo_list(ctx: typer.Context) -> None:
         r = ctx.obj["nexus2"]
         data = r.repo_list()
         log.info(tabulate(data, headers=["Name", "Type", "Provider", "ID"]))
-    except Exception as e:
-        log.exception(f"Failed to list repositories: {e}")
+    except Exception:
+        log.exception("Failed to list repositories")
         raise typer.Exit(1) from None
 
 
@@ -134,8 +134,8 @@ def repo_create(
         r = ctx.obj["nexus2"]
         data = r.repo_create(repo_type, repo_id, repo_name, repo_provider, repo_policy, repo_upstream_url)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to create repository: {e}")
+    except Exception:
+        log.exception("Failed to create repository")
         raise typer.Exit(1) from None
 
 
@@ -149,8 +149,8 @@ def repo_delete(
         r = ctx.obj["nexus2"]
         data = r.repo_delete(repo_id)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to delete repository: {e}")
+    except Exception:
+        log.exception("Failed to delete repository")
         raise typer.Exit(1) from None
 
 
@@ -162,8 +162,8 @@ def role_list(ctx: typer.Context) -> None:
         r = ctx.obj["nexus2"]
         data = r.role_list()
         log.info(tabulate(data, headers=["ID", "Name", "Roles", "Privileges"], tablefmt="grid"))
-    except Exception as e:
-        log.exception(f"Failed to list roles: {e}")
+    except Exception:
+        log.exception("Failed to list roles")
         raise typer.Exit(1) from None
 
 
@@ -181,8 +181,8 @@ def role_create(
         r = ctx.obj["nexus2"]
         data = r.role_create(role_id, role_name, role_description, roles_list, privileges_list)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to create role: {e}")
+    except Exception:
+        log.exception("Failed to create role")
         raise typer.Exit(1) from None
 
 
@@ -196,8 +196,8 @@ def role_delete(
         r = ctx.obj["nexus2"]
         data = r.role_delete(role_id)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to delete role: {e}")
+    except Exception:
+        log.exception("Failed to delete role")
         raise typer.Exit(1) from None
 
 
@@ -209,8 +209,8 @@ def user_list(ctx: typer.Context) -> None:
         r = ctx.obj["nexus2"]
         data = r.user_list()
         log.info(tabulate(data, headers=["ID", "First Name", "Last Name", "Status", "Roles"]))
-    except Exception as e:
-        log.exception(f"Failed to list users: {e}")
+    except Exception:
+        log.exception("Failed to list users")
         raise typer.Exit(1) from None
 
 
@@ -229,8 +229,8 @@ def user_create(
         r = ctx.obj["nexus2"]
         data = r.user_create(username, firstname, lastname, email, roles, password)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to create user: {e}")
+    except Exception:
+        log.exception("Failed to create user")
         raise typer.Exit(1) from None
 
 
@@ -244,6 +244,6 @@ def user_delete(
         r = ctx.obj["nexus2"]
         data = r.user_delete(username)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to delete user: {e}")
+    except Exception:
+        log.exception("Failed to delete user")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/nexus2.py
+++ b/lftools_uv/typer_apps/nexus2.py
@@ -70,7 +70,7 @@ def privilege_list(ctx: typer.Context) -> None:
         data = r.privilege_list()
         log.info(tabulate(data, headers=["Name", "ID"]))
     except Exception as e:
-        log.error(f"Failed to list privileges: {e}")
+        log.exception(f"Failed to list privileges: {e}")
         raise typer.Exit(1) from None
 
 
@@ -87,7 +87,7 @@ def privilege_create(
         data = r.privilege_create(name, description, repo)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to create privilege: {e}")
+        log.exception(f"Failed to create privilege: {e}")
         raise typer.Exit(1) from None
 
 
@@ -102,7 +102,7 @@ def privilege_delete(
         data = r.privilege_delete(privilege_id)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to delete privilege: {e}")
+        log.exception(f"Failed to delete privilege: {e}")
         raise typer.Exit(1) from None
 
 
@@ -115,7 +115,7 @@ def repo_list(ctx: typer.Context) -> None:
         data = r.repo_list()
         log.info(tabulate(data, headers=["Name", "Type", "Provider", "ID"]))
     except Exception as e:
-        log.error(f"Failed to list repositories: {e}")
+        log.exception(f"Failed to list repositories: {e}")
         raise typer.Exit(1) from None
 
 
@@ -135,7 +135,7 @@ def repo_create(
         data = r.repo_create(repo_type, repo_id, repo_name, repo_provider, repo_policy, repo_upstream_url)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to create repository: {e}")
+        log.exception(f"Failed to create repository: {e}")
         raise typer.Exit(1) from None
 
 
@@ -150,7 +150,7 @@ def repo_delete(
         data = r.repo_delete(repo_id)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to delete repository: {e}")
+        log.exception(f"Failed to delete repository: {e}")
         raise typer.Exit(1) from None
 
 
@@ -163,7 +163,7 @@ def role_list(ctx: typer.Context) -> None:
         data = r.role_list()
         log.info(tabulate(data, headers=["ID", "Name", "Roles", "Privileges"], tablefmt="grid"))
     except Exception as e:
-        log.error(f"Failed to list roles: {e}")
+        log.exception(f"Failed to list roles: {e}")
         raise typer.Exit(1) from None
 
 
@@ -182,7 +182,7 @@ def role_create(
         data = r.role_create(role_id, role_name, role_description, roles_list, privileges_list)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to create role: {e}")
+        log.exception(f"Failed to create role: {e}")
         raise typer.Exit(1) from None
 
 
@@ -197,7 +197,7 @@ def role_delete(
         data = r.role_delete(role_id)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to delete role: {e}")
+        log.exception(f"Failed to delete role: {e}")
         raise typer.Exit(1) from None
 
 
@@ -210,7 +210,7 @@ def user_list(ctx: typer.Context) -> None:
         data = r.user_list()
         log.info(tabulate(data, headers=["ID", "First Name", "Last Name", "Status", "Roles"]))
     except Exception as e:
-        log.error(f"Failed to list users: {e}")
+        log.exception(f"Failed to list users: {e}")
         raise typer.Exit(1) from None
 
 
@@ -230,7 +230,7 @@ def user_create(
         data = r.user_create(username, firstname, lastname, email, roles, password)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to create user: {e}")
+        log.exception(f"Failed to create user: {e}")
         raise typer.Exit(1) from None
 
 
@@ -245,5 +245,5 @@ def user_delete(
         data = r.user_delete(username)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to delete user: {e}")
+        log.exception(f"Failed to delete user: {e}")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/nexus3.py
+++ b/lftools_uv/typer_apps/nexus3.py
@@ -81,7 +81,7 @@ def asset_list(ctx: typer.Context, repository: str = typer.Argument(..., help="R
         for item in data:
             log.info(pformat(item))
     except Exception as e:
-        log.error(f"Failed to list assets: {e}")
+        log.exception(f"Failed to list assets: {e}")
         raise typer.Exit(1) from None
 
 
@@ -103,7 +103,7 @@ def asset_search(
             for item in data:
                 log.info(item)
     except Exception as e:
-        log.error(f"Failed to search assets: {e}")
+        log.exception(f"Failed to search assets: {e}")
         raise typer.Exit(1) from None
 
 
@@ -116,7 +116,7 @@ def list_privileges(ctx: typer.Context) -> None:
         data = r.list_privileges()
         log.info(tabulate(data, headers=["Type", "Name", "Description", "Read Only"]))
     except Exception as e:
-        log.error(f"Failed to list privileges: {e}")
+        log.exception(f"Failed to list privileges: {e}")
         raise typer.Exit(1) from None
 
 
@@ -129,7 +129,7 @@ def list_repositories(ctx: typer.Context) -> None:
         data = r.list_repositories()
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to list repositories: {e}")
+        log.exception(f"Failed to list repositories: {e}")
         raise typer.Exit(1) from None
 
 
@@ -142,7 +142,7 @@ def list_roles(ctx: typer.Context) -> None:
         data = r.list_roles()
         log.info(tabulate(data, headers=["Roles"]))
     except Exception as e:
-        log.error(f"Failed to list roles: {e}")
+        log.exception(f"Failed to list roles: {e}")
         raise typer.Exit(1) from None
 
 
@@ -160,7 +160,7 @@ def create_role(
         data = r.create_role(name, description, privileges, roles)
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to create role: {e}")
+        log.exception(f"Failed to create role: {e}")
         raise typer.Exit(1) from None
 
 
@@ -177,7 +177,7 @@ def create_script(
         data = r.create_script(name, filename)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to create script: {e}")
+        log.exception(f"Failed to create script: {e}")
         raise typer.Exit(1) from None
 
 
@@ -192,7 +192,7 @@ def delete_script(
         data = r.delete_script(name)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to delete script: {e}")
+        log.exception(f"Failed to delete script: {e}")
         raise typer.Exit(1) from None
 
 
@@ -204,7 +204,7 @@ def list_scripts(ctx: typer.Context) -> None:
         data = r.list_scripts()
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to list scripts: {e}")
+        log.exception(f"Failed to list scripts: {e}")
         raise typer.Exit(1) from None
 
 
@@ -219,7 +219,7 @@ def read_script(
         data = r.read_script(name)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to read script: {e}")
+        log.exception(f"Failed to read script: {e}")
         raise typer.Exit(1) from None
 
 
@@ -234,7 +234,7 @@ def run_script(
         data = r.run_script(name)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to run script: {e}")
+        log.exception(f"Failed to run script: {e}")
         raise typer.Exit(1) from None
 
 
@@ -250,7 +250,7 @@ def update_script(
         data = r.update_script(name, content)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to update script: {e}")
+        log.exception(f"Failed to update script: {e}")
         raise typer.Exit(1) from None
 
 
@@ -267,7 +267,7 @@ def add_tag(
         data = r.create_tag(name, attributes)
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to add tag: {e}")
+        log.exception(f"Failed to add tag: {e}")
         raise typer.Exit(1) from None
 
 
@@ -282,7 +282,7 @@ def delete_tag(
         data = r.delete_tag(name)
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to delete tag: {e}")
+        log.exception(f"Failed to delete tag: {e}")
         raise typer.Exit(1) from None
 
 
@@ -294,7 +294,7 @@ def list_tags(ctx: typer.Context) -> None:
         data = r.list_tags()
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to list tags: {e}")
+        log.exception(f"Failed to list tags: {e}")
         raise typer.Exit(1) from None
 
 
@@ -309,7 +309,7 @@ def show_tag(
         data = r.show_tag(name)
         log.info(pformat(data))
     except Exception as e:
-        log.error(f"Failed to show tag: {e}")
+        log.exception(f"Failed to show tag: {e}")
         raise typer.Exit(1) from None
 
 
@@ -327,7 +327,7 @@ def list_tasks(ctx: typer.Context) -> None:
             )
         )
     except Exception as e:
-        log.error(f"Failed to list tasks: {e}")
+        log.exception(f"Failed to list tasks: {e}")
         raise typer.Exit(1) from None
 
 
@@ -355,7 +355,7 @@ def search_user(
             )
         )
     except Exception as e:
-        log.error(f"Failed to search user: {e}")
+        log.exception(f"Failed to search user: {e}")
         raise typer.Exit(1) from None
 
 
@@ -375,7 +375,7 @@ def user_create(
         data = r.create_user(username, first_name, last_name, email_address, roles, password)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to create user: {e}")
+        log.exception(f"Failed to create user: {e}")
         raise typer.Exit(1) from None
 
 
@@ -390,5 +390,5 @@ def user_delete(
         data = r.delete_user(username)
         log.info(data)
     except Exception as e:
-        log.error(f"Failed to delete user: {e}")
+        log.exception(f"Failed to delete user: {e}")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/nexus3.py
+++ b/lftools_uv/typer_apps/nexus3.py
@@ -80,8 +80,8 @@ def asset_list(ctx: typer.Context, repository: str = typer.Argument(..., help="R
         data = r.list_assets(repository)
         for item in data:
             log.info(pformat(item))
-    except Exception as e:
-        log.exception(f"Failed to list assets: {e}")
+    except Exception:
+        log.exception("Failed to list assets")
         raise typer.Exit(1) from None
 
 
@@ -102,8 +102,8 @@ def asset_search(
         else:
             for item in data:
                 log.info(item)
-    except Exception as e:
-        log.exception(f"Failed to search assets: {e}")
+    except Exception:
+        log.exception("Failed to search assets")
         raise typer.Exit(1) from None
 
 
@@ -115,8 +115,8 @@ def list_privileges(ctx: typer.Context) -> None:
         r = ctx.obj["nexus3"]
         data = r.list_privileges()
         log.info(tabulate(data, headers=["Type", "Name", "Description", "Read Only"]))
-    except Exception as e:
-        log.exception(f"Failed to list privileges: {e}")
+    except Exception:
+        log.exception("Failed to list privileges")
         raise typer.Exit(1) from None
 
 
@@ -128,8 +128,8 @@ def list_repositories(ctx: typer.Context) -> None:
         r = ctx.obj["nexus3"]
         data = r.list_repositories()
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to list repositories: {e}")
+    except Exception:
+        log.exception("Failed to list repositories")
         raise typer.Exit(1) from None
 
 
@@ -141,8 +141,8 @@ def list_roles(ctx: typer.Context) -> None:
         r = ctx.obj["nexus3"]
         data = r.list_roles()
         log.info(tabulate(data, headers=["Roles"]))
-    except Exception as e:
-        log.exception(f"Failed to list roles: {e}")
+    except Exception:
+        log.exception("Failed to list roles")
         raise typer.Exit(1) from None
 
 
@@ -159,8 +159,8 @@ def create_role(
         r = ctx.obj["nexus3"]
         data = r.create_role(name, description, privileges, roles)
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to create role: {e}")
+    except Exception:
+        log.exception("Failed to create role")
         raise typer.Exit(1) from None
 
 
@@ -176,8 +176,8 @@ def create_script(
         r = ctx.obj["nexus3"]
         data = r.create_script(name, filename)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to create script: {e}")
+    except Exception:
+        log.exception("Failed to create script")
         raise typer.Exit(1) from None
 
 
@@ -191,8 +191,8 @@ def delete_script(
         r = ctx.obj["nexus3"]
         data = r.delete_script(name)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to delete script: {e}")
+    except Exception:
+        log.exception("Failed to delete script")
         raise typer.Exit(1) from None
 
 
@@ -203,8 +203,8 @@ def list_scripts(ctx: typer.Context) -> None:
         r = ctx.obj["nexus3"]
         data = r.list_scripts()
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to list scripts: {e}")
+    except Exception:
+        log.exception("Failed to list scripts")
         raise typer.Exit(1) from None
 
 
@@ -218,8 +218,8 @@ def read_script(
         r = ctx.obj["nexus3"]
         data = r.read_script(name)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to read script: {e}")
+    except Exception:
+        log.exception("Failed to read script")
         raise typer.Exit(1) from None
 
 
@@ -233,8 +233,8 @@ def run_script(
         r = ctx.obj["nexus3"]
         data = r.run_script(name)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to run script: {e}")
+    except Exception:
+        log.exception("Failed to run script")
         raise typer.Exit(1) from None
 
 
@@ -249,8 +249,8 @@ def update_script(
         r = ctx.obj["nexus3"]
         data = r.update_script(name, content)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to update script: {e}")
+    except Exception:
+        log.exception("Failed to update script")
         raise typer.Exit(1) from None
 
 
@@ -266,8 +266,8 @@ def add_tag(
         r = ctx.obj["nexus3"]
         data = r.create_tag(name, attributes)
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to add tag: {e}")
+    except Exception:
+        log.exception("Failed to add tag")
         raise typer.Exit(1) from None
 
 
@@ -281,8 +281,8 @@ def delete_tag(
         r = ctx.obj["nexus3"]
         data = r.delete_tag(name)
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to delete tag: {e}")
+    except Exception:
+        log.exception("Failed to delete tag")
         raise typer.Exit(1) from None
 
 
@@ -293,8 +293,8 @@ def list_tags(ctx: typer.Context) -> None:
         r = ctx.obj["nexus3"]
         data = r.list_tags()
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to list tags: {e}")
+    except Exception:
+        log.exception("Failed to list tags")
         raise typer.Exit(1) from None
 
 
@@ -308,8 +308,8 @@ def show_tag(
         r = ctx.obj["nexus3"]
         data = r.show_tag(name)
         log.info(pformat(data))
-    except Exception as e:
-        log.exception(f"Failed to show tag: {e}")
+    except Exception:
+        log.exception("Failed to show tag")
         raise typer.Exit(1) from None
 
 
@@ -326,8 +326,8 @@ def list_tasks(ctx: typer.Context) -> None:
                 headers=["Name", "Message", "Current State", "Last Run Result"],
             )
         )
-    except Exception as e:
-        log.exception(f"Failed to list tasks: {e}")
+    except Exception:
+        log.exception("Failed to list tasks")
         raise typer.Exit(1) from None
 
 
@@ -354,8 +354,8 @@ def search_user(
                 ],
             )
         )
-    except Exception as e:
-        log.exception(f"Failed to search user: {e}")
+    except Exception:
+        log.exception("Failed to search user")
         raise typer.Exit(1) from None
 
 
@@ -374,8 +374,8 @@ def user_create(
         r = ctx.obj["nexus3"]
         data = r.create_user(username, first_name, last_name, email_address, roles, password)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to create user: {e}")
+    except Exception:
+        log.exception("Failed to create user")
         raise typer.Exit(1) from None
 
 
@@ -389,6 +389,6 @@ def user_delete(
         r = ctx.obj["nexus3"]
         data = r.delete_user(username)
         log.info(data)
-    except Exception as e:
-        log.exception(f"Failed to delete user: {e}")
+    except Exception:
+        log.exception("Failed to delete user")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/rtd.py
+++ b/lftools_uv/typer_apps/rtd.py
@@ -52,7 +52,7 @@ def project_list() -> None:
         else:
             typer.echo("No projects found")
     except Exception as e:
-        log.error(f"Failed to get project list: {e}")
+        log.exception(f"Failed to get project list: {e}")
         typer.echo(f"Error: Failed to get project list: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -83,7 +83,7 @@ def project_details(
             typer.echo(f"Project '{project_slug}' not found")
             raise typer.Exit(1)
     except Exception as e:
-        log.error(f"Failed to get project details: {e}")
+        log.exception(f"Failed to get project details: {e}")
         typer.echo(f"Error: Failed to get project details: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -124,7 +124,7 @@ def project_create(
             typer.echo(f"Failed to create project '{name}'")
             raise typer.Exit(1)
     except Exception as e:
-        log.error(f"Failed to create project: {e}")
+        log.exception(f"Failed to create project: {e}")
         typer.echo(f"Error: Failed to create project: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -169,7 +169,7 @@ def project_update(
             typer.echo(f"Failed to update project '{project_slug}' (HTTP {status_code})")
             raise typer.Exit(1)
     except Exception as e:
-        log.error(f"Failed to update project: {e}")
+        log.exception(f"Failed to update project: {e}")
         typer.echo(f"Error: Failed to update project: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/rtd.py
+++ b/lftools_uv/typer_apps/rtd.py
@@ -52,7 +52,7 @@ def project_list() -> None:
         else:
             typer.echo("No projects found")
     except Exception as e:
-        log.exception(f"Failed to get project list: {e}")
+        log.exception("Failed to get project list")
         typer.echo(f"Error: Failed to get project list: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -83,7 +83,7 @@ def project_details(
             typer.echo(f"Project '{project_slug}' not found")
             raise typer.Exit(1)
     except Exception as e:
-        log.exception(f"Failed to get project details: {e}")
+        log.exception("Failed to get project details")
         typer.echo(f"Error: Failed to get project details: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -124,7 +124,7 @@ def project_create(
             typer.echo(f"Failed to create project '{name}'")
             raise typer.Exit(1)
     except Exception as e:
-        log.exception(f"Failed to create project: {e}")
+        log.exception("Failed to create project")
         typer.echo(f"Error: Failed to create project: {e}", err=True)
         raise typer.Exit(1) from None
 
@@ -169,7 +169,7 @@ def project_update(
             typer.echo(f"Failed to update project '{project_slug}' (HTTP {status_code})")
             raise typer.Exit(1)
     except Exception as e:
-        log.exception(f"Failed to update project: {e}")
+        log.exception("Failed to update project")
         typer.echo(f"Error: Failed to update project: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/schema.py
+++ b/lftools_uv/typer_apps/schema.py
@@ -50,7 +50,7 @@ def verify_schema(
         check_schema_file(str(yamlfile), str(schemafile))
         typer.echo(f"✅ Schema validation passed for {yamlfile}")
     except Exception as e:
-        log.exception(f"Schema validation failed: {e}")
+        log.exception("Schema validation failed")
         typer.echo(f"❌ Schema validation failed: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/schema.py
+++ b/lftools_uv/typer_apps/schema.py
@@ -50,7 +50,7 @@ def verify_schema(
         check_schema_file(str(yamlfile), str(schemafile))
         typer.echo(f"✅ Schema validation passed for {yamlfile}")
     except Exception as e:
-        log.error(f"Schema validation failed: {e}")
+        log.exception(f"Schema validation failed: {e}")
         typer.echo(f"❌ Schema validation failed: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/sign.py
+++ b/lftools_uv/typer_apps/sign.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 import typer
 
+_MSG_SIGN_NOT_FOUND = "'sign' command not found in PATH"
+_MSG_SIGN_NOT_FOUND_LONG = "Error: 'sign' command not found in PATH. Please ensure it's installed."
+
+
 log = logging.getLogger(__name__)
 
 # Create the sign subcommand group
@@ -58,8 +62,8 @@ def directory(
         typer.echo(f"Error: Signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
-        log.error("'sign' command not found in PATH")
-        typer.echo("Error: 'sign' command not found in PATH. Please ensure it's installed.", err=True)
+        log.error(_MSG_SIGN_NOT_FOUND)
+        typer.echo(_MSG_SIGN_NOT_FOUND_LONG, err=True)
         raise typer.Exit(127) from None
 
 
@@ -84,8 +88,8 @@ def git_tag(
         typer.echo(f"Error: Git tag signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
-        log.error("'sign' command not found in PATH")
-        typer.echo("Error: 'sign' command not found in PATH. Please ensure it's installed.", err=True)
+        log.error(_MSG_SIGN_NOT_FOUND)
+        typer.echo(_MSG_SIGN_NOT_FOUND_LONG, err=True)
         raise typer.Exit(127) from None
 
 
@@ -109,8 +113,8 @@ def nexus(
         typer.echo(f"Error: Nexus signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
-        log.error("'sign' command not found in PATH")
-        typer.echo("Error: 'sign' command not found in PATH. Please ensure it's installed.", err=True)
+        log.error(_MSG_SIGN_NOT_FOUND)
+        typer.echo(_MSG_SIGN_NOT_FOUND_LONG, err=True)
         raise typer.Exit(127) from None
 
 

--- a/lftools_uv/typer_apps/sign.py
+++ b/lftools_uv/typer_apps/sign.py
@@ -58,7 +58,7 @@ def directory(
         subprocess.run(["sign", "dir", str(directory), mode], check=True, capture_output=False)
         typer.echo(f"✅ Successfully signed files in {directory} using {mode} mode")
     except subprocess.CalledProcessError as e:
-        log.exception(f"Signing failed with exit code {e.returncode}")
+        log.exception("Signing failed with exit code %s", e.returncode)
         typer.echo(f"Error: Signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -84,7 +84,7 @@ def git_tag(
         subprocess.run(["sign", "git-tag", tag], check=True, capture_output=False)
         typer.echo(f"✅ Successfully signed git tag: {tag}")
     except subprocess.CalledProcessError as e:
-        log.exception(f"Git tag signing failed with exit code {e.returncode}")
+        log.exception("Git tag signing failed with exit code %s", e.returncode)
         typer.echo(f"Error: Git tag signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -109,7 +109,7 @@ def nexus(
         subprocess.run(["sign", "nexus", nexus_repo_url], check=True, capture_output=False)
         typer.echo(f"✅ Successfully signed Nexus artifacts at: {nexus_repo_url}")
     except subprocess.CalledProcessError as e:
-        log.exception(f"Nexus signing failed with exit code {e.returncode}")
+        log.exception("Nexus signing failed with exit code %s", e.returncode)
         typer.echo(f"Error: Nexus signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:

--- a/lftools_uv/typer_apps/sign.py
+++ b/lftools_uv/typer_apps/sign.py
@@ -54,7 +54,7 @@ def directory(
         subprocess.run(["sign", "dir", str(directory), mode], check=True, capture_output=False)
         typer.echo(f"✅ Successfully signed files in {directory} using {mode} mode")
     except subprocess.CalledProcessError as e:
-        log.error(f"Signing failed with exit code {e.returncode}")
+        log.exception(f"Signing failed with exit code {e.returncode}")
         typer.echo(f"Error: Signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -80,7 +80,7 @@ def git_tag(
         subprocess.run(["sign", "git-tag", tag], check=True, capture_output=False)
         typer.echo(f"✅ Successfully signed git tag: {tag}")
     except subprocess.CalledProcessError as e:
-        log.error(f"Git tag signing failed with exit code {e.returncode}")
+        log.exception(f"Git tag signing failed with exit code {e.returncode}")
         typer.echo(f"Error: Git tag signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -105,7 +105,7 @@ def nexus(
         subprocess.run(["sign", "nexus", nexus_repo_url], check=True, capture_output=False)
         typer.echo(f"✅ Successfully signed Nexus artifacts at: {nexus_repo_url}")
     except subprocess.CalledProcessError as e:
-        log.error(f"Nexus signing failed with exit code {e.returncode}")
+        log.exception(f"Nexus signing failed with exit code {e.returncode}")
         typer.echo(f"Error: Nexus signing failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:

--- a/lftools_uv/typer_apps/utils.py
+++ b/lftools_uv/typer_apps/utils.py
@@ -65,7 +65,7 @@ def password_generator(
         password = helpers.generate_password(length)
         typer.echo(password)
     except Exception as e:
-        log.exception("Failed to generate password: %s", e)
+        log.exception("Failed to generate password")
         typer.echo(f"Error: Failed to generate password: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/utils.py
+++ b/lftools_uv/typer_apps/utils.py
@@ -65,7 +65,7 @@ def password_generator(
         password = helpers.generate_password(length)
         typer.echo(password)
     except Exception as e:
-        log.error("Failed to generate password: %s", e)
+        log.exception("Failed to generate password: %s", e)
         typer.echo(f"Error: Failed to generate password: {e}", err=True)
         raise typer.Exit(1) from None
 

--- a/lftools_uv/typer_apps/version.py
+++ b/lftools_uv/typer_apps/version.py
@@ -84,7 +84,7 @@ def bump(
         subprocess.run(["version", "bump", release_tag], check=True, capture_output=False)
         typer.echo(f"Version bump completed successfully for release tag: {release_tag}")
     except subprocess.CalledProcessError as e:
-        log.exception(f"Version bump failed with exit code {e.returncode}")
+        log.exception("Version bump failed with exit code %s", e.returncode)
         typer.echo(f"Error: Version bump failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -114,7 +114,7 @@ def release(
         subprocess.run(["version", "release", release_tag], check=True, capture_output=False)
         typer.echo(f"Version release completed successfully for tag: {release_tag}")
     except subprocess.CalledProcessError as e:
-        log.exception(f"Version release failed with exit code {e.returncode}")
+        log.exception("Version release failed with exit code %s", e.returncode)
         typer.echo(f"Error: Version release failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -154,7 +154,7 @@ def patch(
         subprocess.run(["version", "patch", release_tag, patch_dir, project], check=True, capture_output=False)
         typer.echo(f"Version patch completed successfully for release tag: {release_tag}")
     except subprocess.CalledProcessError as e:
-        log.exception(f"Version patch failed with exit code {e.returncode}")
+        log.exception("Version patch failed with exit code %s", e.returncode)
         typer.echo(f"Error: Version patch failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:

--- a/lftools_uv/typer_apps/version.py
+++ b/lftools_uv/typer_apps/version.py
@@ -15,6 +15,10 @@ import subprocess
 
 import typer
 
+_MSG_VERSION_NOT_FOUND = "'version' command not found in PATH"
+_MSG_VERSION_NOT_FOUND_LONG = "Error: 'version' command not found in PATH. Please ensure it's installed."
+
+
 log = logging.getLogger(__name__)
 
 # Create the version subcommand group
@@ -84,8 +88,8 @@ def bump(
         typer.echo(f"Error: Version bump failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
-        log.error("'version' command not found in PATH")
-        typer.echo("Error: 'version' command not found in PATH. Please ensure it's installed.", err=True)
+        log.error(_MSG_VERSION_NOT_FOUND)
+        typer.echo(_MSG_VERSION_NOT_FOUND_LONG, err=True)
         raise typer.Exit(127) from None
 
 
@@ -114,8 +118,8 @@ def release(
         typer.echo(f"Error: Version release failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
-        log.error("'version' command not found in PATH")
-        typer.echo("Error: 'version' command not found in PATH. Please ensure it's installed.", err=True)
+        log.error(_MSG_VERSION_NOT_FOUND)
+        typer.echo(_MSG_VERSION_NOT_FOUND_LONG, err=True)
         raise typer.Exit(127) from None
 
 
@@ -154,8 +158,8 @@ def patch(
         typer.echo(f"Error: Version patch failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
-        log.error("'version' command not found in PATH")
-        typer.echo("Error: 'version' command not found in PATH. Please ensure it's installed.", err=True)
+        log.error(_MSG_VERSION_NOT_FOUND)
+        typer.echo(_MSG_VERSION_NOT_FOUND_LONG, err=True)
         raise typer.Exit(127) from None
 
 

--- a/lftools_uv/typer_apps/version.py
+++ b/lftools_uv/typer_apps/version.py
@@ -80,7 +80,7 @@ def bump(
         subprocess.run(["version", "bump", release_tag], check=True, capture_output=False)
         typer.echo(f"Version bump completed successfully for release tag: {release_tag}")
     except subprocess.CalledProcessError as e:
-        log.error(f"Version bump failed with exit code {e.returncode}")
+        log.exception(f"Version bump failed with exit code {e.returncode}")
         typer.echo(f"Error: Version bump failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -110,7 +110,7 @@ def release(
         subprocess.run(["version", "release", release_tag], check=True, capture_output=False)
         typer.echo(f"Version release completed successfully for tag: {release_tag}")
     except subprocess.CalledProcessError as e:
-        log.error(f"Version release failed with exit code {e.returncode}")
+        log.exception(f"Version release failed with exit code {e.returncode}")
         typer.echo(f"Error: Version release failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:
@@ -150,7 +150,7 @@ def patch(
         subprocess.run(["version", "patch", release_tag, patch_dir, project], check=True, capture_output=False)
         typer.echo(f"Version patch completed successfully for release tag: {release_tag}")
     except subprocess.CalledProcessError as e:
-        log.error(f"Version patch failed with exit code {e.returncode}")
+        log.exception(f"Version patch failed with exit code {e.returncode}")
         typer.echo(f"Error: Version patch failed with exit code {e.returncode}", err=True)
         raise typer.Exit(e.returncode) from None
     except FileNotFoundError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,13 @@ exclude = [
 [tool.basedpyright]
 typeCheckingMode = "standard"
 pythonVersion = "3.11"
+# Explicit venv pointer so editor LSPs (Zed, VS Code, Neovim, ...) resolve
+# project dependencies the same way `uv run basedpyright` does. Without this,
+# the LSP launches in a clean environment with no VIRTUAL_ENV set and falls
+# back to its bundled stubs, producing spurious "unknown attribute" errors
+# for every dynamically-typed library (notably boto3.resource(...)).
+venvPath = "."
+venv = ".venv"
 
 [tool.mypy]
 python_version = "3.11"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,6 @@ sonar.sources=lftools_uv,shell
 sonar.tests=tests
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.exclusions=**/__pycache__/**,**/.pytest_cache/**,**/.venv/**,**/dist/**
+
+# Supported Python versions (matches pyproject.toml requires-python)
+sonar.python.version=3.11,3.12,3.13,3.14

--- a/tests/test_release_docker_hub.py
+++ b/tests/test_release_docker_hub.py
@@ -14,6 +14,7 @@ import os
 import pytest
 import requests
 import responses
+from pytest_mock import MockerFixture
 
 import lftools_uv.nexus.release_docker_hub as rdh
 
@@ -905,3 +906,93 @@ def test_calculate_docker_project_name(mocker):
     assert test_proj.nexus_repo_name == "this/is/a-test_project"
     assert test_proj.docker_repo_name == "this-is-a-test_project"
     assert test_proj.calc_docker_project_name() == "onap/this-is-a-test_project"
+
+
+class TestProjectClassOrdering:
+    """Tests for ProjectClass equality, hashing, and ordering semantics.
+
+    ProjectClass is decorated with @functools.total_ordering and defines
+    __lt__, __eq__, and __hash__ keyed on nexus_repo_name. These tests pin
+    that contract so future refactors do not silently regress sort order,
+    set / dict membership, or cross-type comparison behaviour.
+    """
+
+    @staticmethod
+    def _make(repo: str, mocker: MockerFixture) -> rdh.ProjectClass:
+        """Build a ProjectClass without touching the network.
+
+        ProjectClass.__init__ instantiates NexusTagClass and DockerTagClass,
+        which both perform real ``requests.get(...)`` calls in their own
+        ``__init__`` methods. Patch those classes (and ``docker.from_env``)
+        so the constructor stays purely in-process and these tests neither
+        depend on external services nor become flaky offline. The patched
+        instances expose an empty ``valid`` list so ``_populate_tags_to_copy``
+        is a no-op.
+        """
+        mocker.patch("docker.from_env")
+        nexus_mock = mocker.patch("lftools_uv.nexus.release_docker_hub.NexusTagClass")
+        nexus_mock.return_value.valid = []
+        docker_mock = mocker.patch("lftools_uv.nexus.release_docker_hub.DockerTagClass")
+        docker_mock.return_value.valid = []
+        rdh.initialize("onap")
+        return rdh.ProjectClass(["onap", repo, ""])
+
+    def test_equal_when_same_nexus_repo_name(self, mocker):
+        a = self._make("foo/bar", mocker)
+        b = self._make("foo/bar", mocker)
+        assert a == b
+        assert not (a != b)
+
+    def test_unequal_when_different_nexus_repo_name(self, mocker):
+        a = self._make("foo/bar", mocker)
+        b = self._make("foo/baz", mocker)
+        assert a != b
+        assert not (a == b)
+
+    def test_eq_with_non_projectclass_returns_notimplemented(self, mocker):
+        a = self._make("foo/bar", mocker)
+        # Python falls back to identity comparison when both __eq__ return
+        # NotImplemented, so a == "foo/bar" must be False (not raise).
+        assert (a == "foo/bar") is False
+        assert (a == 42) is False
+        assert (a == None) is False  # noqa: E711
+
+    def test_lt_with_non_projectclass_returns_notimplemented(self, mocker):
+        a = self._make("foo/bar", mocker)
+        # Comparing a ProjectClass with a non-ProjectClass should raise
+        # TypeError (Python's standard outcome when both sides return
+        # NotImplemented), not AttributeError from naive attribute access.
+        with pytest.raises(TypeError):
+            _ = a < "foo/bar"
+        with pytest.raises(TypeError):
+            _ = a < 42
+
+    def test_hash_consistent_with_equality(self, mocker):
+        a = self._make("foo/bar", mocker)
+        b = self._make("foo/bar", mocker)
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_usable_as_set_member(self, mocker):
+        a = self._make("foo/bar", mocker)
+        b = self._make("foo/bar", mocker)
+        c = self._make("foo/baz", mocker)
+        # a and b are equal -> the set should collapse them to one entry.
+        assert len({a, b, c}) == 2
+
+    def test_sortable_by_nexus_repo_name(self, mocker):
+        c = self._make("foo/c", mocker)
+        a = self._make("foo/a", mocker)
+        b = self._make("foo/b", mocker)
+        ordered = sorted([c, a, b])
+        assert [p.nexus_repo_name for p in ordered] == ["foo/a", "foo/b", "foo/c"]
+
+    def test_total_ordering_provides_le_gt_ge(self, mocker):
+        a = self._make("foo/a", mocker)
+        b = self._make("foo/b", mocker)
+        # @functools.total_ordering should synthesise these from __lt__ + __eq__.
+        assert a <= b
+        assert a <= self._make("foo/a", mocker)
+        assert b > a
+        assert b >= a
+        assert b >= self._make("foo/b", mocker)


### PR DESCRIPTION
## Summary

Cleans up the high-severity (`HIGH` impact) findings reported by SonarCloud for `lfreleng-actions_lftools-uv`, and tightens the SonarCloud project configuration that drives the scan.

This PR was opened originally for a small SonarCloud config tweak (`sonar.python.version`), but has been intentionally re-scoped to also tackle the bulk of high-impact findings the scan surfaces, since these are mechanical, low-risk fixes best handled in one coherent batch.

Cognitive-complexity findings (`python:S3776`, ~30 sites) are intentionally **out of scope** here — those require non-trivial function refactors and will be tackled as a separate programme of work.

After this PR the high-impact findings should drop from **200 → ~30** (an 85% reduction), with the remaining ~30 being the deliberately-deferred complexity refactors.

## Commits (atomic, one per topic)

| # | Commit | Sonar rule / topic | Sites |
|---|---|---|---:|
| 1 | `Fix(sonar): Set sonar.python.version explicitly` | scan config | — |
| 2 | `Fix(logging): Use logging.exception() in except blocks` | `python:S8572` | 135 |
| 3 | `Fix(openstack): Use timezone-aware UTC datetimes` | `python:S6903` | 3 |
| 4 | `Fix(nexus): Apply total_ordering to ProjectClass` | `python:S8500` | 1 |
| 5 | `Refactor(constants): Extract duplicated string literals` | `python:S1192` | 31 |
| 6 | `Style(logging): Drop redundant exception arg from log messages` | follow-up to commit 2 (logging.exception migration) | 54 |
| 7 | `Fix(deploy): Use equality for MIME type checks` | latent bug | 3 |
| 8 | `Fix(gerrit): Send byte length in Content-Length header` | latent bug | 1 |
| 9 | `Fix(gerrit): Use has_section for second-vote presence check` | latent bug | 1 |
| 10 | `Fix(types): Resolve outstanding basedpyright errors` | static-analysis hygiene | 10 |
| 11 | `Fix(gerrit): Stop setting sticky Content-length on session` | latent bug | 3 |
| 12 | `Fix(deploy): Build ExtraArgs without None ContentEncoding` | latent bug | 3 |
| 13 | `Fix(deploy): Upload _tmpfile marker to all S3 prefixes` | latent bug | 1 |
| 14 | `Fix(api): Avoid KeyError on missing Content-Type header` | latent bug | 1 |
| 15 | `Fix(ldap): Exit non-zero on LDAP connection failure` | latent bug | 1 |
| 16 | `Fix(deploy): Use log.exception in S3 ClientError handlers` | logging consistency | 6 |
| 17 | `Style(deploy): Rename dir loop var to avoid shadowing builtin` | naming hygiene | 1 |
| 18 | `Test(nexus): Add ProjectClass equality, hash and ordering tests` | test coverage | 8 cases |

## What changed

- **SonarCloud config** — Set `sonar.python.version=3.11,3.12,3.13,3.14` to match `requires-python` in `pyproject.toml`. (The `coverage.xml` reference is intentionally left in for now and tracked as a follow-up — it requires alignment between the `python-test-action` and `reuse-sonarqube-cloud.yaml` workflows.)
- **`logging.exception()` migration** — In `except` blocks, `logging.error()` was replaced with `logging.exception()` so the traceback is captured. Same signature, so the rename is mechanical and safe. A follow-up commit then strips the now-redundant `: {e}` / `: %s` suffixes from the messages and drops unused `as e:` bindings (auto-fixed by ruff). Useful interpolations such as `e.returncode`, HTTPError details, and group/user/email values are preserved (using `%s` lazy-format args, not f-strings, so the logger only formats them when the record is actually emitted). A later commit extends the same convention to six `except ClientError` handlers in `deploy.py` that Sonar didn't flag (nested helper scope) but which were inconsistent with the rest of the work and made S3 upload failures hard to diagnose.
- **Timezone-aware datetimes** — `datetime.utcnow()` (deprecated in 3.12+, returns naive UTC) replaced with `datetime.now(UTC)`; OpenStack timestamp strings parsed with `strptime()` are now tagged with `tzinfo=UTC` so comparisons stay aware-vs-aware.
- **`total_ordering` on `ProjectClass`** — Added `@functools.total_ordering`, plus explicit `__eq__` / `__hash__` keyed on the same `nexus_repo_name` attribute used by `__lt__`, giving consistent ordering / equality / hashing. `__lt__` and `__eq__` both return `NotImplemented` for non-`ProjectClass` operands, so cross-type comparison falls through to Python's standard handling rather than raising `AttributeError`. The new contract is locked down by **8 focused tests** (`TestProjectClassOrdering`).
- **Constant extraction** — 31 string literals duplicated 3+ times each are now module-level `_NAME` constants (or, where the literal was a string-form forward reference inside `cast(...)`, proper module-level type aliases such as `_LIST_OBJECT_TYPE = list[object]`).
- **basedpyright cleanup** — All 10 outstanding basedpyright errors on this branch (all pre-existing on `main`) have now been resolved so the hook runs clean. The `ldap` import in `cli/ldap_cli.py` is suppressed inline because `python-ldap` publishes no PEP 561 stubs (mypy already had this overridden); `boto3.resource("s3")` in `deploy.py` is annotated as `Any` to opt the `s3` sub-tree out of static analysis (since the project doesn't depend on the `boto3-stubs[s3]` extra), collapsing nine attribute-access errors into a single explicit escape hatch. Also added `venvPath` / `venv` pointers to `[tool.basedpyright]` so editor LSPs (Zed, VS Code, Neovim, ...) resolve project dependencies the same way `uv run basedpyright` does.

## Pre-existing latent bugs fixed during this work

**Eight** genuine pre-existing bugs were surfaced by Copilot during review (because the SonarCloud cleanup happened to put their lines into the reviewable diff). All eight have been fixed in their own atomic commits as a secondary outcome of this PR:

- **`deploy.py` — MIME type substring containment** (commit `Fix(deploy): Use equality for MIME type checks`)
  Three branches in `upload_to_s3_bucket()` were doing `mime_type in "text/plain"` etc. — `in` against a string is **substring containment**, not equality, so prefixes like `"text"` would match `"text/plain"` and pick the wrong upload branch. Replaced `in` with `==` for all three MIME-type branches.

- **`api/endpoints/gerrit.py` — Content-Length header from wrong type** (commit `Fix(gerrit): Send byte length in Content-Length header`)
  The Gerrit `add_file()` endpoint was setting `Content-length` from `f"{my_file_size}"` where `my_file_size` was the whole `os.stat_result` struct, so the header would serialize as `"os.stat_result(st_mode=..., ..., st_size=12345, ...)"` rather than the byte count Gerrit expects. Originally introduced in 2019 (commit `4f06a41`). (Subsequently superseded by the broader sticky-header fix below.)

- **`api/endpoints/gerrit.py` — `vote_on_change()` second-vote guard crashes when section absent** (commit `Fix(gerrit): Use has_section for second-vote presence check`)
  The guard `if config.get_setting(self.fqdn + ".second"):` was being used as a presence check, but `config.get_setting(section)` (no option) calls `ConfigParser.options(section)` which raises `configparser.NoSectionError` when the section is absent — so the guard would crash `vote_on_change()` instead of gracefully skipping the second-user vote. Switched to the existing `config.has_section()` helper.

- **`api/endpoints/gerrit.py` — sticky `Content-length` on session leaking into follow-up POSTs** (commit `Fix(gerrit): Stop setting sticky Content-length on session`)
  Three sites (`add_file`, `add_info_job`, `add_git_review`) set `Content-length` on the **session** (`self.r.headers.update(...)`) for a file-edit PUT, then issued a follow-up `edit:publish` POST that only updated `Content-Type`. Because `requests.Session.headers` persist across requests, the stale `Content-length` was inherited by the publish POST, sending a mismatched body length. Manual `Content-length` was unnecessary in the first place — `requests.PreparedRequest` computes it itself from the encoded body length on every request. Dropped the manual header at all three sites and let `requests` handle it. This also supersedes the value-correctness fix from the preceding `Send byte length in Content-Length header` commit.

- **`deploy.py` — `ContentEncoding=None` rejected by boto3** (commit `Fix(deploy): Build ExtraArgs without None ContentEncoding`)
  Three `ExtraArgs` dicts (`text_html_extra_args`, `text_plain_extra_args`, `app_xml_extra_args`) included `"ContentEncoding": mime_encoding`, but `mimetypes.guess_type()` returns `None` for `mime_encoding` on most uncompressed files and boto3's S3 transfer manager raises `ParamValidationError` on `None` values inside `ExtraArgs`. Introduced a small `_extra_args()` helper that always sets `ContentType` and only includes `ContentEncoding` when `mime_encoding` is a non-empty string.

- **`deploy.py` — `_tmpfile` marker only uploaded to first prefix** (commit `Fix(deploy): Upload _tmpfile marker to all S3 prefixes`)
  The `_tmpfile` marker upload loop iterated over `(logs_dir, silo_dir, jenkins_node_dir)` but the `return True` was nested inside the for-loop body, so the function returned after the first successful upload and skipped the remaining two prefixes. The cleanup pass at the end of `upload_to_s3_bucket()` then attempted to delete two objects that were never created.

- **`api/client.py` — `KeyError` on responses with no `Content-Type` header** (commit `Fix(api): Avoid KeyError on missing Content-Type header`)
  `ApiClient._request()` was deciding whether to JSON-decode the response body via `if _CONTENT_TYPE_JSON in resp.headers["Content-Type"]:`. Subscript access on `requests.CaseInsensitiveDict` raises `KeyError` when the header is absent, which is permitted by HTTP/1.1 (RFC 9110 §8.3) even when the body is non-empty. Switched to `resp.headers.get("Content-Type", "")`.

- **`cli/ldap_cli.py` — LDAP failures masked as success** (commit `Fix(ldap): Exit non-zero on LDAP connection failure`)
  `ldap_connect()` called `sys.exit(0)` on `ldap.LDAPError`, so LDAP bind / connection failures were reported to callers as success. Changed to `sys.exit(1)`.

## Verification

- `prek run --all-files` — **all hooks pass** including `basedpyright`.
- `uv run pytest tests/ -x -q` — **375 passed** (up from 367 with the new `TestProjectClassOrdering` cases) at every commit boundary.

## Out of scope (deferred)

- `python:S3776` (~30 cognitive-complexity findings) — to be addressed in a follow-up programme of work, split by complexity tier (CC ≥40, CC 25–39, CC 16–24).
- Bare `log.exception(e)` / `log.exception(str(e))` calls remaining outside `deploy.py` — still valid (the exception is str-ified as the message and the traceback follows); a useful replacement message requires per-call context.
- SonarCloud coverage report wiring (`sonar.python.coverage.reportPaths`) — needs alignment between the `python-test-action` and `reuse-sonarqube-cloud.yaml` workflows, tracked separately.
- Adding the `boto3-stubs[s3]` extra (and similar service-specific stubs) for proper boto3 typing — would let us drop the `Any` annotation on `s3` in `deploy.py`.
