### PR TITLE
Feat(zulip): List groups (US3)

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -779,11 +779,11 @@ def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
     Maps system role groups to their display names per
     :data:`SYSTEM_ROLE_DISPLAY_NAMES`; custom group names pass through
     unchanged. ``member_count`` is derived from the ``members`` array
-    length.
+    length, or ``0`` when the server omits ``members``.
 
     Raises :class:`ZulipAPIError` when required fields are missing or
     have unexpected types — ``id`` must be an int, ``name`` must be a
-    non-empty string, ``members`` must be a list, and
+    non-empty string, ``members`` must be a list when present, and
     ``is_system_group`` (when present) must be a ``bool``. The
     ``description`` field is coerced to a string (Zulip historically
     returns an empty string when not set, but ``None`` is also

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -749,3 +749,74 @@ def list_users(
             continue
         result.append(_normalize_user(member))
     return result
+
+
+# ---------------------------------------------------------------------------
+# Group listing (US3)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw ``user_groups`` API entry to the lftools schema.
+
+    Maps system role groups to their display names per
+    :data:`SYSTEM_ROLE_DISPLAY_NAMES`; custom group names pass through
+    unchanged. ``member_count`` is derived from the ``members`` array
+    length when the server omits an explicit count.
+    """
+    is_system = bool(raw.get("is_system_group", False))
+    api_name = str(raw.get("name", ""))
+    if is_system:
+        display = SYSTEM_ROLE_DISPLAY_NAMES.get(api_name, api_name)
+    else:
+        display = api_name
+    members = raw.get("members", [])
+    member_count = len(members) if isinstance(members, list) else 0
+    return {
+        "group_id": raw.get("id"),
+        "name": display,
+        "description": str(raw.get("description", "") or ""),
+        "member_count": member_count,
+        "type": "system" if is_system else "custom",
+    }
+
+
+def list_groups(
+    client: Any,
+    *,
+    group_name: str | None = None,
+    group_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """List Zulip user groups (custom and system role groups).
+
+    Returns a list of normalized group dicts with keys ``group_id``,
+    ``name``, ``description``, ``member_count``, and ``type`` (either
+    ``"custom"`` or ``"system"``). System role groups are returned with
+    their human display name (e.g. ``"Administrators"``) rather than
+    the internal ``role:administrators`` API name.
+
+    ``group_name`` and ``group_id`` are mutually exclusive filters.
+    ``group_name`` matching is case-insensitive against the display
+    name and applies after the system-role name mapping; a collision
+    that resolves to more than one group raises
+    :class:`ZulipAmbiguityError` with the matches listed.
+    """
+    if group_name is not None and group_id is not None:
+        raise ZulipValidationError("list_groups: --group-name and --group-id are mutually exclusive")
+    raw_groups = _fetch_groups(client)
+    groups = [_normalize_group(raw) for raw in raw_groups]
+
+    if group_id is not None:
+        return [g for g in groups if g["group_id"] == group_id]
+
+    if group_name is not None:
+        target = group_name.casefold()
+        matches = [g for g in groups if str(g["name"]).casefold() == target]
+        if len(matches) > 1:
+            raise ZulipAmbiguityError(
+                f"Group name {group_name!r} matched {len(matches)} groups; use --group-id to disambiguate",
+                matches=[{"group_id": m["group_id"], "name": m["name"]} for m in matches],
+            )
+        return matches
+
+    return groups

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -836,7 +836,7 @@ def list_groups(
     :class:`ZulipAmbiguityError` with the matches listed.
     """
     if group_name is not None and group_id is not None:
-        raise ZulipValidationError("Specify only one of 'group_name' or 'group_id', not both")
+        raise ZulipValidationError("Specify only one of --group-name or --group-id, not both")
     raw_groups = _fetch_groups(client)
     normalized: list[dict[str, Any]] = []
     for raw in raw_groups:

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -522,6 +522,23 @@ SYSTEM_ROLE_GROUPS: dict[str, str] = {
 }
 
 
+#: Reverse of :data:`SYSTEM_ROLE_GROUPS`: maps the Zulip ``role:`` API name
+#: to the human-facing display name presented in ``group list`` output and
+#: accepted by ``--allow-group``/``--can-remove-subscribers-group``.
+#:
+#: Derived from :data:`SYSTEM_ROLE_GROUPS` to avoid drift — display names
+#: are Title Case versions of the lowercase keys, with the historical
+#: ``Full Members`` two-word form preserved.
+def _build_system_role_display_names() -> dict[str, str]:
+    overrides = {"full members": "Full Members"}
+    return {
+        api_name: overrides.get(display.lower(), display.title()) for display, api_name in SYSTEM_ROLE_GROUPS.items()
+    }
+
+
+SYSTEM_ROLE_DISPLAY_NAMES: dict[str, str] = _build_system_role_display_names()
+
+
 def _fetch_groups(client: Any) -> list[dict[str, Any]]:
     """Return the raw user_groups listing from the Zulip server."""
     try:
@@ -762,21 +779,32 @@ def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
     Maps system role groups to their display names per
     :data:`SYSTEM_ROLE_DISPLAY_NAMES`; custom group names pass through
     unchanged. ``member_count`` is derived from the ``members`` array
-    length when the server omits an explicit count.
+    length.
+
+    Raises :class:`ZulipAPIError` when required fields are missing or
+    have unexpected types — keeping the behaviour consistent with
+    :func:`resolve_groups`, which already validates ``id`` is an int.
     """
+    raw_id = raw.get("id")
+    if not isinstance(raw_id, int):
+        raise ZulipAPIError(f"Group object missing numeric 'id': {raw!r}")
+    api_name = raw.get("name")
+    if not isinstance(api_name, str) or not api_name:
+        raise ZulipAPIError(f"Group object missing string 'name': {raw!r}")
+    members = raw.get("members", [])
+    if not isinstance(members, list):
+        raise ZulipAPIError(f"Group object has non-list 'members': {raw!r}")
     is_system = bool(raw.get("is_system_group", False))
-    api_name = str(raw.get("name", ""))
     if is_system:
         display = SYSTEM_ROLE_DISPLAY_NAMES.get(api_name, api_name)
     else:
         display = api_name
-    members = raw.get("members", [])
-    member_count = len(members) if isinstance(members, list) else 0
+    description = raw.get("description", "") or ""
     return {
-        "group_id": raw.get("id"),
+        "group_id": raw_id,
         "name": display,
-        "description": str(raw.get("description", "") or ""),
-        "member_count": member_count,
+        "description": str(description),
+        "member_count": len(members),
         "type": "system" if is_system else "custom",
     }
 
@@ -802,16 +830,20 @@ def list_groups(
     :class:`ZulipAmbiguityError` with the matches listed.
     """
     if group_name is not None and group_id is not None:
-        raise ZulipValidationError("list_groups: --group-name and --group-id are mutually exclusive")
+        raise ZulipValidationError("list_groups: 'group_name' and 'group_id' are mutually exclusive")
     raw_groups = _fetch_groups(client)
-    groups = [_normalize_group(raw) for raw in raw_groups]
+    normalized: list[dict[str, Any]] = []
+    for raw in raw_groups:
+        if not isinstance(raw, dict):
+            raise ZulipAPIError(f"Malformed user_groups entry (not a dict): {raw!r}")
+        normalized.append(_normalize_group(raw))
 
     if group_id is not None:
-        return [g for g in groups if g["group_id"] == group_id]
+        return [g for g in normalized if g["group_id"] == group_id]
 
     if group_name is not None:
         target = group_name.casefold()
-        matches = [g for g in groups if str(g["name"]).casefold() == target]
+        matches = [g for g in normalized if str(g["name"]).casefold() == target]
         if len(matches) > 1:
             raise ZulipAmbiguityError(
                 f"Group name {group_name!r} matched {len(matches)} groups; use --group-id to disambiguate",
@@ -819,4 +851,4 @@ def list_groups(
             )
         return matches
 
-    return groups
+    return normalized

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -782,8 +782,12 @@ def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
     length.
 
     Raises :class:`ZulipAPIError` when required fields are missing or
-    have unexpected types — keeping the behaviour consistent with
-    :func:`resolve_groups`, which already validates ``id`` is an int.
+    have unexpected types — ``id`` must be an int, ``name`` must be a
+    non-empty string, ``members`` must be a list, and
+    ``is_system_group`` (when present) must be a ``bool``. The
+    ``description`` field is coerced to a string (Zulip historically
+    returns an empty string when not set, but ``None`` is also
+    tolerated).
     """
     raw_id = raw.get("id")
     if not isinstance(raw_id, int):
@@ -794,8 +798,10 @@ def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
     members = raw.get("members", [])
     if not isinstance(members, list):
         raise ZulipAPIError(f"Group object has non-list 'members': {raw!r}")
-    is_system = bool(raw.get("is_system_group", False))
-    if is_system:
+    is_system_raw = raw.get("is_system_group", False)
+    if not isinstance(is_system_raw, bool):
+        raise ZulipAPIError(f"Group object has non-boolean 'is_system_group': {raw!r}")
+    if is_system_raw:
         display = SYSTEM_ROLE_DISPLAY_NAMES.get(api_name, api_name)
     else:
         display = api_name
@@ -805,7 +811,7 @@ def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
         "name": display,
         "description": str(description),
         "member_count": len(members),
-        "type": "system" if is_system else "custom",
+        "type": "system" if is_system_raw else "custom",
     }
 
 
@@ -830,7 +836,7 @@ def list_groups(
     :class:`ZulipAmbiguityError` with the matches listed.
     """
     if group_name is not None and group_id is not None:
-        raise ZulipValidationError("list_groups: 'group_name' and 'group_id' are mutually exclusive")
+        raise ZulipValidationError("Specify only one of 'group_name' or 'group_id', not both")
     raw_groups = _fetch_groups(client)
     normalized: list[dict[str, Any]] = []
     for raw in raw_groups:

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -805,11 +805,11 @@ def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
         display = SYSTEM_ROLE_DISPLAY_NAMES.get(api_name, api_name)
     else:
         display = api_name
-    description = raw.get("description", "") or ""
+    description = raw.get("description")
     return {
         "group_id": raw_id,
         "name": display,
-        "description": str(description),
+        "description": "" if description is None else str(description),
         "member_count": len(members),
         "type": "system" if is_system_raw else "custom",
     }

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -350,9 +350,7 @@ def group_list(
 
     Shows both custom user groups and built-in system role groups
     (Owners, Administrators, Moderators, Full Members, Members,
-    Everyone, Nobody). All listed groups are valid inputs for the
-    ``--allow-group`` and ``--can-remove-subscribers-group`` flags on
-    channel create/update.
+    Everyone, Nobody), including their display names and member counts.
     """
     options = ctx.obj or {}
     try:

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -33,6 +33,7 @@ import typer
 from tabulate import tabulate
 
 from lftools_uv.api.endpoints.zulip import (
+    ZulipAmbiguityError,
     ZulipError,
     get_client,
     list_channels,
@@ -325,7 +326,7 @@ def user_list(
 
 group_app = typer.Typer(
     name="group",
-    help="List and inspect Zulip user groups.",
+    help="List Zulip user groups.",
     no_args_is_help=True,
 )
 zulip_app.add_typer(group_app, name="group")
@@ -361,6 +362,16 @@ def group_list(
             group_name=group_name,
             group_id=group_id,
         )
+    except ZulipAmbiguityError as exc:
+        # Render the per-spec listing of matches with IDs in addition to
+        # the headline message so the user can pick one for --group-id.
+        emit_error(str(exc))
+        for match in exc.matches:
+            typer.echo(
+                f"  - {match.get('name', '<unknown>')} (group_id={match.get('group_id')})",
+                err=True,
+            )
+        raise typer.Exit(code=1) from exc
     except ZulipError as exc:
         raise handle_zulip_error(exc) from exc
 

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -36,6 +36,7 @@ from lftools_uv.api.endpoints.zulip import (
     ZulipError,
     get_client,
     list_channels,
+    list_groups,
     list_users,
     zulip_available,
 )
@@ -315,3 +316,67 @@ def user_list(
             row.append("yes" if not user["is_active"] else "no")
         rows.append(row)
     emit_table(rows, headers)
+
+
+# ---------------------------------------------------------------------------
+# `zulip group` sub-app (US3)
+# ---------------------------------------------------------------------------
+
+
+group_app = typer.Typer(
+    name="group",
+    help="List and inspect Zulip user groups.",
+    no_args_is_help=True,
+)
+zulip_app.add_typer(group_app, name="group")
+
+
+@group_app.command("list")
+def group_list(
+    ctx: typer.Context,
+    group_name: str | None = typer.Option(
+        None,
+        "--group-name",
+        help="Filter by group name (case-insensitive).",
+    ),
+    group_id: int | None = typer.Option(
+        None,
+        "--group-id",
+        help="Filter by numeric group ID.",
+    ),
+) -> None:
+    """List user groups on the Zulip server.
+
+    Shows both custom user groups and built-in system role groups
+    (Owners, Administrators, Moderators, Full Members, Members,
+    Everyone, Nobody). All listed groups are valid inputs for the
+    ``--allow-group`` and ``--can-remove-subscribers-group`` flags on
+    channel create/update.
+    """
+    options = ctx.obj or {}
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        groups = list_groups(
+            client,
+            group_name=group_name,
+            group_id=group_id,
+        )
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json({"groups": groups})
+        return
+
+    headers = ["Name", "Group ID", "Type", "Description", "Members"]
+    rows = [
+        [
+            group.get("name", ""),
+            group.get("group_id", ""),
+            group.get("type", ""),
+            group.get("description", ""),
+            group.get("member_count", 0),
+        ]
+        for group in groups
+    ]
+    emit_table(rows, headers=headers)

--- a/specs/001-zulip-channel-mgmt/tasks.md
+++ b/specs/001-zulip-channel-mgmt/tasks.md
@@ -118,13 +118,13 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 ### Tests for User Story 3
 
-- [ ] T028 [P] [US3] Write CLI tests for `group list` in tests/unit/test_zulip_cli.py — test table output, `--json` output, `--group-name` filter, `--group-id` filter, ambiguity error display, config error
-- [ ] T029 [P] [US3] Write API tests for `list_groups()` in tests/unit/test_zulip_api.py — mock Zulip user_groups API, test custom/system group parsing, filtering, ambiguity detection
+- [x] T028 [P] [US3] Write CLI tests for `group list` in tests/unit/test_zulip_cli.py — test table output, `--json` output, `--group-name` filter, `--group-id` filter, ambiguity error display, config error
+- [x] T029 [P] [US3] Write API tests for `list_groups()` in tests/unit/test_zulip_api.py — mock Zulip user_groups API, test custom/system group parsing, filtering, ambiguity detection
 
 ### Implementation for User Story 3
 
-- [ ] T030 [US3] Implement `list_groups(client, group_name=None, group_id=None)` in lftools_uv/api/endpoints/zulip.py — call Zulip user_groups API, parse response into list of group dicts with group_id, name, description, member_count, type (custom/system), handle system role group display name mapping, handle ambiguous name filter
-- [ ] T031 [US3] Implement `group list` CLI command in lftools_uv/typer_apps/zulip.py — create `group` sub-app, add `list` command with `--group-name`, `--group-id`, and `--json` flags, format table output
+- [x] T030 [US3] Implement `list_groups(client, group_name=None, group_id=None)` in lftools_uv/api/endpoints/zulip.py — call Zulip user_groups API, parse response into list of group dicts with group_id, name, description, member_count, type (custom/system), handle system role group display name mapping, handle ambiguous name filter
+- [x] T031 [US3] Implement `group list` CLI command in lftools_uv/typer_apps/zulip.py — create `group` sub-app, add `list` command with `--group-name`, `--group-id`, and `--json` flags, format table output
 
 **Checkpoint**: User Story 3 is fully functional — `lftools-uv zulip group list` works independently
 

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -822,3 +822,35 @@ def test_list_groups_uses_known_system_role_mapping() -> None:
             # Display name (lowercased) must round-trip via SYSTEM_ROLE_GROUPS.
             display = group["name"].casefold()
             assert display in SYSTEM_ROLE_GROUPS
+
+
+def test_list_groups_rejects_malformed_entry() -> None:
+    """A non-dict entry in the user_groups payload raises ZulipAPIError."""
+    client = mock.MagicMock()
+    client.call_endpoint.return_value = {
+        "result": "success",
+        "user_groups": [{"id": 1, "name": "ok"}, "not-a-dict"],
+    }
+    with pytest.raises(ZulipAPIError):
+        _ = list_groups(client)
+
+
+def test_list_groups_rejects_missing_id() -> None:
+    """A group object lacking a numeric ``id`` raises ZulipAPIError."""
+    client = mock.MagicMock()
+    client.call_endpoint.return_value = {
+        "result": "success",
+        "user_groups": [{"name": "no-id"}],
+    }
+    with pytest.raises(ZulipAPIError, match="numeric 'id'"):
+        _ = list_groups(client)
+
+
+def test_system_role_display_names_round_trip() -> None:
+    """SYSTEM_ROLE_DISPLAY_NAMES is consistent with SYSTEM_ROLE_GROUPS."""
+    from lftools_uv.api.endpoints.zulip import SYSTEM_ROLE_DISPLAY_NAMES
+
+    assert set(SYSTEM_ROLE_DISPLAY_NAMES.keys()) == set(SYSTEM_ROLE_GROUPS.values())
+    # Every display name folds back to a key in SYSTEM_ROLE_GROUPS.
+    for display in SYSTEM_ROLE_DISPLAY_NAMES.values():
+        assert display.casefold() in SYSTEM_ROLE_GROUPS

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -39,6 +39,7 @@ from lftools_uv.api.endpoints.zulip import (
     get_client,
     get_server_feature_level,
     list_channels,
+    list_groups,
     list_users,
     resolve_channel,
     resolve_groups,
@@ -632,3 +633,192 @@ def test_list_users_propagates_api_errors() -> None:
     client.get_members.return_value = {"result": "error", "msg": "boom"}
     with pytest.raises(ZulipAPIError):
         _ = list_users(client)
+
+
+# ---------------------------------------------------------------------------
+# T029 — list_groups (US3)
+# ---------------------------------------------------------------------------
+
+
+LIST_GROUPS = [
+    {
+        "id": 10,
+        "name": "engineering",
+        "description": "Engineering team",
+        "members": [1, 2, 3],
+        "is_system_group": False,
+    },
+    {
+        "id": 11,
+        "name": "design",
+        "description": "Designers",
+        "members": [4, 5],
+        "is_system_group": False,
+    },
+    {
+        "id": 12,
+        "name": "Design",
+        "description": "Duplicate design (case collision)",
+        "members": [6],
+        "is_system_group": False,
+    },
+    {
+        "id": 20,
+        "name": "role:owners",
+        "description": "Owners of this organization",
+        "members": [1],
+        "is_system_group": True,
+    },
+    {
+        "id": 21,
+        "name": "role:administrators",
+        "description": "Administrators of this organization",
+        "members": [1, 2],
+        "is_system_group": True,
+    },
+    {
+        "id": 22,
+        "name": "role:fullmembers",
+        "description": "Full members",
+        "members": [1, 2, 3, 4],
+        "is_system_group": True,
+    },
+    {
+        "id": 23,
+        "name": "role:nobody",
+        "description": "Nobody",
+        "members": [],
+        "is_system_group": True,
+    },
+]
+
+
+def _list_groups_client(groups: list[dict[str, Any]]) -> Any:
+    """Return a mock client whose ``user_groups`` endpoint returns ``groups``."""
+    client = mock.MagicMock()
+    client.call_endpoint.return_value = {
+        "result": "success",
+        "user_groups": groups,
+    }
+    return client
+
+
+def test_list_groups_returns_custom_and_system() -> None:
+    """All custom and system role groups are returned with normalized fields."""
+    client = _list_groups_client(LIST_GROUPS)
+    groups = list_groups(client)
+    # Verify the helper hit the user_groups endpoint.
+    client.call_endpoint.assert_called_once()
+    args, kwargs = client.call_endpoint.call_args
+    call = {**kwargs, **dict(zip(["url", "method"], args, strict=False))}
+    assert call.get("url") == "user_groups"
+    assert call.get("method") == "GET"
+    # Custom and system groups both present.
+    types = {g["type"] for g in groups}
+    assert types == {"custom", "system"}
+    # Every group has the standard shape.
+    for group in groups:
+        assert set(group.keys()) >= {
+            "group_id",
+            "name",
+            "description",
+            "member_count",
+            "type",
+        }
+        assert isinstance(group["group_id"], int)
+        assert isinstance(group["member_count"], int)
+
+
+def test_list_groups_system_groups_use_display_names() -> None:
+    """System role groups appear with their display names, not ``role:`` API names."""
+    client = _list_groups_client(LIST_GROUPS)
+    groups = list_groups(client)
+    system_names = {g["name"] for g in groups if g["type"] == "system"}
+    # No internal ``role:`` strings leak to the caller.
+    assert not any(n.startswith("role:") for n in system_names)
+    # Expected display names from the spec mapping appear.
+    assert {"Owners", "Administrators", "Full Members", "Nobody"} <= system_names
+
+
+def test_list_groups_member_counts() -> None:
+    """``member_count`` is derived from the ``members`` array length."""
+    client = _list_groups_client(LIST_GROUPS)
+    groups = list_groups(client)
+    by_id = {g["group_id"]: g for g in groups}
+    assert by_id[10]["member_count"] == 3
+    assert by_id[20]["member_count"] == 1
+    assert by_id[23]["member_count"] == 0
+
+
+def test_list_groups_filter_by_group_id() -> None:
+    """``group_id`` filter narrows the result to exactly one group."""
+    client = _list_groups_client(LIST_GROUPS)
+    groups = list_groups(client, group_id=21)
+    assert len(groups) == 1
+    assert groups[0]["group_id"] == 21
+    assert groups[0]["name"] == "Administrators"
+    assert groups[0]["type"] == "system"
+
+
+def test_list_groups_filter_by_group_id_not_found() -> None:
+    """An unknown ``group_id`` returns an empty list (no error)."""
+    client = _list_groups_client(LIST_GROUPS)
+    assert list_groups(client, group_id=9999) == []
+
+
+def test_list_groups_filter_by_group_name_custom() -> None:
+    """``group_name`` filter matches custom groups case-insensitively."""
+    client = _list_groups_client(LIST_GROUPS)
+    groups = list_groups(client, group_name="ENGINEERING")
+    assert len(groups) == 1
+    assert groups[0]["group_id"] == 10
+    assert groups[0]["type"] == "custom"
+
+
+def test_list_groups_filter_by_group_name_system() -> None:
+    """``group_name`` filter matches system role display names."""
+    client = _list_groups_client(LIST_GROUPS)
+    groups = list_groups(client, group_name="administrators")
+    assert len(groups) == 1
+    assert groups[0]["group_id"] == 21
+    assert groups[0]["name"] == "Administrators"
+
+
+def test_list_groups_filter_by_group_name_not_found() -> None:
+    """An unmatched ``group_name`` returns an empty list (no error)."""
+    client = _list_groups_client(LIST_GROUPS)
+    assert list_groups(client, group_name="nonesuch") == []
+
+
+def test_list_groups_ambiguous_group_name_raises() -> None:
+    """A case-insensitive collision under ``group_name`` raises ambiguity."""
+    client = _list_groups_client(LIST_GROUPS)
+    with pytest.raises(ZulipAmbiguityError) as exc:
+        _ = list_groups(client, group_name="design")
+    assert {m["group_id"] for m in exc.value.matches} == {11, 12}
+
+
+def test_list_groups_mutually_exclusive_filters() -> None:
+    """``group_name`` and ``group_id`` cannot be combined."""
+    client = _list_groups_client(LIST_GROUPS)
+    with pytest.raises(ZulipValidationError):
+        _ = list_groups(client, group_name="design", group_id=11)
+
+
+def test_list_groups_api_error_on_unexpected_response() -> None:
+    """A malformed Zulip response surfaces as :class:`ZulipAPIError`."""
+    client = mock.MagicMock()
+    client.call_endpoint.return_value = {"result": "error", "msg": "boom"}
+    with pytest.raises(ZulipAPIError):
+        _ = list_groups(client)
+
+
+def test_list_groups_uses_known_system_role_mapping() -> None:
+    """The SYSTEM_ROLE_GROUPS table is the canonical mapping source."""
+    client = _list_groups_client(LIST_GROUPS)
+    groups = list_groups(client)
+    for group in groups:
+        if group["type"] == "system":
+            # Display name (lowercased) must round-trip via SYSTEM_ROLE_GROUPS.
+            display = group["name"].casefold()
+            assert display in SYSTEM_ROLE_GROUPS

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -750,6 +750,14 @@ def test_list_groups_member_counts() -> None:
     assert by_id[23]["member_count"] == 0
 
 
+def test_list_groups_preserves_falsy_descriptions() -> None:
+    """Falsy non-None descriptions are coerced with ``str(...)``."""
+    client = _list_groups_client(
+        [{"id": 1, "name": "zero", "description": 0, "members": []}],
+    )
+    assert list_groups(client)[0]["description"] == "0"
+
+
 def test_list_groups_filter_by_group_id() -> None:
     """``group_id`` filter narrows the result to exactly one group."""
     client = _list_groups_client(LIST_GROUPS)

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -479,3 +479,148 @@ def test_user_list_missing_extra(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.exit_code == 1
     combined = result.output + (getattr(result, "stderr", "") or "")
     assert "zulip extra" in combined
+
+
+# ---------------------------------------------------------------------------
+# T028 — ``zulip group list`` (US3)
+# ---------------------------------------------------------------------------
+
+
+_FAKE_GROUPS = [
+    {
+        "group_id": 10,
+        "name": "engineering",
+        "description": "Engineering team",
+        "member_count": 15,
+        "type": "custom",
+    },
+    {
+        "group_id": 21,
+        "name": "Administrators",
+        "description": "Administrators of this organization",
+        "member_count": 3,
+        "type": "system",
+    },
+]
+
+
+def _invoke_group_list(
+    args: list[str],
+    *,
+    list_groups_return: Any = None,
+    list_groups_exc: BaseException | None = None,
+    get_client_exc: BaseException | None = None,
+) -> Any:
+    """Invoke ``zulip group list`` with the API layer fully mocked."""
+    runner = CliRunner()
+    global_args: list[str] = []
+    command_args = list(args)
+    if "--json" in command_args:
+        command_args.remove("--json")
+        global_args.append("--json")
+    with (
+        mock.patch.object(zulip_mod, "get_client") as get_client_mock,
+        mock.patch.object(zulip_mod, "list_groups") as list_groups_mock,
+        mock.patch.object(zulip_mod, "zulip_available", return_value=True),
+    ):
+        if get_client_exc is not None:
+            get_client_mock.side_effect = get_client_exc
+        else:
+            get_client_mock.return_value = mock.MagicMock()
+        if list_groups_exc is not None:
+            list_groups_mock.side_effect = list_groups_exc
+        else:
+            list_groups_mock.return_value = list_groups_return or []
+        result = runner.invoke(zulip_app, [*global_args, "group", "list", *command_args])
+        return result, list_groups_mock
+
+
+def test_group_list_table_output() -> None:
+    """Default table output renders the expected column headers and rows."""
+    result, _ = _invoke_group_list([], list_groups_return=_FAKE_GROUPS)
+    assert result.exit_code == 0, result.stdout
+    assert "engineering" in result.stdout
+    assert "Administrators" in result.stdout
+    # Required columns from the contract.
+    for header in ("Name", "Group ID", "Type", "Description", "Members"):
+        assert header in result.stdout
+
+
+def test_group_list_json_output_schema() -> None:
+    """``--json`` emits the standard ``{"groups": [...]}`` schema."""
+    result, _ = _invoke_group_list(["--json"], list_groups_return=_FAKE_GROUPS)
+    assert result.exit_code == 0, result.stdout
+    payload = _json.loads(result.stdout)
+    assert set(payload.keys()) == {"groups"}
+    assert payload["groups"] == _FAKE_GROUPS
+
+
+def test_group_list_passes_group_name_filter() -> None:
+    """``--group-name`` is forwarded to the API helper as ``group_name``."""
+    _, list_mock = _invoke_group_list(
+        ["--group-name", "engineering"],
+        list_groups_return=[_FAKE_GROUPS[0]],
+    )
+    _, kwargs = list_mock.call_args
+    assert kwargs.get("group_name") == "engineering"
+    assert kwargs.get("group_id") is None
+
+
+def test_group_list_passes_group_id_filter() -> None:
+    """``--group-id`` is forwarded to the API helper as ``group_id``."""
+    _, list_mock = _invoke_group_list(
+        ["--group-id", "21"],
+        list_groups_return=[_FAKE_GROUPS[1]],
+    )
+    _, kwargs = list_mock.call_args
+    assert kwargs.get("group_id") == 21
+    assert kwargs.get("group_name") is None
+
+
+def test_group_list_accepts_global_zuliprc() -> None:
+    """``--zuliprc`` is accepted before the group subcommands."""
+    runner = CliRunner()
+    with (
+        mock.patch.object(zulip_mod, "get_client") as get_client_mock,
+        mock.patch.object(zulip_mod, "list_groups", return_value=[]),
+        mock.patch.object(zulip_mod, "zulip_available", return_value=True),
+    ):
+        get_client_mock.return_value = mock.MagicMock()
+        result = runner.invoke(zulip_app, ["--zuliprc", "custom.rc", "group", "list"])
+
+    assert result.exit_code == 0, result.stdout
+    _, kwargs = get_client_mock.call_args
+    assert str(kwargs["zuliprc"]) == "custom.rc"
+
+
+def test_group_list_ambiguity_error_display() -> None:
+    """A ``ZulipAmbiguityError`` from the API surfaces with exit code 1."""
+    exc = ZulipAmbiguityError(
+        "Group name 'design' matched 2 groups",
+        matches=[
+            {"group_id": 11, "name": "design"},
+            {"group_id": 12, "name": "Design"},
+        ],
+    )
+    result, _ = _invoke_group_list(["--group-name", "design"], list_groups_exc=exc)
+    assert result.exit_code == 1
+    assert "design" in result.stderr.lower()
+
+
+def test_group_list_config_error_display() -> None:
+    """A ``ZulipConfigError`` from ``get_client`` is surfaced cleanly."""
+    result, _ = _invoke_group_list(
+        [],
+        get_client_exc=ZulipConfigError("No Zulip configuration found."),
+    )
+    assert result.exit_code == 1
+    assert "No Zulip configuration" in result.stderr
+
+
+def test_group_list_help_renders() -> None:
+    """``zulip group list --help`` produces usable help text."""
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["group", "list", "--help"])
+    assert result.exit_code == 0
+    assert "--group-name" in result.stdout
+    assert "--group-id" in result.stdout

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -511,17 +511,14 @@ _FAKE_GROUPS = [
 def _invoke_group_list(
     args: list[str],
     *,
+    json_output: bool = False,
     list_groups_return: Any = None,
     list_groups_exc: BaseException | None = None,
     get_client_exc: BaseException | None = None,
 ) -> Any:
     """Invoke ``zulip group list`` with the API layer fully mocked."""
     runner = CliRunner()
-    global_args: list[str] = []
-    command_args = list(args)
-    if "--json" in command_args:
-        command_args.remove("--json")
-        global_args.append("--json")
+    global_args = ["--json"] if json_output else []
     with (
         mock.patch.object(zulip_mod, "get_client") as get_client_mock,
         mock.patch.object(zulip_mod, "list_groups") as list_groups_mock,
@@ -535,7 +532,7 @@ def _invoke_group_list(
             list_groups_mock.side_effect = list_groups_exc
         else:
             list_groups_mock.return_value = list_groups_return or []
-        result = runner.invoke(zulip_app, [*global_args, "group", "list", *command_args])
+        result = runner.invoke(zulip_app, [*global_args, "group", "list", *args])
         return result, list_groups_mock
 
 
@@ -551,8 +548,8 @@ def test_group_list_table_output() -> None:
 
 
 def test_group_list_json_output_schema() -> None:
-    """``--json`` emits the standard ``{"groups": [...]}`` schema."""
-    result, _ = _invoke_group_list(["--json"], list_groups_return=_FAKE_GROUPS)
+    """Global ``--json`` emits the standard ``{"groups": [...]}`` schema."""
+    result, _ = _invoke_group_list([], json_output=True, list_groups_return=_FAKE_GROUPS)
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     assert set(payload.keys()) == {"groups"}
@@ -613,7 +610,7 @@ def test_group_list_ambiguity_error_display() -> None:
     )
     result, _ = _invoke_group_list(["--group-name", "design"], list_groups_exc=exc)
     assert result.exit_code == 1
-    combined = result.stdout + result.stderr
+    combined = result.output + (getattr(result, "stderr", "") or "")
     assert "design" in combined.lower()
     # Matches list rendered with both ids.
     assert "11" in combined
@@ -627,7 +624,7 @@ def test_group_list_config_error_display() -> None:
         get_client_exc=ZulipConfigError("No Zulip configuration found."),
     )
     assert result.exit_code == 1
-    combined = result.stdout + result.stderr
+    combined = result.output + (getattr(result, "stderr", "") or "")
     assert "No Zulip configuration" in combined
 
 

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -25,13 +25,17 @@ import pytest
 from typer.testing import CliRunner
 
 import lftools_uv.typer_apps.zulip as zulip_mod
-from lftools_uv.api.endpoints.zulip import ZulipConfigError
+from lftools_uv.api.endpoints.zulip import (
+    ZulipAmbiguityError,
+    ZulipConfigError,
+)
 from lftools_uv.typer_apps.zulip import (
     MISSING_EXTRA_MESSAGE,
     bulk_mutation_result,
     mutation_result,
     zulip_app,
 )
+from tests.test_utils import clean_cli_output
 
 
 def test_zulip_app_registered() -> None:
@@ -627,8 +631,6 @@ def test_group_list_config_error_display() -> None:
 
 def test_group_list_help_renders() -> None:
     """``zulip group list --help`` produces usable help text."""
-    import re as _re
-
     runner = CliRunner()
     result = runner.invoke(
         zulip_app,
@@ -636,7 +638,6 @@ def test_group_list_help_renders() -> None:
         env={"COLUMNS": "200", "NO_COLOR": "1", "TERM": "dumb"},
     )
     assert result.exit_code == 0
-    # Strip any residual ANSI escape sequences before substring assertions.
-    cleaned = _re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", result.stdout)
+    cleaned = clean_cli_output(result.stdout)
     assert "--group-name" in cleaned
     assert "--group-id" in cleaned

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -554,7 +554,7 @@ def test_group_list_json_output_schema() -> None:
     """``--json`` emits the standard ``{"groups": [...]}`` schema."""
     result, _ = _invoke_group_list(["--json"], list_groups_return=_FAKE_GROUPS)
     assert result.exit_code == 0, result.stdout
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert set(payload.keys()) == {"groups"}
     assert payload["groups"] == _FAKE_GROUPS
 

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -613,10 +613,11 @@ def test_group_list_ambiguity_error_display() -> None:
     )
     result, _ = _invoke_group_list(["--group-name", "design"], list_groups_exc=exc)
     assert result.exit_code == 1
-    assert "design" in result.stderr.lower()
+    combined = result.stdout + result.stderr
+    assert "design" in combined.lower()
     # Matches list rendered with both ids.
-    assert "11" in result.stderr
-    assert "12" in result.stderr
+    assert "11" in combined
+    assert "12" in combined
 
 
 def test_group_list_config_error_display() -> None:
@@ -626,7 +627,8 @@ def test_group_list_config_error_display() -> None:
         get_client_exc=ZulipConfigError("No Zulip configuration found."),
     )
     assert result.exit_code == 1
-    assert "No Zulip configuration" in result.stderr
+    combined = result.stdout + result.stderr
+    assert "No Zulip configuration" in combined
 
 
 def test_group_list_help_renders() -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -619,8 +619,16 @@ def test_group_list_config_error_display() -> None:
 
 def test_group_list_help_renders() -> None:
     """``zulip group list --help`` produces usable help text."""
+    import re as _re
+
     runner = CliRunner()
-    result = runner.invoke(zulip_app, ["group", "list", "--help"])
+    result = runner.invoke(
+        zulip_app,
+        ["group", "list", "--help"],
+        env={"COLUMNS": "200", "NO_COLOR": "1", "TERM": "dumb"},
+    )
     assert result.exit_code == 0
-    assert "--group-name" in result.stdout
-    assert "--group-id" in result.stdout
+    # Strip any residual ANSI escape sequences before substring assertions.
+    cleaned = _re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", result.stdout)
+    assert "--group-name" in cleaned
+    assert "--group-id" in cleaned

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -594,7 +594,12 @@ def test_group_list_accepts_global_zuliprc() -> None:
 
 
 def test_group_list_ambiguity_error_display() -> None:
-    """A ``ZulipAmbiguityError`` from the API surfaces with exit code 1."""
+    """A ``ZulipAmbiguityError`` from the API surfaces with exit code 1.
+
+    The per-spec contract requires that the matches list (group IDs +
+    names) is rendered to stderr so the user can pick one for
+    ``--group-id``.
+    """
     exc = ZulipAmbiguityError(
         "Group name 'design' matched 2 groups",
         matches=[
@@ -605,6 +610,9 @@ def test_group_list_ambiguity_error_display() -> None:
     result, _ = _invoke_group_list(["--group-name", "design"], list_groups_exc=exc)
     assert result.exit_code == 1
     assert "design" in result.stderr.lower()
+    # Matches list rendered with both ids.
+    assert "11" in result.stderr
+    assert "12" in result.stderr
 
 
 def test_group_list_config_error_display() -> None:


### PR DESCRIPTION
## Summary

Implements **User Story 3 — List User Groups** from the
[`001-zulip-channel-mgmt`](../tree/main/specs/001-zulip-channel-mgmt)
feature spec. Adds `lftools-uv zulip group list`, which shows all
custom user groups *and* built-in system role groups (Owners,
Administrators, Moderators, Full Members, Members, Everyone, Nobody)
in a single combined listing.

## Tasks completed

- **T028** — CLI tests for `group list` in `tests/unit/test_zulip_cli.py`
- **T029** — API tests for `list_groups()` in `tests/unit/test_zulip_api.py`
- **T030** — `list_groups(client, group_name=None, group_id=None)` in
  `lftools_uv/api/endpoints/zulip.py` (calls `GET /user_groups`,
  normalizes to `{group_id, name, description, member_count, type}`,
  maps `role:NAME` system groups to display names, handles
  `--group-name`/`--group-id` filters and ambiguity)
- **T031** — `group` sub-app + `list` command with `--group-name`,
  `--group-id`, `--json`, `--zuliprc` flags in
  `lftools_uv/typer_apps/zulip.py`

## Independence

US3 is independent of US1 (PR #378) and the in-flight US2 PR per the
spec's user-story dependency graph. This branch is based directly on
`upstream/main` (which contains the Phase 1 + 2 foundation merged via
PR #362) and does not require either of the other US PRs to land
first. The branches can merge in any order.

## Pre-existing test fix

`upstream/main` currently fails the
`tests/test_cli/test_typer_migration.py::TestTyperUtilsPassgen::test_passgen_invalid_length_negative`
test because Click changed its 'No such option' error format from
``No such option: -5`` to ``No such option '-5'``. This branch
includes the same one-line tolerance fix that PR #378 contains; if
PR #378 merges first the commit becomes a no-op.

## Test plan

- ``uv run pytest tests/`` — 436 passed
- ``uv run ruff check`` on touched files — clean
- ``uv run ruff format --check`` on touched files — clean
- All pre-commit hooks pass (basedpyright skipped per repo
  convention — pre-existing failures in ``lftools_uv/deploy.py``)
- New tests:
  - 12 API tests (custom/system parsing, member counts, both
    filters, ambiguity, mutual exclusivity, malformed response)
  - 7 CLI tests (table, ``--json``, both filters, ambiguity error
    display, config-error display, ``--help``)

## Commits

1. ``Fix(tests): Tolerate Click error format change``
2. ``Feat(zulip): Add list_groups API helper (US3)``
3. ``Feat(zulip): Add 'group list' CLI command (US3)``
4. ``Docs(tasks): Mark T028-T031 complete``

🤖 Generated with assistance from GitHub Copilot.