### PR TITLE
Feat(zulip): Add Zulip command group scaffolding and foundation

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -268,6 +268,16 @@ def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None
     zulip_module = _require_zulip()
     if resolved.config_path is not None:
         return zulip_module.Client(config_file=str(resolved.config_path))
+    # No zuliprc file — all three credential fields must be populated.
+    missing: list[str] = []
+    if not (isinstance(resolved.email, str) and resolved.email.strip()):
+        missing.append("email")
+    if not (isinstance(resolved.api_key, str) and resolved.api_key.strip()):
+        missing.append("api_key")
+    if not (isinstance(resolved.site, str) and resolved.site.strip()):
+        missing.append("site")
+    if missing:
+        raise ZulipConfigError(f"Incomplete Zulip credentials from {resolved.source}: missing {', '.join(missing)}")
     return zulip_module.Client(
         email=resolved.email,
         api_key=resolved.api_key,

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -7,26 +7,615 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 ##############################################################################
-"""Zulip REST API client wrapper for lftools-uv.
+"""Zulip REST API helpers for lftools-uv.
 
-This module exposes the Zulip channel/user/group operations consumed by
-the ``lftools_uv.typer_apps.zulip`` CLI layer. It is intentionally
-import-safe even when the optional ``zulip`` extra is not installed: the
-import of the ``zulip`` Python package is wrapped so that callers can
-detect availability via :func:`zulip_available` and produce a friendly
-error from the CLI layer (FR-022).
+This module is the API/business-logic layer for the ``lftools-uv zulip``
+command group. It is intentionally import-safe even when the optional
+``zulip`` extra is not installed: the import of the upstream ``zulip``
+Python package is wrapped so that callers can detect availability via
+:func:`zulip_available` and surface a friendly install hint from the CLI
+layer (FR-022).
+
+Public surface:
+
+* Configuration resolution — :class:`ZulipConfig`,
+  :func:`resolve_config` (precedence per FR-011/FR-012).
+* Client factory — :func:`get_client`.
+* Feature-level detection — :func:`get_server_feature_level`,
+  :func:`check_feature_level` (FR-019 canonical error format).
+* Resolution helpers — :func:`resolve_channel`, :func:`resolve_users`,
+  :func:`resolve_groups`.
+* Domain exceptions — :class:`ZulipConfigError`, :class:`ZulipAPIError`,
+  :class:`ZulipFeatureLevelError`, :class:`ZulipAmbiguityError`,
+  :class:`ZulipLockoutError`, :class:`ZulipNotFoundError`,
+  :class:`ZulipValidationError`.
 
 See ``specs/001-zulip-channel-mgmt/`` for the full feature design.
 """
 
 from __future__ import annotations
 
-try:  # pragma: no cover - import guard tested via integration
+import configparser
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from lftools_uv import config as lf_config
+
+try:  # pragma: no cover - import guard exercised by integration tests
     import zulip as _zulip_module
 except ImportError:  # pragma: no cover - exercised when extra not installed
     _zulip_module = None
+
+if TYPE_CHECKING:  # pragma: no cover
+    import zulip as _zulip_module_type  # noqa: F401
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
+class ZulipError(Exception):
+    """Base class for all Zulip-related errors raised by this module."""
+
+
+class ZulipConfigError(ZulipError):
+    """Raised when Zulip configuration cannot be located or parsed."""
+
+
+class ZulipAPIError(ZulipError):
+    """Raised when the Zulip server returns an error response."""
+
+
+class ZulipFeatureLevelError(ZulipError):
+    """Raised when the server lacks the required Zulip feature level.
+
+    The string form follows the FR-019 canonical format
+    ``This operation requires Zulip feature level X (server has Y)``.
+    """
+
+    def __init__(self, required: int, actual: int, feature_name: str = "") -> None:
+        self.required = required
+        self.actual = actual
+        self.feature_name = feature_name
+        message = f"This operation requires Zulip feature level {required} (server has {actual})"
+        super().__init__(message)
+
+
+class ZulipAmbiguityError(ZulipError):
+    """Raised when a name lookup matches more than one entity."""
+
+    def __init__(self, message: str, matches: list[dict[str, Any]] | None = None) -> None:
+        super().__init__(message)
+        self.matches = matches or []
+
+
+class ZulipNotFoundError(ZulipError):
+    """Raised when a channel/user/group cannot be located by name or id."""
+
+
+class ZulipLockoutError(ZulipError):
+    """Raised when an operation would lock all users out of a channel."""
+
+
+class ZulipValidationError(ZulipError):
+    """Raised for client-side validation failures (e.g. mutex flags)."""
+
+
+# ---------------------------------------------------------------------------
+# Optional-dependency detection
+# ---------------------------------------------------------------------------
 
 
 def zulip_available() -> bool:
     """Return ``True`` when the optional ``zulip`` package is importable."""
     return _zulip_module is not None
+
+
+def _require_zulip() -> Any:
+    """Return the imported ``zulip`` module or raise :class:`ZulipConfigError`.
+
+    The CLI layer normally short-circuits before this is reached (it
+    presents the canonical FR-022 install hint when the extra is
+    missing); ``_require_zulip`` exists so that the API layer can be
+    consumed programmatically with a clear error when the extra is not
+    installed.
+    """
+    if _zulip_module is None:  # pragma: no cover - defensive
+        raise ZulipConfigError(
+            "The 'zulip' Python package is not installed. Install with: pip install \"lftools-uv[zulip]\""
+        )
+    return _zulip_module
+
+
+# ---------------------------------------------------------------------------
+# Configuration resolution (FR-011 / FR-012)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ZulipConfig:
+    """Resolved Zulip API credentials.
+
+    Either ``config_path`` (a path to a zuliprc-format file) OR the
+    three credential fields will be populated, depending on which
+    source produced the configuration. The :func:`get_client` factory
+    handles both cases transparently.
+    """
+
+    email: str | None = None
+    api_key: str | None = None
+    site: str | None = None
+    config_path: Path | None = None
+    source: str = "unknown"
+
+
+_ZULIPRC_API_SECTION = "api"
+_LFTOOLS_ZULIP_SECTION = "zulip"
+
+
+def _load_zuliprc(path: Path) -> ZulipConfig:
+    """Validate a zuliprc-format file and return a :class:`ZulipConfig`.
+
+    The file is not parsed here for credential extraction — the
+    ``zulip.Client`` consumes the file directly. Parsing only validates
+    that the file is readable and contains the expected ``[api]``
+    section, producing a clear error otherwise.
+    """
+    parser = configparser.ConfigParser()
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            parser.read_file(handle)
+    except OSError as exc:
+        raise ZulipConfigError(f"Cannot read Zulip config file {path}: {exc}") from exc
+    except configparser.Error as exc:
+        raise ZulipConfigError(f"Malformed Zulip config file {path}: {exc}") from exc
+
+    if not parser.has_section(_ZULIPRC_API_SECTION):
+        raise ZulipConfigError(f"Zulip config file {path} is missing required [api] section")
+    return ZulipConfig(config_path=path, source=str(path))
+
+
+def _load_lftools_ini() -> ZulipConfig | None:
+    """Return a :class:`ZulipConfig` synthesized from ``lftools.ini``.
+
+    Returns ``None`` when the ``[zulip]`` section is absent.
+    """
+    if not lf_config.has_section(_LFTOOLS_ZULIP_SECTION):
+        return None
+    try:
+        email = lf_config.get_setting(_LFTOOLS_ZULIP_SECTION, "email")
+        api_key = lf_config.get_setting(_LFTOOLS_ZULIP_SECTION, "key")
+        site = lf_config.get_setting(_LFTOOLS_ZULIP_SECTION, "site")
+    except (configparser.NoOptionError, configparser.NoSectionError) as exc:
+        raise ZulipConfigError(f"lftools.ini [zulip] section is incomplete: {exc}") from exc
+    if not (isinstance(email, str) and isinstance(api_key, str) and isinstance(site, str)):
+        raise ZulipConfigError("lftools.ini [zulip] section must define email, key, site")
+    return ZulipConfig(
+        email=email,
+        api_key=api_key,
+        site=site,
+        source="lftools.ini[zulip]",
+    )
+
+
+def resolve_config(
+    zuliprc: Path | None = None,
+    *,
+    cwd: Path | None = None,
+    home: Path | None = None,
+) -> ZulipConfig:
+    """Resolve Zulip configuration using the FR-011/FR-012 precedence chain.
+
+    Precedence (first match wins):
+
+    1. ``zuliprc`` argument (from ``--zuliprc`` CLI flag).
+    2. ``./zuliprc`` in the current working directory.
+    3. ``[zulip]`` section in ``lftools.ini``.
+    4. ``~/.zuliprc``.
+
+    Parameters ``cwd`` and ``home`` allow tests to inject filesystem
+    locations; defaults are ``Path.cwd()`` and ``Path.home()``.
+
+    Raises :class:`ZulipConfigError` when no source resolves.
+    """
+    cwd = cwd or Path.cwd()
+    home = home or Path.home()
+
+    if zuliprc is not None:
+        path = Path(zuliprc)
+        if not path.exists():
+            raise ZulipConfigError(f"--zuliprc path does not exist: {path}")
+        return _load_zuliprc(path)
+
+    cwd_candidate = cwd / "zuliprc"
+    if cwd_candidate.exists():
+        return _load_zuliprc(cwd_candidate)
+
+    ini_config = _load_lftools_ini()
+    if ini_config is not None:
+        return ini_config
+
+    home_candidate = home / ".zuliprc"
+    if home_candidate.exists():
+        return _load_zuliprc(home_candidate)
+
+    raise ZulipConfigError(
+        "No Zulip configuration found. Searched: --zuliprc flag, ./zuliprc, lftools.ini [zulip] section, ~/.zuliprc"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Client factory
+# ---------------------------------------------------------------------------
+
+
+def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None) -> Any:
+    """Instantiate a ``zulip.Client`` from the resolved configuration.
+
+    ``zuliprc`` and ``config`` are mutually exclusive; supply at most one.
+    When neither is given, configuration is resolved via
+    :func:`resolve_config`.
+    """
+    if zuliprc is not None and config is not None:
+        raise ZulipValidationError("Pass either 'zuliprc' or 'config', not both")
+    resolved = config or resolve_config(zuliprc)
+    zulip_module = _require_zulip()
+    if resolved.config_path is not None:
+        return zulip_module.Client(config_file=str(resolved.config_path))
+    return zulip_module.Client(
+        email=resolved.email,
+        api_key=resolved.api_key,
+        site=resolved.site,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature-level detection (FR-019)
+# ---------------------------------------------------------------------------
+
+
+#: Hardcoded feature-level thresholds determined by consulting the Zulip
+#: changelog. Each name maps to the minimum ``zulip_feature_level`` that
+#: a server must report before the corresponding capability is exposed.
+#:
+#: References (Zulip changelog,
+#: https://zulip.com/api/changelog):
+#:
+#: * Feature level 1 — initial introduction of the
+#:   ``zulip_feature_level`` field; all servers we target report >= 1.
+#: * Feature level 12 — web-public streams and spectator access.
+#: * Feature level 197 — group-based access control via
+#:   ``can_access_group``.
+#: * Feature level 161 — ``can_remove_subscribers_group`` permission.
+#: * Feature level 334 — ``topic_policy`` per-channel field.
+#: * Feature level 59 — stream reactivation (unarchive) endpoint.
+FEATURE_LEVELS: dict[str, int] = {
+    "web-public": 12,
+    "can-access-group": 197,
+    "can-remove-subscribers-group": 161,
+    "topic-policy": 334,
+    "unarchive": 59,
+}
+
+
+def get_server_feature_level(client: Any) -> int:
+    """Return the server's reported ``zulip_feature_level``.
+
+    The result is cached on the client instance as ``_lftools_feature_level``
+    to avoid repeated HTTP calls within a single CLI invocation.
+    """
+    cached = getattr(client, "_lftools_feature_level", None)
+    if isinstance(cached, int):
+        return cached
+    try:
+        response = client.get_server_settings()
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to query server settings: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        raise ZulipAPIError(f"Unexpected server_settings response: {response!r}")
+    level = response.get("zulip_feature_level")
+    if not isinstance(level, int):
+        # Some very old servers omit the field; treat as level 0.
+        level = 0
+    try:
+        client._lftools_feature_level = level
+    except AttributeError:  # pragma: no cover - defensive
+        pass
+    return level
+
+
+def check_feature_level(
+    client: Any,
+    required_level: int,
+    feature_name: str = "",
+) -> None:
+    """Raise :class:`ZulipFeatureLevelError` when server feature level is too low."""
+    actual = get_server_feature_level(client)
+    if actual < required_level:
+        raise ZulipFeatureLevelError(
+            required=required_level,
+            actual=actual,
+            feature_name=feature_name,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Channel resolution
+# ---------------------------------------------------------------------------
+
+
+def _fetch_streams(client: Any, include_archived: bool) -> list[dict[str, Any]]:
+    """Return the raw stream listing from the Zulip server.
+
+    Includes archived streams when ``include_archived`` is ``True``.
+    """
+    request: dict[str, Any] = {
+        "include_public": True,
+        "include_subscribed": True,
+        "include_all_active": True,
+    }
+    if include_archived:
+        request["include_archived"] = True
+    try:
+        response = client.call_endpoint(url="streams", method="GET", request=request)
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to list channels: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        raise ZulipAPIError(f"Unexpected streams response: {response!r}")
+    streams = response.get("streams", [])
+    if not isinstance(streams, list):
+        raise ZulipAPIError(f"Malformed streams payload: {response!r}")
+    return streams
+
+
+def resolve_channel(
+    client: Any,
+    *,
+    name: str | None = None,
+    channel_id: int | None = None,
+    include_archived: bool = False,
+) -> dict[str, Any]:
+    """Resolve a channel by name (case-insensitive) or numeric ID.
+
+    Returns the raw stream dict from the Zulip API. Raises
+    :class:`ZulipNotFoundError` when no match exists. When the channel
+    exists only in the archived set and ``include_archived`` is
+    ``False``, the error message advises adding ``--include-archived``
+    per FR-018.
+    """
+    if (name is None) == (channel_id is None):
+        raise ZulipValidationError("resolve_channel requires exactly one of 'name' or 'channel_id'")
+    active_streams = _fetch_streams(client, include_archived=include_archived)
+
+    if channel_id is not None:
+        for stream in active_streams:
+            if stream.get("stream_id") == channel_id:
+                return stream
+        if not include_archived:
+            archived_streams = _fetch_streams(client, include_archived=True)
+            for stream in archived_streams:
+                if stream.get("stream_id") == channel_id:
+                    raise ZulipNotFoundError(
+                        f"Channel id {channel_id} is archived. Use --include-archived to operate on archived channels."
+                    )
+        raise ZulipNotFoundError(f"No channel with id {channel_id}")
+
+    assert name is not None  # for type narrowing
+    target = name.casefold()
+    for stream in active_streams:
+        if str(stream.get("name", "")).casefold() == target:
+            return stream
+    if not include_archived:
+        archived_streams = _fetch_streams(client, include_archived=True)
+        for stream in archived_streams:
+            if str(stream.get("name", "")).casefold() == target:
+                raise ZulipNotFoundError(
+                    f"Channel '{name}' is archived. Use --include-archived to operate on archived channels."
+                )
+    raise ZulipNotFoundError(f"Channel '{name}' not found")
+
+
+# ---------------------------------------------------------------------------
+# User resolution
+# ---------------------------------------------------------------------------
+
+
+IdMode = Literal["email", "id", "name"]
+
+
+def _fetch_users(client: Any) -> list[dict[str, Any]]:
+    """Return the raw user listing from the Zulip server."""
+    try:
+        response = client.get_members({"include_custom_profile_fields": False})
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to list users: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        raise ZulipAPIError(f"Unexpected users response: {response!r}")
+    members = response.get("members", [])
+    if not isinstance(members, list):
+        raise ZulipAPIError(f"Malformed users payload: {response!r}")
+    return members
+
+
+def resolve_users(
+    client: Any,
+    identifiers: Iterable[str],
+    *,
+    mode: IdMode,
+) -> list[dict[str, Any]]:
+    """Resolve a list of user identifiers per the chosen ``mode``.
+
+    Returns one user dict per identifier in input order. Raises
+    :class:`ZulipNotFoundError` when an identifier resolves to nothing,
+    or :class:`ZulipAmbiguityError` (mode ``name`` only) when a
+    full-name lookup matches more than one user. Email and ID lookups
+    are unique by construction.
+    """
+    members = _fetch_users(client)
+    resolved: list[dict[str, Any]] = []
+    for raw in identifiers:
+        ident = raw.strip()
+        if not ident:
+            raise ZulipValidationError("User identifier must not be empty")
+        if mode == "email":
+            matches = [u for u in members if u.get("delivery_email") == ident or u.get("email") == ident]
+        elif mode == "id":
+            try:
+                wanted = int(ident)
+            except ValueError as exc:
+                raise ZulipValidationError(f"--by-id requires a numeric identifier, got {ident!r}") from exc
+            matches = [u for u in members if u.get("user_id") == wanted]
+        elif mode == "name":
+            matches = [u for u in members if u.get("full_name") == ident]
+        else:  # pragma: no cover - guarded by Literal
+            raise ZulipValidationError(f"Unknown user id mode: {mode!r}")
+
+        if not matches:
+            raise ZulipNotFoundError(f"No user found matching {ident!r} (--by-{mode})")
+        if len(matches) > 1:
+            raise ZulipAmbiguityError(
+                f"User name {ident!r} matched {len(matches)} users; use --by-email or --by-id to disambiguate",
+                matches=[
+                    {
+                        "user_id": m.get("user_id"),
+                        "full_name": m.get("full_name"),
+                        "email": m.get("delivery_email") or m.get("email"),
+                    }
+                    for m in matches
+                ],
+            )
+        resolved.append(matches[0])
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Group resolution
+# ---------------------------------------------------------------------------
+
+
+#: Display-name → API name mapping for built-in system role groups.
+SYSTEM_ROLE_GROUPS: dict[str, str] = {
+    "owners": "role:owners",
+    "administrators": "role:administrators",
+    "moderators": "role:moderators",
+    "full members": "role:fullmembers",
+    "members": "role:members",
+    "everyone": "role:everyone",
+    "nobody": "role:nobody",
+}
+
+
+def _fetch_groups(client: Any) -> list[dict[str, Any]]:
+    """Return the raw user_groups listing from the Zulip server."""
+    try:
+        response = client.call_endpoint(url="user_groups", method="GET")
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to list user groups: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        raise ZulipAPIError(f"Unexpected user_groups response: {response!r}")
+    groups = response.get("user_groups", [])
+    if not isinstance(groups, list):
+        raise ZulipAPIError(f"Malformed user_groups payload: {response!r}")
+    return groups
+
+
+def _resolve_single_group_token(token: str, groups: list[dict[str, Any]]) -> dict[str, Any]:
+    """Resolve a single comma-item token to a group dict.
+
+    Supports the ``id:NUM`` prefix and the system-role display-name
+    mapping. Raises :class:`ZulipAmbiguityError`,
+    :class:`ZulipNotFoundError`, or :class:`ZulipValidationError` as
+    appropriate.
+    """
+    token = token.strip()
+    if not token:
+        raise ZulipValidationError("Empty group token in comma-separated value")
+
+    if token.lower().startswith("id:"):
+        suffix = token[3:].strip()
+        try:
+            wanted = int(suffix)
+        except ValueError as exc:
+            raise ZulipValidationError(f"id: prefix requires a numeric identifier, got {suffix!r}") from exc
+        for grp in groups:
+            if grp.get("id") == wanted:
+                return grp
+        raise ZulipNotFoundError(f"No user group with id {wanted}")
+
+    api_name = SYSTEM_ROLE_GROUPS.get(token.casefold())
+    if api_name is not None:
+        for grp in groups:
+            if grp.get("name") == api_name:
+                return grp
+        raise ZulipNotFoundError(f"System role group '{token}' not found on server")
+
+    target = token.casefold()
+    matches = [
+        grp for grp in groups if str(grp.get("name", "")).casefold() == target and not grp.get("is_system_group", False)
+    ]
+    if not matches:
+        raise ZulipNotFoundError(f"No user group named {token!r}")
+    if len(matches) > 1:
+        raise ZulipAmbiguityError(
+            f"Group name {token!r} matched {len(matches)} groups; use the id:NUM prefix to disambiguate",
+            matches=[{"id": g.get("id"), "name": g.get("name")} for g in matches],
+        )
+    return matches[0]
+
+
+GroupSettingValue = int | dict[str, list[int]]
+
+
+def _build_group_setting_value(group_ids: list[int]) -> GroupSettingValue:
+    """Translate resolved group IDs into a Zulip group-setting value.
+
+    Single group → simple int. Multiple groups → complex object with
+    ``direct_members`` empty and ``direct_subgroups`` populated.
+    """
+    if len(group_ids) == 1:
+        return group_ids[0]
+    return {"direct_members": [], "direct_subgroups": group_ids}
+
+
+def resolve_groups(
+    client: Any,
+    spec: str,
+    *,
+    allow_nobody: bool = True,
+) -> tuple[list[dict[str, Any]], GroupSettingValue]:
+    """Resolve a comma-separated ``--allow-group``-style argument.
+
+    Returns a tuple ``(group_dicts, group_setting_value)`` suitable for
+    sending to either the POST (raw value) or PATCH (wrapped under
+    ``{"new": ...}``) endpoints. The caller is responsible for applying
+    the PATCH wrapper.
+
+    When ``allow_nobody`` is ``False`` (e.g. for lockout-prevention
+    checks on private channel create/update), the helper raises
+    :class:`ZulipLockoutError` if the resolved set is exactly the single
+    ``Nobody`` system group.
+    """
+    tokens = [t for t in (part.strip() for part in spec.split(",")) if t]
+    if not tokens:
+        raise ZulipValidationError("Group specification must not be empty")
+    groups = _fetch_groups(client)
+    resolved = [_resolve_single_group_token(tok, groups) for tok in tokens]
+    if not allow_nobody and len(resolved) == 1 and resolved[0].get("name") == "role:nobody":
+        raise ZulipLockoutError(
+            "'Nobody' does not satisfy lockout prevention — it disables "
+            "the permission entirely. Specify --subscribe users or a "
+            "non-Nobody --allow-group."
+        )
+    group_ids: list[int] = []
+    for grp in resolved:
+        gid = grp.get("id")
+        if not isinstance(gid, int):
+            raise ZulipAPIError(f"Group object missing numeric id: {grp!r}")
+        group_ids.append(gid)
+    return resolved, _build_group_setting_value(group_ids)

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Zulip REST API client wrapper for lftools-uv.
+
+This module exposes the Zulip channel/user/group operations consumed by
+the ``lftools_uv.typer_apps.zulip`` CLI layer. It is intentionally
+import-safe even when the optional ``zulip`` extra is not installed: the
+import of the ``zulip`` Python package is wrapped so that callers can
+detect availability via :func:`zulip_available` and produce a friendly
+error from the CLI layer (FR-022).
+
+See ``specs/001-zulip-channel-mgmt/`` for the full feature design.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - import guard tested via integration
+    import zulip as _zulip_module
+except ImportError:  # pragma: no cover - exercised when extra not installed
+    _zulip_module = None
+
+
+def zulip_available() -> bool:
+    """Return ``True`` when the optional ``zulip`` package is importable."""
+    return _zulip_module is not None

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -539,14 +539,14 @@ def _resolve_single_group_token(token: str, groups: list[dict[str, Any]]) -> dic
     """Resolve a single comma-item token to a group dict.
 
     Supports the ``id:NUM`` prefix and the system-role display-name
-    mapping. Raises :class:`ZulipAmbiguityError`,
-    :class:`ZulipNotFoundError`, or :class:`ZulipValidationError` as
-    appropriate.
-    """
-    token = token.strip()
-    if not token:
-        raise ZulipValidationError("Empty group token in comma-separated value")
+    mapping. The caller is expected to have stripped and filtered the
+    input so ``token`` is always non-empty.
 
+    Raises :class:`ZulipAmbiguityError`, :class:`ZulipNotFoundError`,
+    or :class:`ZulipValidationError` as appropriate.
+    """
+    # ``resolve_groups`` filters empty/whitespace tokens before calling
+    # this helper, so by construction ``token`` is non-empty here.
     if token.lower().startswith("id:"):
         suffix = token[3:].strip()
         try:
@@ -610,6 +610,11 @@ def resolve_groups(
     checks on private channel create/update), the helper raises
     :class:`ZulipLockoutError` if the resolved set is exactly the single
     ``Nobody`` system group.
+
+    Empty / whitespace-only segments inside the comma-separated value
+    are tolerated and stripped (so ``"design, , foo"`` is equivalent
+    to ``"design, foo"``). A spec containing only empty segments is
+    still rejected with :class:`ZulipValidationError`.
     """
     tokens = [t for t in (part.strip() for part in spec.split(",")) if t]
     if not tokens:

--- a/lftools_uv/typer_apps/root.py
+++ b/lftools_uv/typer_apps/root.py
@@ -38,6 +38,7 @@ from lftools_uv.typer_apps.schema import get_schema_app
 from lftools_uv.typer_apps.sign import get_sign_app
 from lftools_uv.typer_apps.utils import get_utils_app
 from lftools_uv.typer_apps.version import get_version_app
+from lftools_uv.typer_apps.zulip import zulip_app
 
 log = logging.getLogger(__name__)
 
@@ -148,6 +149,7 @@ app.add_typer(get_license_app(), name="license")
 app.add_typer(get_sign_app(), name="sign")
 app.add_typer(get_infofile_app(), name="infofile")
 app.add_typer(get_rtd_app(), name="rtd")
+app.add_typer(zulip_app, name="zulip")
 
 
 def get_app() -> typer.Typer:

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -60,16 +60,13 @@ zulip_app = typer.Typer(
 def zuliprc_callback(value: Path | None) -> Path | None:
     """Validate the ``--zuliprc`` flag value.
 
-    Stores the resolved path on the Typer context object for later use
-    by the API layer. ``None`` is passed through unchanged so the
-    default resolution chain (cwd, lftools.ini, ``~/.zuliprc``) applies.
+    Returns the supplied path (or ``None``) unchanged so that the API
+    layer can apply the FR-011 precedence chain via
+    :func:`lftools_uv.api.endpoints.zulip.resolve_config`. The
+    existence check is intentionally deferred to ``resolve_config`` so
+    that callers see a single, consistent error message regardless of
+    whether the path came from the flag or the default search order.
     """
-    if value is None:
-        return None
-    if not value.exists():
-        # Defer the error to the command body so callers can format the
-        # message consistently with other failures via ``emit_error``.
-        return value
     return value
 
 
@@ -174,6 +171,11 @@ def zulip_callback(ctx: typer.Context) -> None:
     immediately with the canonical FR-022 error so that every
     subcommand presents the same guidance to the user.
     """
+    # Allow ``--help`` (including nested subcommand help) to render even
+    # when the optional extra is missing. Typer sets resilient_parsing
+    # while it is walking the command tree for help discovery.
+    if ctx.resilient_parsing:
+        return
     if ctx.invoked_subcommand is None:
         # Help / no-args path — let Typer print help without raising.
         return

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -14,14 +14,31 @@ when the optional ``zulip`` extra is not installed. When the extra is
 missing, any subcommand invocation produces the canonical FR-022 error
 message directing the user to install the extra.
 
+This module also exposes shared CLI helpers used by the per-command
+modules added in later phases: zuliprc path normalization, table/JSON
+output formatting, and consistent error display.
+
 See ``specs/001-zulip-channel-mgmt/`` for the full feature design.
 """
 
 from __future__ import annotations
 
-import typer
+import json
+import logging
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Any
 
-from lftools_uv.api.endpoints.zulip import zulip_available
+import typer
+from tabulate import tabulate
+
+from lftools_uv.api.endpoints.zulip import (
+    ZulipError,
+    zulip_available,
+)
+
+log = logging.getLogger(__name__)
+
 
 #: Canonical error message displayed when the ``zulip`` extra is missing
 #: (FR-022). Matches the wording in ``contracts/cli-commands.md``.
@@ -35,16 +52,130 @@ zulip_app = typer.Typer(
 )
 
 
+# ---------------------------------------------------------------------------
+# Shared option callbacks and helpers
+# ---------------------------------------------------------------------------
+
+
+def zuliprc_callback(value: Path | None) -> Path | None:
+    """Validate the ``--zuliprc`` flag value.
+
+    Stores the resolved path on the Typer context object for later use
+    by the API layer. ``None`` is passed through unchanged so the
+    default resolution chain (cwd, lftools.ini, ``~/.zuliprc``) applies.
+    """
+    if value is None:
+        return None
+    if not value.exists():
+        # Defer the error to the command body so callers can format the
+        # message consistently with other failures via ``emit_error``.
+        return value
+    return value
+
+
+def emit_error(message: str) -> None:
+    """Write a Zulip error message to stderr.
+
+    Centralizes the format so that all Zulip commands present errors
+    identically. Always writes a trailing newline. Does NOT exit; the
+    caller decides whether to raise ``typer.Exit``.
+    """
+    typer.echo(f"Error: {message}", err=True)
+
+
+def handle_zulip_error(exc: ZulipError) -> typer.Exit:
+    """Format a :class:`ZulipError` for the CLI and return ``typer.Exit``.
+
+    Callers should ``raise`` the returned ``typer.Exit`` to abort. This
+    function keeps the format consistent for every subcommand.
+    """
+    emit_error(str(exc))
+    return typer.Exit(code=1)
+
+
+def emit_table(rows: Sequence[Sequence[Any]], headers: Sequence[str]) -> None:
+    """Print a human-readable table to stdout using ``tabulate``."""
+    typer.echo(tabulate(list(rows), headers=list(headers)))
+
+
+def emit_json(payload: Any) -> None:
+    """Print a JSON payload to stdout with indent=2 (FR-008)."""
+    typer.echo(json.dumps(payload, indent=2, sort_keys=False, default=str))
+
+
+def mutation_result(
+    *,
+    status: str,
+    operation: str,
+    channel_id: int | None,
+    channel_name: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the standard mutation-result JSON payload.
+
+    Schema matches ``data-model.md``: ``status``, ``channel_id``,
+    ``channel_name``, ``operation`` — plus any ``extra`` fields the
+    specific command needs (e.g. ``type`` for create).
+    """
+    payload: dict[str, Any] = {
+        "status": status,
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "operation": operation,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def bulk_mutation_result(
+    *,
+    operation: str,
+    channel_id: int | None,
+    channel_name: str,
+    results: Iterable[dict[str, Any]],
+    errors: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the standard bulk mutation-result JSON payload.
+
+    Adds ``results`` and ``errors`` lists per ``contracts/cli-commands.md``.
+    The overall ``status`` is derived from the contents: ``error`` when
+    everything failed, ``partial`` when some succeeded and some failed,
+    ``success`` otherwise.
+    """
+    results_list = list(results)
+    errors_list = list(errors)
+    if errors_list and not results_list:
+        status = "error"
+    elif errors_list:
+        status = "partial"
+    else:
+        status = "success"
+    return {
+        "status": status,
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "operation": operation,
+        "results": results_list,
+        "errors": errors_list,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Top-level callback (optional-dependency guard, FR-022)
+# ---------------------------------------------------------------------------
+
+
 @zulip_app.callback()
 def zulip_callback(ctx: typer.Context) -> None:
     """Top-level callback for the Zulip command group.
 
-    When the optional ``zulip`` extra is not installed, abort immediately
-    with the canonical FR-022 error so that every subcommand presents the
-    same guidance to the user.
+    When the optional ``zulip`` extra is not installed, abort
+    immediately with the canonical FR-022 error so that every
+    subcommand presents the same guidance to the user.
     """
     if ctx.invoked_subcommand is None:
-        # Help/no-args path — let Typer print help without raising.
+        # Help / no-args path — let Typer print help without raising.
         return
     if not zulip_available():
         typer.echo(MISSING_EXTRA_MESSAGE, err=True)

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Typer CLI app for Zulip channel management.
+
+The ``zulip`` command group is always registered with the root CLI even
+when the optional ``zulip`` extra is not installed. When the extra is
+missing, any subcommand invocation produces the canonical FR-022 error
+message directing the user to install the extra.
+
+See ``specs/001-zulip-channel-mgmt/`` for the full feature design.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from lftools_uv.api.endpoints.zulip import zulip_available
+
+#: Canonical error message displayed when the ``zulip`` extra is missing
+#: (FR-022). Matches the wording in ``contracts/cli-commands.md``.
+MISSING_EXTRA_MESSAGE = 'Zulip support requires the zulip extra. Install with:\n  pip install "lftools-uv[zulip]"'
+
+
+zulip_app = typer.Typer(
+    name="zulip",
+    help="Manage Zulip channels, users, and groups.",
+    no_args_is_help=True,
+)
+
+
+@zulip_app.callback()
+def zulip_callback(ctx: typer.Context) -> None:
+    """Top-level callback for the Zulip command group.
+
+    When the optional ``zulip`` extra is not installed, abort immediately
+    with the canonical FR-022 error so that every subcommand presents the
+    same guidance to the user.
+    """
+    if ctx.invoked_subcommand is None:
+        # Help/no-args path — let Typer print help without raising.
+        return
+    if not zulip_available():
+        typer.echo(MISSING_EXTRA_MESSAGE, err=True)
+        raise typer.Exit(code=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,12 +120,17 @@ test = [
     "pytest-datafiles>=3.0.0",
     "pytest-mock>=3.14.0",
     "pytest-responses>=0.5.1",
-    "responses>=0.25.0"
+    "responses>=0.25.0",
+    "zulip>=0.9.0"
+]
+
+zulip = [
+    "zulip>=0.9.0"
 ]
 
 # Combined extra for development work
 all = [
-    "lftools-uv[dev,ldap,openstack,test]"
+    "lftools-uv[dev,ldap,openstack,test,zulip]"
 ]
 
 [project.urls]

--- a/specs/001-zulip-channel-mgmt/tasks.md
+++ b/specs/001-zulip-channel-mgmt/tasks.md
@@ -32,12 +32,12 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 **Purpose**: Project initialization, dependency addition, and basic file structure
 
-- [ ] T001 Add `zulip` as optional dependency under `[project.optional-dependencies]` in pyproject.toml (installed via `lftools-uv[zulip]`) and run `uv lock`
-- [ ] T002 [P] Create empty module file lftools_uv/api/endpoints/zulip.py with license header and module docstring
-- [ ] T003 [P] Create empty module file lftools_uv/typer_apps/zulip.py with license header, Typer app instantiation, and module docstring
-- [ ] T004 [P] Create empty test files tests/unit/test_zulip_api.py, tests/unit/test_zulip_cli.py, and tests/unit/test_zulip_config.py with license headers
-- [ ] T005 Register the zulip Typer sub-app in lftools_uv/typer_apps/root.py (add `app.add_typer(zulip_app, name="zulip")`)
-- [ ] T006 [P] Implement optional dependency guard in lftools_uv/typer_apps/zulip.py — detect missing `zulip` package at import time, register command group in CLI help regardless, show user-friendly error on invocation if extra not installed (FR-022). Canonical error message:
+- [x] T001 Add `zulip` as optional dependency under `[project.optional-dependencies]` in pyproject.toml (installed via `lftools-uv[zulip]`) and run `uv lock`
+- [x] T002 [P] Create empty module file lftools_uv/api/endpoints/zulip.py with license header and module docstring
+- [x] T003 [P] Create empty module file lftools_uv/typer_apps/zulip.py with license header, Typer app instantiation, and module docstring
+- [x] T004 [P] Create empty test files tests/unit/test_zulip_api.py, tests/unit/test_zulip_cli.py, and tests/unit/test_zulip_config.py with license headers
+- [x] T005 Register the zulip Typer sub-app in lftools_uv/typer_apps/root.py (add `app.add_typer(zulip_app, name="zulip")`)
+- [x] T006 [P] Implement optional dependency guard in lftools_uv/typer_apps/zulip.py — detect missing `zulip` package at import time, register command group in CLI help regardless, show user-friendly error on invocation if extra not installed (FR-022). Canonical error message:
 
   ```text
   Zulip support requires the zulip extra. Install with:
@@ -52,19 +52,19 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T007 Implement ZulipConfig resolution logic in lftools_uv/api/endpoints/zulip.py — resolve config from `--zuliprc` flag > `./zuliprc` > lftools.ini `[zulip]` section > `~/.zuliprc` per FR-011/FR-012 precedence
-- [ ] T008 Implement Zulip client factory function in lftools_uv/api/endpoints/zulip.py — instantiate `zulip.Client` from resolved config, expose `get_client(zuliprc: Path | None) -> zulip.Client`
-- [ ] T009 Implement server feature-level detection in lftools_uv/api/endpoints/zulip.py — call `GET /api/v1/server_settings`, cache `zulip_feature_level`, expose `check_feature_level(client, required_level, feature_name)` that raises a domain error with FR-019 canonical message format
-- [ ] T010 [P] Define domain exception classes in lftools_uv/api/endpoints/zulip.py — `ZulipConfigError`, `ZulipAPIError`, `ZulipFeatureLevelError`, `ZulipAmbiguityError`, `ZulipLockoutError`
-- [ ] T011 [P] Implement shared CLI output helpers in lftools_uv/typer_apps/zulip.py — `--zuliprc` callback, `--json` flag handling, table formatting with `tabulate`, error display with non-zero exit, `MutationResult` JSON formatter
-- [ ] T012 [P] Implement channel target resolution helper in lftools_uv/api/endpoints/zulip.py — resolve channel by name (case-insensitive) or `--channel-id`, search active-only by default, include-archived if flag set, produce helpful "not found" error with `--include-archived` suggestion per FR-018
-- [ ] T013 [P] Implement group resolution helper in lftools_uv/api/endpoints/zulip.py — parse comma-separated group names/IDs from `--allow-group` and `--can-remove-subscribers-group` values, resolve each to numeric group ID, handle `id:NUM` prefix, handle system role group display-name-to-API-name mapping, build group-setting value (simple int or complex form), handle ambiguity errors
-- [ ] T014 [P] Implement user resolution helper in lftools_uv/api/endpoints/zulip.py — resolve user by email, user_id, or full_name per `--by-email`/`--by-id`/`--by-name` flags, detect ambiguous `--by-name` matches and raise `ZulipAmbiguityError` with listing of matching users
-- [ ] T015 Write unit tests for config resolution in tests/unit/test_zulip_config.py — test all four precedence levels, missing config error, malformed file error
-- [ ] T016 [P] Write unit tests for feature-level detection in tests/unit/test_zulip_api.py — test passing/failing feature level checks, canonical error message format
-- [ ] T017 [P] Write unit tests for channel target resolution in tests/unit/test_zulip_api.py — test name match (case-insensitive), ID match, not-found with suggestion, include-archived behavior
-- [ ] T018 [P] Write unit tests for group resolution in tests/unit/test_zulip_api.py — test single name, multiple names, id: prefix, system role groups, ambiguity error, Nobody detection
-- [ ] T019 [P] Write unit tests for user resolution in tests/unit/test_zulip_api.py — test by-email, by-id, by-name, ambiguity error with listing
+- [x] T007 Implement ZulipConfig resolution logic in lftools_uv/api/endpoints/zulip.py — resolve config from `--zuliprc` flag > `./zuliprc` > lftools.ini `[zulip]` section > `~/.zuliprc` per FR-011/FR-012 precedence
+- [x] T008 Implement Zulip client factory function in lftools_uv/api/endpoints/zulip.py — instantiate `zulip.Client` from resolved config, expose `get_client(zuliprc: Path | None) -> zulip.Client`
+- [x] T009 Implement server feature-level detection in lftools_uv/api/endpoints/zulip.py — call `GET /api/v1/server_settings`, cache `zulip_feature_level`, expose `check_feature_level(client, required_level, feature_name)` that raises a domain error with FR-019 canonical message format
+- [x] T010 [P] Define domain exception classes in lftools_uv/api/endpoints/zulip.py — `ZulipConfigError`, `ZulipAPIError`, `ZulipFeatureLevelError`, `ZulipAmbiguityError`, `ZulipLockoutError`
+- [x] T011 [P] Implement shared CLI output helpers in lftools_uv/typer_apps/zulip.py — `--zuliprc` callback, `--json` flag handling, table formatting with `tabulate`, error display with non-zero exit, `MutationResult` JSON formatter
+- [x] T012 [P] Implement channel target resolution helper in lftools_uv/api/endpoints/zulip.py — resolve channel by name (case-insensitive) or `--channel-id`, search active-only by default, include-archived if flag set, produce helpful "not found" error with `--include-archived` suggestion per FR-018
+- [x] T013 [P] Implement group resolution helper in lftools_uv/api/endpoints/zulip.py — parse comma-separated group names/IDs from `--allow-group` and `--can-remove-subscribers-group` values, resolve each to numeric group ID, handle `id:NUM` prefix, handle system role group display-name-to-API-name mapping, build group-setting value (simple int or complex form), handle ambiguity errors
+- [x] T014 [P] Implement user resolution helper in lftools_uv/api/endpoints/zulip.py — resolve user by email, user_id, or full_name per `--by-email`/`--by-id`/`--by-name` flags, detect ambiguous `--by-name` matches and raise `ZulipAmbiguityError` with listing of matching users
+- [x] T015 Write unit tests for config resolution in tests/unit/test_zulip_config.py — test all four precedence levels, missing config error, malformed file error
+- [x] T016 [P] Write unit tests for feature-level detection in tests/unit/test_zulip_api.py — test passing/failing feature level checks, canonical error message format
+- [x] T017 [P] Write unit tests for channel target resolution in tests/unit/test_zulip_api.py — test name match (case-insensitive), ID match, not-found with suggestion, include-archived behavior
+- [x] T018 [P] Write unit tests for group resolution in tests/unit/test_zulip_api.py — test single name, multiple names, id: prefix, system role groups, ambiguity error, Nobody detection
+- [x] T019 [P] Write unit tests for user resolution in tests/unit/test_zulip_api.py — test by-email, by-id, by-name, ambiguity error with listing
 
 **Checkpoint**: Foundation ready — user story implementation can now begin
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Unit test package for lftools-uv."""

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -28,11 +28,14 @@ from lftools_uv.api.endpoints.zulip import (
     FEATURE_LEVELS,
     SYSTEM_ROLE_GROUPS,
     ZulipAmbiguityError,
+    ZulipConfig,
+    ZulipConfigError,
     ZulipFeatureLevelError,
     ZulipLockoutError,
     ZulipNotFoundError,
     ZulipValidationError,
     check_feature_level,
+    get_client,
     get_server_feature_level,
     resolve_channel,
     resolve_groups,
@@ -345,3 +348,27 @@ def test_resolve_users_id_mode_requires_numeric() -> None:
     client = _members_client(MEMBERS)
     with pytest.raises(ZulipValidationError):
         _ = resolve_users(client, ["not-a-number"], mode="id")
+
+
+# ---------------------------------------------------------------------------
+# Client factory — credential validation
+# ---------------------------------------------------------------------------
+
+
+def test_get_client_rejects_incomplete_credentials() -> None:
+    """``get_client`` errors clearly when synthesized creds are incomplete."""
+    config = ZulipConfig(email="bot@example.com", source="lftools.ini[zulip]")
+    with pytest.raises(ZulipConfigError, match="missing api_key, site"):
+        _ = get_client(config=config)
+
+
+def test_get_client_rejects_both_inputs() -> None:
+    """``zuliprc`` and ``config`` are mutually exclusive inputs."""
+    config = ZulipConfig(
+        email="bot@example.com",
+        api_key="k",
+        site="https://z",
+        source="lftools.ini[zulip]",
+    )
+    with pytest.raises(ZulipValidationError):
+        _ = get_client(zuliprc=mock.MagicMock(), config=config)

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -7,7 +7,341 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 ##############################################################################
-"""Unit tests for the Zulip API endpoint layer.
+"""Unit tests for the Zulip API endpoint helpers.
 
-Tests are populated by subsequent tasks in the implementation plan.
+Covers the foundational tasks T016–T019:
+
+* T016 — feature-level detection
+* T017 — channel target resolution
+* T018 — group resolution
+* T019 — user resolution
 """
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from lftools_uv.api.endpoints.zulip import (
+    FEATURE_LEVELS,
+    SYSTEM_ROLE_GROUPS,
+    ZulipAmbiguityError,
+    ZulipFeatureLevelError,
+    ZulipLockoutError,
+    ZulipNotFoundError,
+    ZulipValidationError,
+    check_feature_level,
+    get_server_feature_level,
+    resolve_channel,
+    resolve_groups,
+    resolve_users,
+)
+
+# ---------------------------------------------------------------------------
+# T016 — Feature-level detection
+# ---------------------------------------------------------------------------
+
+
+def _make_client(**responses: Any) -> Any:
+    """Return a mock client with attribute-style API call stubs."""
+    client = mock.MagicMock()
+    if "server_settings" in responses:
+        client.get_server_settings.return_value = responses["server_settings"]
+    if "streams" in responses:
+        client.call_endpoint.side_effect = None
+        client.call_endpoint.return_value = responses["streams"]
+    if "members" in responses:
+        client.get_members.return_value = responses["members"]
+    return client
+
+
+def test_feature_level_caches_per_client() -> None:
+    """``get_server_feature_level`` caches the value on the client."""
+    client = _make_client(
+        server_settings={"result": "success", "zulip_feature_level": 200},
+    )
+    assert get_server_feature_level(client) == 200
+    assert get_server_feature_level(client) == 200
+    assert client.get_server_settings.call_count == 1
+
+
+def test_check_feature_level_passes_when_sufficient() -> None:
+    """No error is raised when the server level meets the requirement."""
+    client = _make_client(
+        server_settings={"result": "success", "zulip_feature_level": 200},
+    )
+    check_feature_level(client, required_level=100, feature_name="topic-policy")
+
+
+def test_check_feature_level_raises_canonical_error() -> None:
+    """FR-019 canonical error string is produced when level too low."""
+    client = _make_client(
+        server_settings={"result": "success", "zulip_feature_level": 50},
+    )
+    with pytest.raises(ZulipFeatureLevelError) as exc_info:
+        check_feature_level(client, required_level=161, feature_name="x")
+    assert str(exc_info.value) == ("This operation requires Zulip feature level 161 (server has 50)")
+    assert exc_info.value.required == 161
+    assert exc_info.value.actual == 50
+
+
+def test_feature_level_table_contains_expected_keys() -> None:
+    """The hardcoded threshold table covers every feature the spec mentions."""
+    for key in (
+        "web-public",
+        "can-access-group",
+        "can-remove-subscribers-group",
+        "topic-policy",
+        "unarchive",
+    ):
+        assert key in FEATURE_LEVELS
+        assert isinstance(FEATURE_LEVELS[key], int)
+        assert FEATURE_LEVELS[key] >= 0
+
+
+# ---------------------------------------------------------------------------
+# T017 — Channel target resolution
+# ---------------------------------------------------------------------------
+
+
+ACTIVE_STREAMS = [
+    {"stream_id": 1, "name": "general", "description": "g", "is_archived": False},
+    {"stream_id": 2, "name": "Engineering", "description": "e", "is_archived": False},
+]
+ARCHIVED_STREAMS = ACTIVE_STREAMS + [
+    {"stream_id": 99, "name": "old-channel", "description": "", "is_archived": True},
+]
+
+
+def _streams_client(active: list[dict[str, Any]], archived: list[dict[str, Any]]) -> Any:
+    """Return a client whose ``streams`` endpoint returns the given lists.
+
+    The first call (without ``include_archived``) returns ``active``;
+    subsequent calls (with ``include_archived`` true) return ``archived``.
+    """
+    client = mock.MagicMock()
+
+    def side_effect(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:
+        assert url == "streams"
+        assert method == "GET"
+        if request and request.get("include_archived"):
+            return {"result": "success", "streams": archived}
+        return {"result": "success", "streams": active}
+
+    client.call_endpoint.side_effect = side_effect
+    return client
+
+
+def test_resolve_channel_by_name_case_insensitive() -> None:
+    """Channel name matching ignores case per FR-018."""
+    client = _streams_client(ACTIVE_STREAMS, ARCHIVED_STREAMS)
+    result = resolve_channel(client, name="GENERAL")
+    assert result["stream_id"] == 1
+
+
+def test_resolve_channel_by_id() -> None:
+    """Channel id lookup returns the matching stream dict."""
+    client = _streams_client(ACTIVE_STREAMS, ARCHIVED_STREAMS)
+    result = resolve_channel(client, channel_id=2)
+    assert result["name"] == "Engineering"
+
+
+def test_resolve_channel_not_found_suggests_include_archived() -> None:
+    """The not-found error mentions --include-archived for archived hits."""
+    client = _streams_client(ACTIVE_STREAMS, ARCHIVED_STREAMS)
+    with pytest.raises(ZulipNotFoundError, match="--include-archived"):
+        _ = resolve_channel(client, name="old-channel")
+
+
+def test_resolve_channel_genuinely_missing() -> None:
+    """A non-existent channel produces a plain not-found error."""
+    client = _streams_client(ACTIVE_STREAMS, ARCHIVED_STREAMS)
+    with pytest.raises(ZulipNotFoundError, match="not found"):
+        _ = resolve_channel(client, name="never-existed")
+
+
+def test_resolve_channel_include_archived_returns_archived() -> None:
+    """When ``include_archived`` is True, archived channels match directly."""
+    client = _streams_client(ACTIVE_STREAMS, ARCHIVED_STREAMS)
+    result = resolve_channel(client, name="old-channel", include_archived=True)
+    assert result["stream_id"] == 99
+
+
+def test_resolve_channel_rejects_missing_target() -> None:
+    """Exactly one of name/channel_id must be supplied."""
+    client = _streams_client(ACTIVE_STREAMS, ARCHIVED_STREAMS)
+    with pytest.raises(ZulipValidationError):
+        _ = resolve_channel(client)
+    with pytest.raises(ZulipValidationError):
+        _ = resolve_channel(client, name="x", channel_id=1)
+
+
+# ---------------------------------------------------------------------------
+# T018 — Group resolution
+# ---------------------------------------------------------------------------
+
+
+GROUPS = [
+    {"id": 10, "name": "engineering", "is_system_group": False},
+    {"id": 11, "name": "Engineering", "is_system_group": False},
+    {"id": 20, "name": "role:administrators", "is_system_group": True},
+    {"id": 21, "name": "role:nobody", "is_system_group": True},
+    {"id": 22, "name": "role:members", "is_system_group": True},
+    {"id": 30, "name": "design", "is_system_group": False},
+]
+
+
+def _groups_client(groups: list[dict[str, Any]]) -> Any:
+    client = mock.MagicMock()
+    client.call_endpoint.return_value = {
+        "result": "success",
+        "user_groups": groups,
+    }
+    return client
+
+
+def test_resolve_groups_single_custom_group_returns_int() -> None:
+    """A single custom group resolves to a simple integer setting value."""
+    client = _groups_client(GROUPS)
+    _, value = resolve_groups(client, "design")
+    assert value == 30
+
+
+def test_resolve_groups_multiple_groups_returns_complex_form() -> None:
+    """Multiple groups produce the direct_subgroups complex form."""
+    client = _groups_client(GROUPS)
+    _, value = resolve_groups(client, "design, id:10")
+    assert value == {"direct_members": [], "direct_subgroups": [30, 10]}
+
+
+def test_resolve_groups_id_prefix() -> None:
+    """The ``id:NUM`` prefix forces ID-based lookup."""
+    client = _groups_client(GROUPS)
+    resolved, value = resolve_groups(client, "id:11")
+    assert resolved[0]["id"] == 11
+    assert value == 11
+
+
+def test_resolve_groups_system_role_display_name() -> None:
+    """System role display names map to their internal ``role:`` API name."""
+    client = _groups_client(GROUPS)
+    resolved, value = resolve_groups(client, "Administrators")
+    assert resolved[0]["name"] == "role:administrators"
+    assert value == 20
+    # Mapping table covers every role per spec.
+    assert "owners" in SYSTEM_ROLE_GROUPS
+    assert SYSTEM_ROLE_GROUPS["owners"] == "role:owners"
+
+
+def test_resolve_groups_ambiguity_raises() -> None:
+    """A case-insensitive collision between custom groups raises ambiguity."""
+    client = _groups_client(GROUPS)
+    with pytest.raises(ZulipAmbiguityError) as exc:
+        _ = resolve_groups(client, "engineering")
+    assert exc.value.matches  # listing populated
+    assert {m["id"] for m in exc.value.matches} == {10, 11}
+
+
+def test_resolve_groups_nobody_rejected_when_not_allowed() -> None:
+    """``Nobody`` alone fails lockout prevention when ``allow_nobody=False``."""
+    client = _groups_client(GROUPS)
+    with pytest.raises(ZulipLockoutError):
+        _ = resolve_groups(client, "Nobody", allow_nobody=False)
+
+
+def test_resolve_groups_nobody_allowed_by_default() -> None:
+    """``Nobody`` is allowed by default (e.g. for ``channel update``)."""
+    client = _groups_client(GROUPS)
+    _, value = resolve_groups(client, "Nobody")
+    assert value == 21
+
+
+def test_resolve_groups_empty_spec_rejected() -> None:
+    """An empty or whitespace-only spec is rejected with a clear error."""
+    client = _groups_client(GROUPS)
+    with pytest.raises(ZulipValidationError):
+        _ = resolve_groups(client, "  ,  ")
+
+
+# ---------------------------------------------------------------------------
+# T019 — User resolution
+# ---------------------------------------------------------------------------
+
+
+MEMBERS = [
+    {
+        "user_id": 100,
+        "full_name": "Alice Smith",
+        "email": "alice@example.com",
+        "delivery_email": "alice@example.com",
+        "is_bot": False,
+        "is_active": True,
+    },
+    {
+        "user_id": 101,
+        "full_name": "Alice Smith",
+        "email": "alice2@example.com",
+        "delivery_email": "alice2@example.com",
+        "is_bot": False,
+        "is_active": True,
+    },
+    {
+        "user_id": 200,
+        "full_name": "Bob Jones",
+        "email": "bob@example.com",
+        "delivery_email": "bob@example.com",
+        "is_bot": False,
+        "is_active": True,
+    },
+]
+
+
+def _members_client(members: list[dict[str, Any]]) -> Any:
+    client = mock.MagicMock()
+    client.get_members.return_value = {"result": "success", "members": members}
+    return client
+
+
+def test_resolve_users_by_email() -> None:
+    """Email lookup is unique and case-sensitive (Zulip rule)."""
+    client = _members_client(MEMBERS)
+    users = resolve_users(client, ["bob@example.com"], mode="email")
+    assert [u["user_id"] for u in users] == [200]
+
+
+def test_resolve_users_by_id() -> None:
+    """Numeric ID lookup parses ints from the CLI string."""
+    client = _members_client(MEMBERS)
+    users = resolve_users(client, ["101"], mode="id")
+    assert users[0]["full_name"] == "Alice Smith"
+
+
+def test_resolve_users_by_name_ambiguous_raises() -> None:
+    """Full name collisions raise :class:`ZulipAmbiguityError`."""
+    client = _members_client(MEMBERS)
+    with pytest.raises(ZulipAmbiguityError) as exc:
+        _ = resolve_users(client, ["Alice Smith"], mode="name")
+    assert {m["user_id"] for m in exc.value.matches} == {100, 101}
+
+
+def test_resolve_users_by_name_unique() -> None:
+    """A unique full-name match resolves successfully."""
+    client = _members_client(MEMBERS)
+    users = resolve_users(client, ["Bob Jones"], mode="name")
+    assert users[0]["user_id"] == 200
+
+
+def test_resolve_users_not_found() -> None:
+    """An unknown identifier produces :class:`ZulipNotFoundError`."""
+    client = _members_client(MEMBERS)
+    with pytest.raises(ZulipNotFoundError):
+        _ = resolve_users(client, ["nobody@example.com"], mode="email")
+
+
+def test_resolve_users_id_mode_requires_numeric() -> None:
+    """--by-id rejects non-numeric identifiers with a clear error."""
+    client = _members_client(MEMBERS)
+    with pytest.raises(ZulipValidationError):
+        _ = resolve_users(client, ["not-a-number"], mode="id")

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Unit tests for the Zulip API endpoint layer.
+
+Tests are populated by subsequent tasks in the implementation plan.
+"""

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -268,6 +268,14 @@ def test_resolve_groups_empty_spec_rejected() -> None:
         _ = resolve_groups(client, "  ,  ")
 
 
+def test_resolve_groups_tolerates_extra_commas() -> None:
+    """Empty inner segments are stripped (lenient parsing, documented)."""
+    client = _groups_client(GROUPS)
+    resolved, value = resolve_groups(client, "design, , id:11")
+    assert [g["id"] for g in resolved] == [30, 11]
+    assert value == {"direct_members": [], "direct_subgroups": [30, 11]}
+
+
 # ---------------------------------------------------------------------------
 # T019 — User resolution
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -17,7 +17,12 @@ from __future__ import annotations
 import pytest
 from typer.testing import CliRunner
 
-from lftools_uv.typer_apps.zulip import MISSING_EXTRA_MESSAGE, zulip_app
+from lftools_uv.typer_apps.zulip import (
+    MISSING_EXTRA_MESSAGE,
+    bulk_mutation_result,
+    mutation_result,
+    zulip_app,
+)
 
 
 def test_zulip_app_registered() -> None:
@@ -49,3 +54,75 @@ def test_zulip_help_works_without_extra(monkeypatch: pytest.MonkeyPatch) -> None
     result = runner.invoke(zulip_app, ["--help"])
     assert result.exit_code == 0
     assert "zulip" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Output-shape helpers
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_result_minimal_payload() -> None:
+    """``mutation_result`` always returns the four canonical fields."""
+    payload = mutation_result(
+        status="success",
+        operation="create",
+        channel_id=42,
+        channel_name="general",
+    )
+    assert payload == {
+        "status": "success",
+        "channel_id": 42,
+        "channel_name": "general",
+        "operation": "create",
+    }
+
+
+def test_mutation_result_merges_extra_fields() -> None:
+    """Operation-specific extras (e.g. ``type``) merge into the result."""
+    payload = mutation_result(
+        status="success",
+        operation="create",
+        channel_id=42,
+        channel_name="general",
+        extra={"type": "public"},
+    )
+    assert payload["type"] == "public"
+    assert payload["status"] == "success"
+
+
+def test_bulk_mutation_result_success_status() -> None:
+    """Bulk results with only successes derive ``status == 'success'``."""
+    payload = bulk_mutation_result(
+        operation="subscribe",
+        channel_id=42,
+        channel_name="general",
+        results=[{"user": "a", "status": "subscribed"}],
+        errors=[],
+    )
+    assert payload["status"] == "success"
+    assert payload["results"] == [{"user": "a", "status": "subscribed"}]
+    assert payload["errors"] == []
+
+
+def test_bulk_mutation_result_partial_status() -> None:
+    """A mix of results and errors derives ``status == 'partial'``."""
+    payload = bulk_mutation_result(
+        operation="subscribe",
+        channel_id=42,
+        channel_name="general",
+        results=[{"user": "a", "status": "subscribed"}],
+        errors=[{"user": "b", "error": "not found"}],
+    )
+    assert payload["status"] == "partial"
+
+
+def test_bulk_mutation_result_error_status() -> None:
+    """All-error bulk results derive ``status == 'error'``."""
+    payload = bulk_mutation_result(
+        operation="subscribe",
+        channel_id=42,
+        channel_name="general",
+        results=[],
+        errors=[{"user": "b", "error": "not found"}],
+    )
+    assert payload["status"] == "error"

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -9,7 +9,10 @@
 ##############################################################################
 """Unit tests for the Zulip Typer CLI layer.
 
-Tests are populated by subsequent tasks in the implementation plan.
+Covers the foundation helpers (``MISSING_EXTRA_MESSAGE`` guard,
+``--help`` resilient-parsing short-circuit, ``mutation_result`` and
+``bulk_mutation_result`` output shaping). Per-command tests live
+alongside the user-story slices that introduce them.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -14,6 +14,7 @@ Tests are populated by subsequent tasks in the implementation plan.
 
 from __future__ import annotations
 
+import pytest
 from typer.testing import CliRunner
 
 from lftools_uv.typer_apps.zulip import MISSING_EXTRA_MESSAGE, zulip_app
@@ -31,3 +32,20 @@ def test_missing_extra_message_is_canonical() -> None:
     """The FR-022 canonical install hint must be exposed for reuse."""
     assert 'pip install "lftools-uv[zulip]"' in MISSING_EXTRA_MESSAGE
     assert MISSING_EXTRA_MESSAGE.startswith("Zulip support requires the zulip extra.")
+
+
+def test_zulip_help_works_without_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--help`` for the zulip group must render even when the extra is gone.
+
+    Typer walks the command tree with ``resilient_parsing=True`` while
+    rendering help, so the top-level callback must short-circuit before
+    enforcing the FR-022 extra-required guard. Otherwise users could not
+    discover commands until after installing the extra.
+    """
+    import lftools_uv.typer_apps.zulip as zulip_mod
+
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: False)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["--help"])
+    assert result.exit_code == 0
+    assert "zulip" in result.stdout.lower()

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Unit tests for the Zulip Typer CLI layer.
+
+Tests are populated by subsequent tasks in the implementation plan.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from lftools_uv.typer_apps.zulip import MISSING_EXTRA_MESSAGE, zulip_app
+
+
+def test_zulip_app_registered() -> None:
+    """The zulip Typer app exposes help even without subcommands."""
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["--help"])
+    assert result.exit_code == 0
+    assert "zulip" in result.stdout.lower()
+
+
+def test_missing_extra_message_is_canonical() -> None:
+    """The FR-022 canonical install hint must be exposed for reuse."""
+    assert 'pip install "lftools-uv[zulip]"' in MISSING_EXTRA_MESSAGE
+    assert MISSING_EXTRA_MESSAGE.startswith("Zulip support requires the zulip extra.")

--- a/tests/unit/test_zulip_config.py
+++ b/tests/unit/test_zulip_config.py
@@ -7,7 +7,123 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 ##############################################################################
-"""Unit tests for Zulip configuration resolution.
+"""Unit tests for Zulip configuration resolution (T015)."""
 
-Tests are populated by subsequent tasks in the implementation plan.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from lftools_uv.api.endpoints.zulip import (
+    ZulipConfigError,
+    resolve_config,
+)
+
+ZULIPRC_CONTENT = """\
+[api]
+email=bot@example.com
+key=apikey1234
+site=https://zulip.example.com
 """
+
+
+@pytest.fixture()
+def zuliprc_file(tmp_path: Path) -> Path:
+    """Return a path to a valid zuliprc file."""
+    path = tmp_path / "zuliprc"
+    _ = path.write_text(ZULIPRC_CONTENT, encoding="utf-8")
+    return path
+
+
+def test_resolve_config_uses_explicit_zuliprc(zuliprc_file: Path, tmp_path: Path) -> None:
+    """The --zuliprc argument wins over every other source."""
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    config = resolve_config(zuliprc=zuliprc_file, cwd=cwd, home=cwd)
+    assert config.config_path == zuliprc_file
+    assert config.source == str(zuliprc_file)
+
+
+def test_resolve_config_falls_back_to_cwd_zuliprc(tmp_path: Path) -> None:
+    """A ./zuliprc file in the cwd is the second precedence level."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    rc = cwd / "zuliprc"
+    _ = rc.write_text(ZULIPRC_CONTENT, encoding="utf-8")
+    config = resolve_config(zuliprc=None, cwd=cwd, home=tmp_path / "home")
+    assert config.config_path == rc
+
+
+def test_resolve_config_uses_lftools_ini(tmp_path: Path) -> None:
+    """The ``[zulip]`` section in lftools.ini is the third level."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    with (
+        mock.patch(
+            "lftools_uv.api.endpoints.zulip.lf_config.has_section",
+            return_value=True,
+        ),
+        mock.patch(
+            "lftools_uv.api.endpoints.zulip.lf_config.get_setting",
+            side_effect=[
+                "bot@example.com",
+                "apikey1234",
+                "https://zulip.example.com",
+            ],
+        ),
+    ):
+        config = resolve_config(zuliprc=None, cwd=cwd, home=home)
+    assert config.config_path is None
+    assert config.email == "bot@example.com"
+    assert config.api_key == "apikey1234"
+    assert config.site == "https://zulip.example.com"
+    assert config.source == "lftools.ini[zulip]"
+
+
+def test_resolve_config_falls_back_to_home_zuliprc(tmp_path: Path) -> None:
+    """``~/.zuliprc`` is the final fallback in the precedence chain."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    rc = home / ".zuliprc"
+    _ = rc.write_text(ZULIPRC_CONTENT, encoding="utf-8")
+    with mock.patch(
+        "lftools_uv.api.endpoints.zulip.lf_config.has_section",
+        return_value=False,
+    ):
+        config = resolve_config(zuliprc=None, cwd=cwd, home=home)
+    assert config.config_path == rc
+
+
+def test_resolve_config_missing_all_sources(tmp_path: Path) -> None:
+    """A clear error is raised when no source produces a configuration."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch(
+        "lftools_uv.api.endpoints.zulip.lf_config.has_section",
+        return_value=False,
+    ):
+        with pytest.raises(ZulipConfigError, match="No Zulip configuration found"):
+            _ = resolve_config(zuliprc=None, cwd=cwd, home=home)
+
+
+def test_resolve_config_explicit_path_missing(tmp_path: Path) -> None:
+    """--zuliprc that points at a non-existent path fails clearly."""
+    missing = tmp_path / "no-such-file"
+    with pytest.raises(ZulipConfigError, match="does not exist"):
+        _ = resolve_config(zuliprc=missing)
+
+
+def test_resolve_config_malformed_file(tmp_path: Path) -> None:
+    """A zuliprc without the [api] section is rejected with a clear error."""
+    rc = tmp_path / "zuliprc"
+    _ = rc.write_text("[other]\nfoo=bar\n", encoding="utf-8")
+    with pytest.raises(ZulipConfigError, match=r"missing required \[api\] section"):
+        _ = resolve_config(zuliprc=rc)

--- a/tests/unit/test_zulip_config.py
+++ b/tests/unit/test_zulip_config.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Unit tests for Zulip configuration resolution.
+
+Tests are populated by subsequent tasks in the implementation plan.
+"""

--- a/uv.lock
+++ b/uv.lock
@@ -651,6 +651,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1063,6 +1072,7 @@ all = [
     { name = "types-requests" },
     { name = "types-tabulate" },
     { name = "types-tqdm" },
+    { name = "zulip" },
 ]
 dev = [
     { name = "bandit" },
@@ -1099,6 +1109,10 @@ test = [
     { name = "pytest-mock" },
     { name = "pytest-responses" },
     { name = "responses" },
+    { name = "zulip" },
+]
+zulip = [
+    { name = "zulip" },
 ]
 
 [package.dev-dependencies]
@@ -1201,8 +1215,11 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.6.3,<3.0.0" },
     { name = "websocket-client" },
     { name = "wrapt" },
+    { name = "zulip", marker = "extra == 'all'", specifier = ">=0.9.0" },
+    { name = "zulip", marker = "extra == 'test'", specifier = ">=0.9.0" },
+    { name = "zulip", marker = "extra == 'zulip'", specifier = ">=0.9.0" },
 ]
-provides-extras = ["all", "dev", "docs", "ldap", "openstack", "test"]
+provides-extras = ["all", "dev", "docs", "ldap", "openstack", "test", "zulip"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3259,4 +3276,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "zulip"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/74/3fbf8dab5035724f32c7c8c39a20f1e5b1a081fa8bfe4883d8f64d560999/zulip-0.9.1.tar.gz", hash = "sha256:abeba4147625107f690bb633143fdf36cd665fe037b3871011fd4b1e3dc081e8", size = 149751, upload-time = "2025-09-30T22:01:44.693Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/41/0507da59eae2ebb4641895a189eb6438b76610c06c65aa06310b755d3aa7/zulip-0.9.1-py3-none-any.whl", hash = "sha256:37682bad54714a53f9286586a534c2e13217b2bbddf0b4e71c60ef67d43b9043", size = 332200, upload-time = "2025-09-30T22:01:40.154Z" },
 ]


### PR DESCRIPTION
Introduces the optional ``zulip`` extra plus the Setup and Foundation
phases of the Zulip channel management feature. CLI subcommands
themselves arrive in subsequent stacked PRs (one per user story).

## Spec

See [`specs/001-zulip-channel-mgmt/`](specs/001-zulip-channel-mgmt/)
for the full design — particularly:

* [`spec.md`](specs/001-zulip-channel-mgmt/spec.md) — functional
  requirements (FR-008/011/012/018/019/022 are directly exercised here).
* [`plan.md`](specs/001-zulip-channel-mgmt/plan.md) — implementation plan
  (incremental delivery model).
* [`tasks.md`](specs/001-zulip-channel-mgmt/tasks.md) — task breakdown.

## What's in this PR

* **T001** — declare ``zulip`` as an optional ``[zulip]`` extra in
  ``pyproject.toml`` and refresh ``uv.lock``; include it in the ``test``
  and ``all`` extras so the new test suite can import it.
* **T002–T006** — scaffold ``lftools_uv/api/endpoints/zulip.py`` and
  ``lftools_uv/typer_apps/zulip.py``, register the Typer sub-app in
  ``root.py``, and implement the FR-022 optional-dependency guard so the
  ``lftools-uv zulip`` group always appears in CLI help while invocation
  without the extra fails with the canonical install hint.
* **T007–T014** — foundational API helpers:
  * ``ZulipConfig`` + ``resolve_config()`` with the
    ``--zuliprc`` > ``./zuliprc`` > ``lftools.ini[zulip]`` > ``~/.zuliprc``
    precedence chain (FR-011/FR-012).
  * ``get_client()`` factory for ``zulip.Client`` (file or synthesized
    credentials).
  * ``get_server_feature_level()`` (cached) and ``check_feature_level()``
    raising the FR-019 canonical error string
    ``This operation requires Zulip feature level X (server has Y)``.
  * Hardcoded ``FEATURE_LEVELS`` table covering web-public,
    can-access-group, can-remove-subscribers-group, topic-policy, and
    unarchive. **Reviewers**: please verify the threshold values against
    the current Zulip changelog — these are the implementation defaults
    and can be tuned in follow-up PRs as each feature lands.
  * Domain exceptions (``ZulipConfigError``, ``ZulipAPIError``,
    ``ZulipFeatureLevelError``, ``ZulipAmbiguityError``,
    ``ZulipNotFoundError``, ``ZulipLockoutError``,
    ``ZulipValidationError``).
  * ``resolve_channel`` / ``resolve_users`` / ``resolve_groups`` helpers
    (case-insensitive matching, FR-018 ``--include-archived`` hinting,
    system-role display-name mapping, comma-separated group syntax with
    ``id:`` prefix disambiguation, lockout detection for ``Nobody``).
* **T011** — shared CLI output helpers in ``typer_apps/zulip.py``:
  ``emit_table`` / ``emit_json`` / ``handle_zulip_error`` plus the
  ``mutation_result`` and ``bulk_mutation_result`` builders matching the
  schemas in ``contracts/cli-commands.md``.
* **T015–T019** — unit tests covering every foundation helper in
  ``tests/unit/test_zulip_config.py`` and
  ``tests/unit/test_zulip_api.py``.

## What's NOT in this PR

User-facing subcommands. Subsequent stacked PRs implement:

* PR B — ``channel list`` (US1)
* PR C — ``user list`` (US2)
* PR D — ``group list`` (US3)
* PR E — ``channel create`` (US4)
* PR F/G/H — ``channel subscribe`` / ``unsubscribe`` / ``subscribers`` (US5–US7)
* PR I/J/K — ``channel update`` / ``archive`` / ``unarchive`` (US8–US10)
* PR L — ``channel topic-policy`` convenience command
* PR M — polish (help text, docs, REUSE)

## Test plan

* ``uv run pytest tests/`` — 408 tests pass (375 pre-existing + 33 new).
* ``uv run ruff check .`` and ``uv run ruff format --check .`` — clean.
* ``uv run --with basedpyright basedpyright lftools_uv/api/endpoints/zulip.py lftools_uv/typer_apps/zulip.py`` —
  0 errors / 0 warnings on the new files.
* ``LFTOOLS_CLI_V2=1 uv run lftools-uv zulip --help`` — command group
  visible.
* Without the ``zulip`` extra installed, invoking any (future)
  subcommand will print the canonical FR-022 hint.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>