### PR TITLE
Fix(deps): Install test deps in default dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,5 +306,10 @@ constraint-dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=8.3.5",
+    "pytest-click>=1.1.0",
     "pytest-cov>=5.0.0",
+    "pytest-datafiles>=3.0.0",
+    "pytest-mock>=3.14.0",
+    "pytest-responses>=0.5.1",
+    "responses>=0.25.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1104,7 +1104,12 @@ test = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-click" },
     { name = "pytest-cov" },
+    { name = "pytest-datafiles" },
+    { name = "pytest-mock" },
+    { name = "pytest-responses" },
+    { name = "responses" },
 ]
 
 [package.metadata]
@@ -1202,7 +1207,12 @@ provides-extras = ["all", "dev", "docs", "ldap", "openstack", "test"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-click", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-datafiles", specifier = ">=3.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pytest-responses", specifier = ">=0.5.1" },
+    { name = "responses", specifier = ">=0.25.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`uv run pytest tests/` fails at collection on a fresh local checkout:

```
ModuleNotFoundError: No module named 'responses'
ModuleNotFoundError: No module named 'pytest_mock'
```

This affects (at minimum) tests/test_api_client.py,
tests/test_openstack_cluster.py, tests/test_release_docker_hub.py, and
tests/test_rtd.py, with additional fixture failures
(`pytest-datafiles`) once the import errors are resolved.

Root cause: the test-time dependencies are declared only in
`[project.optional-dependencies].test`. The
`[dependency-groups].dev` group used by default `uv run` / `uv sync`
contained just `pytest` and `pytest-cov`. CI passes because
`lfreleng-actions/python-test-action` installs the `test` extra.

## Fix

Mirror the full `test` extra into `[dependency-groups].dev` so
`uv run pytest` works out of the box for local development. The
`test` extra (consumed by CI and the `all` extra) is unchanged.

Added to dev group:
- `pytest-click>=1.1.0`
- `pytest-datafiles>=3.0.0`
- `pytest-mock>=3.14.0`
- `pytest-responses>=0.5.1`
- `responses>=0.25.0`

## Test plan

After the change, on a fresh clone:

```
uv lock && uv sync && uv run pytest tests/ --no-cov
```

→ `375 passed`. Previously this failed at collection.