### PR TITLE
Feat(ci): Wire pytest coverage into SonarCloud scan

### DIFF
--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -38,18 +38,72 @@ jobs:
     secrets:
       NEXUS_IQ_PASSWORD: "${{ secrets.NEXUS_IQ_PASSWORD }}"
 
+  # Run pytest with coverage so the SonarCloud scan can ingest the report.
+  # Mirrors the python-tests pattern from build-test.yaml; uploads
+  # coverage.xml as a workflow artefact named 'sonarqube-coverage' for the
+  # downstream SonarCloud job to download.
+  python-tests:
+    name: 'Python Tests (coverage)'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 12
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: 'Python tests [pytest]'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/python-test-action@aa753462f090101dcb0c4708e9499f55e276e373  # v1.1.2
+        with:
+          python_version: '3.14'
+          artefact_name: 'sonarqube-coverage'
+
   # Scan results are found at: https://sonarcloud.io/login
   sonarqube-cloud:
     name: 'SonarQube Cloud'
-    # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonarqube-cloud.yaml@9b7880d03148ac73ba5f4e32d423b322db94ebc1 # v0.3.4
+    runs-on: ubuntu-24.04
+    needs: 'python-tests'
+    if: ${{ !cancelled() && needs.python-tests.result == 'success' }}
     permissions:
+      contents: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
-    secrets:
-      SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"
+    timeout-minutes: 10
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # SonarCloud uses git history for blame / new-code detection.
+          fetch-depth: 0
+
+      - name: 'Download coverage artefact'
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sonarqube-coverage
+          # Default extracts to ${{ github.workspace }} so coverage.xml
+          # lands at the project root, where sonar.python.coverage.reportPaths
+          # in sonar-project.properties expects it.
+
+      - name: 'SonarQube Cloud scan'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@9e62d4bd0dda495089e97d3dd7e316abd24b5f72  # v1.1.0
+        with:
+          sonar_token: ${{ secrets.SONAR_TOKEN }}
+          # Workspace already populated by the steps above (checkout +
+          # downloaded coverage artefact); skip the action's own checkout
+          # so it does not wipe the coverage report.
+          no_checkout: 'true'


### PR DESCRIPTION
## Summary

Address the SonarCloud "no report was found for
`sonar.python.coverage.reportPaths` using pattern `coverage.xml`"
warning by actually producing a coverage report ahead of the
scan, using the established `sbom`/`grype` artefact-handoff
pattern from `build-test.yaml`.

## Approach

Two jobs, no inline shell, every action already used elsewhere
in this repo:

```/dev/null/diagram.txt#L1-9
push / schedule / dispatch
        │
        ├──> python-tests          (lfreleng-actions/python-test-action@v1.1.2)
        │       └─ uploads artefact 'sonarqube-coverage' (coverage.xml)
        │
        └──> sonarqube-cloud       (needs: python-tests)
                ├─ actions/checkout (fetch-depth: 0)
                ├─ actions/download-artifact 'sonarqube-coverage'
                └─ lfreleng-actions/sonarqube-cloud-scan-action@v1.1.0
                       (no_checkout: true)
```

`actions/download-artifact` defaults to extracting into
`${{ github.workspace }}`, so `coverage.xml` lands at the
project root — exactly where the existing
`sonar.python.coverage.reportPaths=coverage.xml` line in
`sonar-project.properties` resolves to.

## Why this design

- **Mirrors `sbom -> grype`** in `build-test.yaml`: a producer
  job uploads a known-named artefact, a consumer job downloads
  and uses it. Same pattern, same action SHAs (`actions/checkout`,
  `step-security/harden-runner`, `actions/upload-artifact` /
  `actions/download-artifact`) already pinned in this repo.
- **Reuses the canonical Python test action** rather than
  hand-rolling pytest: same `lfreleng-actions/python-test-action`
  this repo's `build-test.yaml` uses for the matrix. The action
  already emits `coverage.xml` and handles the artefact upload
  for us; we just give it a stable `artefact_name` for the
  consumer.
- **Picks the newest supported Python**: `requires-python =
  ">=3.11, <3.15"` in `pyproject.toml`, so `python_version: '3.14'`.
  No matrix needed — SonarCloud only consumes one report.
- **Drops the SonarCloud reusable-workflow indirection** for
  this repo. The reusable workflow's first step is its own
  checkout, which wipes any pre-populated workspace state, and
  it does not expose a way to inject a download step. It also
  does little more than call `sonarqube-cloud-scan-action`
  itself, so the indirection cost outweighs the benefit. The
  Sonatype Lifecycle half stays on its reusable workflow (it
  does not need coverage).
- **Picks up the JRE-auto-provisioning fix for free**:
  `sonarqube-cloud-scan-action` v1.1.0 (commit
  `9e62d4bd0dda495089e97d3dd7e316abd24b5f72`) is the first
  release with `skip_jre_provisioning` defaulting to `false`,
  which also clears the recent Java 17 deprecation warning.

## Action pins

All by commit SHA per the project's GitHub-Actions-calling rule:

| Action | Tag | Commit SHA |
| --- | --- | --- |
| `step-security/harden-runner` | v2.19.1 | `a5ad31d6a139d249332a2605b85202e8c0b78450` |
| `actions/checkout` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/download-artifact` | v8.0.1 | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `lfreleng-actions/python-test-action` | v1.1.2 | `aa753462f090101dcb0c4708e9499f55e276e373` |
| `lfreleng-actions/sonarqube-cloud-scan-action` | v1.1.0 | `9e62d4bd0dda495089e97d3dd7e316abd24b5f72` |

Every one of these is already pinned (to the same SHAs) in
`.github/workflows/build-test.yaml` and friends, except the
`sonarqube-cloud-scan-action` pin which is new (and its v1.1.0
release was tagged today after my upstream PR landed).

## Related PR

PR #332 sets `sonar.python.version` in `sonar-project.properties`
(addressing the sibling "all Python 3 versions by default"
warning). The two PRs are complementary and conflict-free; they
can merge in either order.

## Verification plan

After merge, re-run `Security Scans` (via `workflow_dispatch`
or wait for the scheduled run) and confirm:

1. `python-tests` job succeeds and uploads the
   `sonarqube-coverage` artefact.
2. `sonarqube-cloud` job downloads it and the scan log shows
   coverage being processed (no more "No report was found …"
   warning).
3. SonarCloud project page shows a non-zero coverage figure
   for the new analysis.

If `python-tests` fails for any reason, the SonarCloud job is
gated by `if: ${{ !cancelled() && needs.python-tests.result == 'success' }}`
and will be skipped rather than running against a missing
artefact — surfaces the underlying test failure clearly without
producing a misleading coverage-less scan.
