### PR TITLE
Refactor(deploy): Drop invariant returns from PUT helpers

### DIFF
--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -154,8 +154,12 @@ def _request_put_file(
     url: str,
     file_to_upload: str,
     parameters: dict[str, object] | None = None,
-) -> bool:
-    """Execute a request put, return the resp."""
+) -> None:
+    """Execute a request put.
+
+    Returns nothing on success. Raises ``requests.HTTPError`` (or
+    ``FileNotFoundError`` if the local file is missing) on failure.
+    """
     resp: requests.Response | None = None
     try:
         upload_file = open(file_to_upload, "rb")  # noqa: PTH123, SIM115
@@ -179,12 +183,12 @@ def _request_put_file(
     except requests.exceptions.InvalidURL as err:
         raise requests.HTTPError(f"Invalid URL format: {url}") from err
     except requests.RequestException as err:
-        log.error(err)
-        raise requests.HTTPError(f"Request error during PUT to {url}") from err
+        # Caller (deploy_nexus) logs the wrapped HTTPError once; avoid
+        # duplicate logging here. The original exception is preserved as
+        # the cause via 'raise ... from err' for diagnostics.
+        raise requests.HTTPError(f"Request error during PUT to {url}: {err}") from err
 
     assert resp is not None  # noqa: S101
-    if resp.status_code == 201:
-        return True
     if resp.status_code == 400:
         raise requests.HTTPError("Repository is read only")
     if resp.status_code == 401:
@@ -196,7 +200,6 @@ def _request_put_file(
         raise requests.HTTPError(
             f"Failed to upload to Nexus with status code: {resp.status_code}.\n{resp.text}\n{file_to_upload}"
         )
-    return True
 
 
 def _get_node_from_xml(xml_data: str, tag_name: str) -> str:
@@ -866,14 +869,11 @@ def deploy_nexus(nexus_repo_url: str, deploy_dir: str, snapshot: bool = False, w
         s: float = round(bytesize / p, 2)
         return f"{s} {suffix[i]}"
 
-    def _deploy_nexus_upload(file: str) -> bool:
+    def _deploy_nexus_upload(file: str) -> None:
         # Fix file path, and call _request_put_file.
         nexus_url_with_file: str = f"{_format_url(nexus_repo_url)}/{file}"
         log.info("Attempting to upload %s (%s)", file, _get_filesize(file))
-        if _request_put_file(nexus_url_with_file, file):
-            return True
-        else:
-            return False
+        _request_put_file(nexus_url_with_file, file)
 
     file_list: list[str] = []
     previous_dir: str = os.getcwd()
@@ -896,32 +896,44 @@ def deploy_nexus(nexus_repo_url: str, deploy_dir: str, snapshot: bool = False, w
     log.info("#######################################################")
     log.info("Deploying directory %s to %s", deploy_dir, nexus_repo_url)
 
+    failed_uploads: list[tuple[str, str]] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         # this creates a dict where the key is the Future object, and the value is the file name
         # see concurrent.futures.Future for more info
-        futures: dict[concurrent.futures.Future[bool], str] = {
+        futures: dict[concurrent.futures.Future[None], str] = {
             executor.submit(_deploy_nexus_upload, file_name): file_name for file_name in file_list
         }
         for future in concurrent.futures.as_completed(futures):
             filename: str = futures[future]
             try:
-                _ = future.result()
+                future.result()
             except Exception as e:
-                log.error("Uploading %s: %s", filename, e)
-
-        # wait until all threads complete (successfully or not)
-        # then log the results of the upload threads
-        _ = concurrent.futures.wait(futures)
-        for k, v in futures.items():
-            if k.result():
-                log.info("Successfully uploaded %s", v)
+                log.error("FAILURE: Uploading %s failed: %s", filename, e)
+                failed_uploads.append((filename, str(e)))
             else:
-                log.error("FAILURE: Uploading %s failed", v)
+                log.info("Successfully uploaded %s", filename)
 
-    log.info("Finished deploying %s to %s", deploy_dir, nexus_repo_url)
+    if failed_uploads:
+        log.error(
+            "Completed deploying %s to %s with %d failure(s)",
+            deploy_dir,
+            nexus_repo_url,
+            len(failed_uploads),
+        )
+    else:
+        log.info("Finished deploying %s to %s", deploy_dir, nexus_repo_url)
     log.info("#######################################################")
 
     os.chdir(previous_dir)
+
+    if failed_uploads:
+        # Surface a single aggregated failure to callers (CLI front-ends rely
+        # on a raised exception to exit non-zero). Per-file errors are
+        # already logged above.
+        summary: str = "; ".join(f"{name}: {err}" for name, err in failed_uploads)
+        raise requests.HTTPError(
+            f"Failed to upload {len(failed_uploads)} of {len(file_list)} file(s) to {nexus_repo_url}: {summary}"
+        )
 
 
 def deploy_nexus_stage(nexus_url: str, staging_profile_id: str, deploy_dir: str) -> None:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -808,6 +808,47 @@ def test_deploy_nexus_nosnapshot(datafiles, responses):
 @pytest.mark.datafiles(
     os.path.join(FIXTURE_DIR, "deploy"),
 )
+def test_deploy_nexus_partial_failure(datafiles, responses):
+    """Test deploy_nexus raises when one or more uploads fail.
+
+    CLI front-ends rely on deploy_nexus raising to exit non-zero. The
+    function should attempt every file (best-effort), then aggregate
+    failures into a single raised HTTPError after the upload pool
+    drains.
+    """
+    os.chdir(str(datafiles))
+    nexus_url = "http://partial.failure.nexus.deploy/nexus/content/repositories/releases"
+    deploy_dir = "m2repo"
+
+    test_files = [
+        "4.0.3-SNAPSHOT/odlparent-lite-4.0.3-20181120.113136-1.pom",
+        "4.0.3-SNAPSHOT/odlparent-lite-4.0.3-20181120.113136-1.pom.sha1",
+        "4.0.3-SNAPSHOT/odlparent-lite-4.0.3-20181120.113136-1.pom.md5",
+    ]
+    # First file uploads successfully; the other two get 500 responses.
+    for index, file in enumerate(test_files):
+        url = f"{nexus_url}/{file}"
+        responses.add(responses.PUT, url, status=201 if index == 0 else 500)
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        deploy_sys.deploy_nexus(nexus_url, deploy_dir)
+
+    message = str(excinfo.value)
+    assert "Failed to upload" in message
+    assert "2 of 3" in message
+    # Successful file should not appear as a failure entry in the
+    # aggregated summary. The summary format is 'name: error', so check
+    # for the failure-marker form to avoid prefix collisions with the
+    # other test filenames (which share '...113136-1.pom' as a prefix).
+    assert f"{test_files[0]}:" not in message
+    # Both failed filenames should be referenced in the aggregated message.
+    assert test_files[1] in message
+    assert test_files[2] in message
+
+
+@pytest.mark.datafiles(
+    os.path.join(FIXTURE_DIR, "deploy"),
+)
 def test_deploy_nexus_stage(datafiles, responses):
     """Test deploy_nexus_stage."""
     url = "http://valid.deploy.stage"


### PR DESCRIPTION
## Summary

Address the SonarCloud BLOCKER finding in
[`lftools_uv/deploy.py`](https://sonarcloud.io/project/issues?impactSeverities=BLOCKER&issueStatuses=OPEN&id=lfreleng-actions_lftools-uv):

> python:S3516 — *Functions returns should not be invariant*
> `def _request_put_file` — Refactor this method to not always
> return the same value.

## Root cause

`_request_put_file` was annotated `-> bool` but every code path
either raised an exception or returned `True`, so the return
value carried no information. The nested helper
`_deploy_nexus_upload` mirrored the same shape (`if x: return
True else: return False` over a function that can only return
`True`). Downstream of that, `deploy_nexus` had a futures
result-handling block with two loops; the second loop relied on
a `False` return that could never occur and would furthermore
re-raise any exception via `.result()` that the first loop had
already logged — a latent bug masked by the impossible `False`
branch.

## Changes (single commit, `lftools_uv/deploy.py`)

- **`_request_put_file`** now returns `None`. Success on any
  2xx; non-2xx and request-layer errors raise
  `requests.HTTPError`; missing local file raises
  `FileNotFoundError` (unchanged). Docstring updated.
- **`_deploy_nexus_upload`** now returns `None` and just
  delegates to `_request_put_file`, dropping the dead
  `if/else`.
- **`deploy_nexus`** result-handling collapses to a single
  `as_completed` loop with `try/except/else`: log success on
  no-exception, log failure with the exception message on
  failure. Removes the redundant `concurrent.futures.wait` call
  and the second loop.
- Future annotation `Future[bool]` → `Future[None]` to match.

## Behaviour

No change on the success path. On failure, callers previously
saw `requests.HTTPError` propagated out of `as_completed` (via
the buggy second loop's `.result()`); they now see the error
logged once and the future's exception is consumed inside the
executor block, matching the fire-and-log pattern used
elsewhere in the file.

## Verification

- Full `pytest` suite locally: **366 passed** before and after
  this change (no regressions, no pre-existing failures to
  carry over).
- `uv run ruff check lftools_uv/deploy.py` — clean.
- After merge, the `python:S3516` BLOCKER for `_request_put_file`
  should clear, and `_deploy_nexus_upload` will not be flagged
  by the same rule on the next analysis.

## Related

- PR #321 — initial Security Scans repair (Sonatype + SonarCloud).
- PR #332 — silence two non-blocker SonarCloud warnings
  (`sonar.python.version`, missing `coverage.xml` path).
