### PR TITLE
Feat(zulip): Unsubscribe users from channel (US6)

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1229,3 +1229,124 @@ def subscribe_users(
         "results": results,
         "errors": errors,
     }
+
+
+# Subscription mutations (US6 — unsubscribe)
+# ---------------------------------------------------------------------------
+
+
+def unsubscribe_users(
+    client: Any,
+    users: Iterable[str],
+    *,
+    channel: str | None = None,
+    channel_id: int | None = None,
+    id_mode: IdMode,
+    include_archived: bool = False,
+) -> dict[str, Any]:
+    """Unsubscribe one or more users from a channel.
+
+    Resolves the channel target (by name or numeric id) and the user
+    identifiers (per ``id_mode``), then calls the Zulip
+    ``DELETE /users/me/subscriptions`` endpoint. The return value is a
+    bulk :class:`MutationResult`-shaped dict:
+
+    .. code-block:: python
+
+       {
+           "status": "success" | "partial" | "error",
+           "channel_id": int,
+           "channel_name": str,
+           "operation": "unsubscribe",
+           "results": [
+               {"user": "<identifier>", "status": "unsubscribed"},
+               {"user": "<identifier>", "status": "not_subscribed"},
+           ],
+           "errors": [],
+       }
+
+    The Zulip server returns ``removed`` for users who were unsubscribed
+    and ``not_removed`` for users who were not subscribed in the first
+    place — the latter is reported as a ``not_subscribed`` no-op,
+    consistent with the CLI contract "exit 0 = all succeeded (including
+    no-ops)".
+    """
+    if (channel is None) == (channel_id is None):
+        raise ZulipValidationError("unsubscribe_users requires exactly one of 'channel' or 'channel_id'")
+    user_list = list(users)
+    if not user_list:
+        raise ZulipValidationError("unsubscribe_users requires at least one user")
+
+    target = resolve_channel(
+        client,
+        name=channel,
+        channel_id=channel_id,
+        include_archived=include_archived,
+    )
+    resolved_target_id = target.get("stream_id")
+    resolved_target_name = str(target.get("name", ""))
+
+    resolved_users = resolve_users(client, user_list, mode=id_mode)
+
+    principals: list[Any]
+    if id_mode == "id":
+        principals = [int(u["user_id"]) for u in resolved_users]
+    else:
+        # For both name- and email-mode lookups we send delivery_email
+        # (falling back to ``email``) as principals so that the server
+        # can match against the channel's subscriber list. Zulip
+        # principals accept emails or user IDs interchangeably.
+        principals = [u.get("delivery_email") or u.get("email") for u in resolved_users]
+
+    try:
+        response = client.call_endpoint(
+            url="users/me/subscriptions",
+            method="DELETE",
+            request={
+                "subscriptions": [resolved_target_name],
+                "principals": principals,
+            },
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to unsubscribe users: {exc}") from exc
+
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = (response or {}).get("msg") if isinstance(response, dict) else None
+        raise ZulipAPIError(f"Unexpected unsubscribe response: {msg or response!r}")
+
+    removed_set = {str(item) for item in response.get("removed", []) or []}
+    not_removed_set = {str(item) for item in response.get("not_removed", []) or []}
+
+    results: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    for original, _resolved, principal in zip(user_list, resolved_users, principals, strict=True):
+        principal_str = str(principal)
+        if principal_str in removed_set:
+            results.append({"user": original, "status": "unsubscribed"})
+        elif principal_str in not_removed_set:
+            results.append({"user": original, "status": "not_subscribed"})
+        else:
+            # Neither list mentioned this principal — treat as an error
+            # so the operator notices an unexpected server response.
+            errors.append(
+                {
+                    "user": original,
+                    "error": "Server did not report an outcome for this user",
+                }
+            )
+
+    if errors and not results:
+        status = "error"
+    elif errors:
+        status = "partial"
+    else:
+        status = "success"
+
+    return {
+        "status": status,
+        "channel_id": resolved_target_id,
+        "channel_name": resolved_target_name,
+        "operation": "unsubscribe",
+        "results": results,
+        "errors": errors,
+    }

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1305,6 +1305,10 @@ def unsubscribe_users(
     user_list = list(users)
     if not user_list:
         raise ZulipValidationError("unsubscribe_users requires at least one user")
+    if len(user_list) > MAX_SUBSCRIBE_USERS:
+        raise ZulipValidationError(
+            f"unsubscribe_users accepts at most {MAX_SUBSCRIBE_USERS} users per invocation (got {len(user_list)})"
+        )
 
     if resolved_channel is not None:
         target = resolved_channel

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -454,6 +454,57 @@ def _fetch_users(client: Any) -> list[dict[str, Any]]:
     return members
 
 
+def _resolve_single_user(
+    ident: str,
+    members: list[dict[str, Any]],
+    *,
+    mode: IdMode,
+) -> dict[str, Any]:
+    """Resolve a single user identifier against a pre-fetched member list.
+
+    Factored out of :func:`resolve_users` so that callers needing
+    per-identifier error handling (e.g. bulk mutations that report
+    partial failures) can drive the loop themselves and capture
+    failures one-by-one instead of aborting on the first bad entry.
+
+    Raises :class:`ZulipValidationError` for malformed input,
+    :class:`ZulipNotFoundError` when the identifier matches nothing,
+    and :class:`ZulipAmbiguityError` (mode ``name`` only) when a
+    full-name lookup matches more than one user.
+    """
+    ident = ident.strip()
+    if not ident:
+        raise ZulipValidationError("User identifier must not be empty")
+    if mode == "email":
+        matches = [u for u in members if u.get("delivery_email") == ident or u.get("email") == ident]
+    elif mode == "id":
+        try:
+            wanted = int(ident)
+        except ValueError as exc:
+            raise ZulipValidationError(f"--by-id requires a numeric identifier, got {ident!r}") from exc
+        matches = [u for u in members if u.get("user_id") == wanted]
+    elif mode == "name":
+        matches = [u for u in members if u.get("full_name") == ident]
+    else:  # pragma: no cover - guarded by Literal
+        raise ZulipValidationError(f"Unknown user id mode: {mode!r}")
+
+    if not matches:
+        raise ZulipNotFoundError(f"No user found matching {ident!r} (--by-{mode})")
+    if len(matches) > 1:
+        raise ZulipAmbiguityError(
+            f"User name {ident!r} matched {len(matches)} users; use --by-email or --by-id to disambiguate",
+            matches=[
+                {
+                    "user_id": m.get("user_id"),
+                    "full_name": m.get("full_name"),
+                    "email": m.get("delivery_email") or m.get("email"),
+                }
+                for m in matches
+            ],
+        )
+    return matches[0]
+
+
 def resolve_users(
     client: Any,
     identifiers: Iterable[str],
@@ -469,40 +520,7 @@ def resolve_users(
     are unique by construction.
     """
     members = _fetch_users(client)
-    resolved: list[dict[str, Any]] = []
-    for raw in identifiers:
-        ident = raw.strip()
-        if not ident:
-            raise ZulipValidationError("User identifier must not be empty")
-        if mode == "email":
-            matches = [u for u in members if u.get("delivery_email") == ident or u.get("email") == ident]
-        elif mode == "id":
-            try:
-                wanted = int(ident)
-            except ValueError as exc:
-                raise ZulipValidationError(f"--by-id requires a numeric identifier, got {ident!r}") from exc
-            matches = [u for u in members if u.get("user_id") == wanted]
-        elif mode == "name":
-            matches = [u for u in members if u.get("full_name") == ident]
-        else:  # pragma: no cover - guarded by Literal
-            raise ZulipValidationError(f"Unknown user id mode: {mode!r}")
-
-        if not matches:
-            raise ZulipNotFoundError(f"No user found matching {ident!r} (--by-{mode})")
-        if len(matches) > 1:
-            raise ZulipAmbiguityError(
-                f"User name {ident!r} matched {len(matches)} users; use --by-email or --by-id to disambiguate",
-                matches=[
-                    {
-                        "user_id": m.get("user_id"),
-                        "full_name": m.get("full_name"),
-                        "email": m.get("delivery_email") or m.get("email"),
-                    }
-                    for m in matches
-                ],
-            )
-        resolved.append(matches[0])
-    return resolved
+    return [_resolve_single_user(ident, members, mode=mode) for ident in identifiers]
 
 
 # ---------------------------------------------------------------------------
@@ -1286,17 +1304,46 @@ def unsubscribe_users(
     resolved_target_id = target.get("stream_id")
     resolved_target_name = str(target.get("name", ""))
 
-    resolved_users = resolve_users(client, user_list, mode=id_mode)
+    # Resolve identifiers one-by-one so a single bad entry does not
+    # abort the whole bulk operation. Per-user resolution failures are
+    # captured into ``errors`` while successfully-resolved users still
+    # get sent to the Zulip API. This matches the bulk-operation
+    # behavior described in the data-model spec (status: partial).
+    members = _fetch_users(client)
+    results: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    principals: list[Any] = []
+    resolved_pairs: list[tuple[str, Any]] = []  # (original, principal)
 
-    principals: list[Any]
-    if id_mode == "id":
-        principals = [int(u["user_id"]) for u in resolved_users]
-    else:
-        # For both name- and email-mode lookups we send delivery_email
-        # (falling back to ``email``) as principals so that the server
-        # can match against the channel's subscriber list. Zulip
-        # principals accept emails or user IDs interchangeably.
-        principals = [u.get("delivery_email") or u.get("email") for u in resolved_users]
+    for original in user_list:
+        try:
+            user = _resolve_single_user(original, members, mode=id_mode)
+        except (ZulipNotFoundError, ZulipAmbiguityError, ZulipValidationError) as exc:
+            errors.append({"user": original, "error": str(exc)})
+            continue
+        if id_mode == "id":
+            principal: Any = int(user["user_id"])
+        else:
+            # For both name- and email-mode lookups we send delivery_email
+            # (falling back to ``email``) as principals so that the server
+            # can match against the channel's subscriber list. Zulip
+            # principals accept emails or user IDs interchangeably.
+            principal = user.get("delivery_email") or user.get("email")
+        principals.append(principal)
+        resolved_pairs.append((original, principal))
+
+    if not principals:
+        # Every identifier failed to resolve — skip the API call entirely
+        # and return an all-errors payload so the caller can surface the
+        # per-user failures without a spurious server round-trip.
+        return {
+            "status": "error",
+            "channel_id": resolved_target_id,
+            "channel_name": resolved_target_name,
+            "operation": "unsubscribe",
+            "results": results,
+            "errors": errors,
+        }
 
     try:
         response = client.call_endpoint(
@@ -1317,9 +1364,7 @@ def unsubscribe_users(
     removed_set = {str(item) for item in response.get("removed", []) or []}
     not_removed_set = {str(item) for item in response.get("not_removed", []) or []}
 
-    results: list[dict[str, Any]] = []
-    errors: list[dict[str, Any]] = []
-    for original, _resolved, principal in zip(user_list, resolved_users, principals, strict=True):
+    for original, principal in resolved_pairs:
         principal_str = str(principal)
         if principal_str in removed_set:
             results.append({"user": original, "status": "unsubscribed"})

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1261,6 +1261,7 @@ def unsubscribe_users(
     channel_id: int | None = None,
     id_mode: IdMode,
     include_archived: bool = False,
+    resolved_channel: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Unsubscribe one or more users from a channel.
 
@@ -1288,19 +1289,31 @@ def unsubscribe_users(
     place — the latter is reported as a ``not_subscribed`` no-op,
     consistent with the CLI contract "exit 0 = all succeeded (including
     no-ops)".
+
+    Pass ``resolved_channel`` (a stream dict as returned by
+    :func:`resolve_channel`) to skip the internal channel resolution
+    step. This lets callers that have already resolved the channel
+    (for example the CLI, which needs the resolved id available for
+    the ``--json`` error payload before invoking this function) avoid
+    a redundant ``GET /streams`` round-trip. When ``resolved_channel``
+    is supplied, ``channel`` and ``channel_id`` are ignored.
     """
-    if (channel is None) == (channel_id is None):
-        raise ZulipValidationError("unsubscribe_users requires exactly one of 'channel' or 'channel_id'")
+    if resolved_channel is None:
+        if (channel is None) == (channel_id is None):
+            raise ZulipValidationError("unsubscribe_users requires exactly one of 'channel' or 'channel_id'")
     user_list = list(users)
     if not user_list:
         raise ZulipValidationError("unsubscribe_users requires at least one user")
 
-    target = resolve_channel(
-        client,
-        name=channel,
-        channel_id=channel_id,
-        include_archived=include_archived,
-    )
+    if resolved_channel is not None:
+        target = resolved_channel
+    else:
+        target = resolve_channel(
+            client,
+            name=channel,
+            channel_id=channel_id,
+            include_archived=include_archived,
+        )
     resolved_target_id = target.get("stream_id")
     resolved_target_name = str(target.get("name", ""))
 

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -470,8 +470,9 @@ def _resolve_single_user(
 
     Raises :class:`ZulipValidationError` for malformed input,
     :class:`ZulipNotFoundError` when the identifier matches nothing,
-    and :class:`ZulipAmbiguityError` (mode ``name`` only) when a
-    full-name lookup matches more than one user.
+    and :class:`ZulipAmbiguityError` when a lookup matches more than one
+    user. Ambiguity is normally expected only for full-name lookups, but
+    malformed member payloads can also duplicate email or ID matches.
     """
     ident = ident.strip()
     if not ident:

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1354,6 +1354,9 @@ def unsubscribe_users(
             # can match against the channel's subscriber list. Zulip
             # principals accept emails or user IDs interchangeably.
             principal = user.get("delivery_email") or user.get("email")
+            if not isinstance(principal, str) or not principal:
+                errors.append({"user": original, "error": f"Resolved user missing email: {user!r}"})
+                continue
         principals.append(principal)
         resolved_pairs.append((original, principal))
 

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1320,7 +1320,9 @@ def unsubscribe_users(
             include_archived=include_archived,
         )
     resolved_target_id = target.get("stream_id")
-    resolved_target_name = str(target.get("name", ""))
+    resolved_target_name = target.get("name")
+    if not isinstance(resolved_target_id, int) or not isinstance(resolved_target_name, str):
+        raise ZulipAPIError(f"Malformed stream object: {target!r}")
 
     # Resolve identifiers one-by-one so a single bad entry does not
     # abort the whole bulk operation. Per-user resolution failures are

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -36,6 +36,7 @@ See ``specs/001-zulip-channel-mgmt/`` for the full feature design.
 from __future__ import annotations
 
 import configparser
+import json
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -1369,8 +1370,8 @@ def unsubscribe_users(
                 url="users/me/subscriptions",
                 method="DELETE",
                 request={
-                    "subscriptions": [resolved_target_name],
-                    "principals": [principal],
+                    "subscriptions": json.dumps([resolved_target_name]),
+                    "principals": json.dumps([principal]),
                 },
             )
         except Exception as exc:  # pragma: no cover - network errors

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1373,6 +1373,9 @@ def unsubscribe_users(
             "errors": errors,
         }
 
+    # The DELETE response reports removed/not_removed by stream, not by
+    # principal, so request one principal at a time to preserve per-user
+    # results and partial-failure reporting.
     for original, principal in resolved_pairs:
         try:
             response = client.call_endpoint(

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1331,7 +1331,12 @@ def unsubscribe_users(
     for original in user_list:
         try:
             user = _resolve_single_user(original, members, mode=id_mode)
-        except (ZulipNotFoundError, ZulipAmbiguityError, ZulipValidationError) as exc:
+        except ZulipAmbiguityError as exc:
+            match_parts = [f"{m.get('full_name')} <{m.get('email')}> (id: {m.get('user_id')})" for m in exc.matches]
+            detail = f"{exc}; matches: {', '.join(match_parts)}"
+            errors.append({"user": original, "error": detail, "matches": exc.matches})
+            continue
+        except (ZulipNotFoundError, ZulipValidationError) as exc:
             errors.append({"user": original, "error": str(exc)})
             continue
         if id_mode == "id":

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1363,34 +1363,31 @@ def unsubscribe_users(
             "errors": errors,
         }
 
-    try:
-        response = client.call_endpoint(
-            url="users/me/subscriptions",
-            method="DELETE",
-            request={
-                "subscriptions": [resolved_target_name],
-                "principals": principals,
-            },
-        )
-    except Exception as exc:  # pragma: no cover - network errors
-        raise ZulipAPIError(f"Failed to unsubscribe users: {exc}") from exc
-
-    if not isinstance(response, dict) or response.get("result") != "success":
-        msg = (response or {}).get("msg") if isinstance(response, dict) else None
-        raise ZulipAPIError(f"Unexpected unsubscribe response: {msg or response!r}")
-
-    removed_set = {str(item) for item in response.get("removed", []) or []}
-    not_removed_set = {str(item) for item in response.get("not_removed", []) or []}
-
     for original, principal in resolved_pairs:
-        principal_str = str(principal)
-        if principal_str in removed_set:
+        try:
+            response = client.call_endpoint(
+                url="users/me/subscriptions",
+                method="DELETE",
+                request={
+                    "subscriptions": [resolved_target_name],
+                    "principals": [principal],
+                },
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            raise ZulipAPIError(f"Failed to unsubscribe users: {exc}") from exc
+
+        if not isinstance(response, dict) or response.get("result") != "success":
+            msg = (response or {}).get("msg") if isinstance(response, dict) else None
+            raise ZulipAPIError(f"Unexpected unsubscribe response: {msg or response!r}")
+
+        removed_set = {str(item) for item in response.get("removed", []) or []}
+        not_removed_set = {str(item) for item in response.get("not_removed", []) or []}
+
+        if resolved_target_name in removed_set:
             results.append({"user": original, "status": "unsubscribed"})
-        elif principal_str in not_removed_set:
+        elif resolved_target_name in not_removed_set:
             results.append({"user": original, "status": "not_subscribed"})
         else:
-            # Neither list mentioned this principal — treat as an error
-            # so the operator notices an unexpected server response.
             errors.append(
                 {
                     "user": original,

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -33,6 +33,7 @@ import typer
 from tabulate import tabulate
 
 from lftools_uv.api.endpoints.zulip import (
+    IdMode,
     ZulipAmbiguityError,
     ZulipError,
     get_client,
@@ -866,7 +867,7 @@ def channel_unsubscribe(
     if len(chosen) != 1:
         emit_error("Exactly one of --by-email/--by-id/--by-name is required")
         raise typer.Exit(code=1)
-    id_mode = chosen[0]
+    id_mode = cast(IdMode, chosen[0])
 
     # Split positional targets into channel + users.
     if channel_id is not None:
@@ -890,7 +891,7 @@ def channel_unsubscribe(
             users,
             channel=channel_name,
             channel_id=channel_id,
-            id_mode=id_mode,  # type: ignore[arg-type]
+            id_mode=id_mode,
             include_archived=include_archived,
         )
     except ZulipError as exc:

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -893,7 +893,7 @@ def channel_unsubscribe(
         if options.get("json_output"):
             error_payload = bulk_mutation_result(
                 operation="unsubscribe",
-                channel_id=channel_id,
+                channel_id=None,
                 channel_name=channel_name or "",
                 results=[],
                 errors=[{"user": None, "error": str(exc)}],

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -941,9 +941,9 @@ def channel_unsubscribe(
         payload = zulip_api.unsubscribe_users(
             client,
             users,
-            channel_id=resolved_channel_id,
             id_mode=id_mode,
             include_archived=include_archived,
+            resolved_channel=target,
         )
     except ZulipError as exc:
         if options.get("json_output"):

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -851,13 +851,21 @@ def channel_unsubscribe(
         "--include-archived",
         help="Search archived channels when resolving the channel target.",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of a table.",
+        hidden=True,
+    ),
 ) -> None:
     """Unsubscribe one or more users from a channel."""
     # Import the endpoint module as a namespace so tests can monkeypatch
     # its helpers while keeping ``get_client`` patched on this module.
     from lftools_uv.api.endpoints import zulip as zulip_api
 
-    options = ctx.obj or {}
+    options = {**(ctx.obj or {})}
+    if json_output:
+        options["json_output"] = True
 
     def fail_validation(message: str, *, channel_name: str = "") -> None:
         if options.get("json_output"):

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -221,7 +221,15 @@ def zulip_callback(
 # ---------------------------------------------------------------------------
 # US1 — channel list (T023)
 # ---------------------------------------------------------------------------
-
+#
+# NOTE: The ``channel`` sub-app is shared across the channel-scoped
+# user-story slices: US1 (channel list), US4 (channel create), US5
+# (channel subscribe), US6 (channel unsubscribe), and the remaining
+# US7-US10 channel commands. The first PR to land that touches a
+# channel command also lands this sub-app instantiation. If two PRs
+# instantiate the sub-app independently, the trivial merge conflict
+# on the ``channel_app = typer.Typer(...)`` line should be resolved
+# by keeping a single instance.
 
 channel_app = typer.Typer(
     name="channel",
@@ -886,16 +894,32 @@ def channel_unsubscribe(
             include_archived=include_archived,
         )
     except ZulipError as exc:
+        if options.get("json_output"):
+            # FR-008: mutation commands emit the canonical JSON schema
+            # even on error. ``channel_id`` is None when the failure
+            # happened before channel resolution succeeded; the channel
+            # name is echoed back from the user-supplied target so the
+            # operator can correlate the failure with their command.
+            error_payload = bulk_mutation_result(
+                operation="unsubscribe",
+                channel_id=channel_id,
+                channel_name=channel_name or "",
+                results=[],
+                errors=[{"user": None, "error": str(exc)}],
+            )
+            emit_json(error_payload)
+            raise typer.Exit(code=1) from exc
         raise handle_zulip_error(exc) from exc
 
     if options.get("json_output"):
         emit_json(payload)
-        if payload["status"] == "error":
-            raise typer.Exit(code=1)
-        return
+    else:
+        rows = [(item["user"], item["status"]) for item in payload["results"]]
+        rows.extend((item["user"], f"error: {item['error']}") for item in payload["errors"])
+        emit_table(rows, headers=["user", "status"])
 
-    rows = [(item["user"], item["status"]) for item in payload["results"]]
-    rows.extend((item["user"], f"error: {item['error']}") for item in payload["errors"])
-    emit_table(rows, headers=["user", "status"])
-    if payload["status"] == "error":
+    # Per the CLI contract, exit non-zero on ANY error condition. A
+    # ``partial`` status means some operations failed, so it must also
+    # produce a non-zero exit code alongside ``error``.
+    if payload["status"] in ("error", "partial"):
         raise typer.Exit(code=1)

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -886,25 +886,74 @@ def channel_unsubscribe(
     options = ctx.obj or {}
     try:
         client = get_client(zuliprc=options.get("zuliprc"))
+    except ZulipError as exc:
+        # Configuration/connect failure happens before channel
+        # resolution can even be attempted, so the error payload
+        # cannot carry a resolved channel_id.
+        if options.get("json_output"):
+            error_payload = bulk_mutation_result(
+                operation="unsubscribe",
+                channel_id=channel_id,
+                channel_name=channel_name or "",
+                results=[],
+                errors=[{"user": None, "error": str(exc)}],
+            )
+            emit_json(error_payload)
+            raise typer.Exit(code=1) from exc
+        raise handle_zulip_error(exc) from exc
+
+    # Pre-resolve the channel so that any failure inside
+    # ``unsubscribe_users`` (e.g. the DELETE call returning an error
+    # response) can still report the resolved channel_id/channel_name
+    # in the --json error payload. The contract documents
+    # ``channel_id: null`` only for the case where the channel itself
+    # could not be resolved.
+    resolved_channel_id: int | None = channel_id
+    resolved_channel_name: str = channel_name or ""
+    try:
+        target = zulip_api.resolve_channel(
+            client,
+            name=channel_name,
+            channel_id=channel_id,
+            include_archived=include_archived,
+        )
+    except ZulipError as exc:
+        if options.get("json_output"):
+            error_payload = bulk_mutation_result(
+                operation="unsubscribe",
+                channel_id=None,
+                channel_name=channel_name or "",
+                results=[],
+                errors=[{"user": None, "error": str(exc)}],
+            )
+            emit_json(error_payload)
+            raise typer.Exit(code=1) from exc
+        raise handle_zulip_error(exc) from exc
+
+    raw_id = target.get("stream_id")
+    if isinstance(raw_id, int):
+        resolved_channel_id = raw_id
+    resolved_channel_name = str(target.get("name", "")) or resolved_channel_name
+
+    try:
         payload = zulip_api.unsubscribe_users(
             client,
             users,
-            channel=channel_name,
-            channel_id=channel_id,
+            channel_id=resolved_channel_id,
             id_mode=id_mode,
             include_archived=include_archived,
         )
     except ZulipError as exc:
         if options.get("json_output"):
             # FR-008: mutation commands emit the canonical JSON schema
-            # even on error. ``channel_id`` is None when the failure
-            # happened before channel resolution succeeded; the channel
-            # name is echoed back from the user-supplied target so the
-            # operator can correlate the failure with their command.
+            # even on error. The channel was successfully resolved
+            # above, so we report the resolved channel_id/name here
+            # (the failure is downstream — e.g. the DELETE call itself
+            # returned an error).
             error_payload = bulk_mutation_result(
                 operation="unsubscribe",
-                channel_id=channel_id,
-                channel_name=channel_name or "",
+                channel_id=resolved_channel_id,
+                channel_name=resolved_channel_name,
                 results=[],
                 errors=[{"user": None, "error": str(exc)}],
             )

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -859,6 +859,34 @@ def channel_unsubscribe(
     # there by the CLI unit tests.
     from lftools_uv.api.endpoints import zulip as zulip_api
 
+    def fail_validation(message: str, *, channel_name: str = "") -> None:
+        if as_json:
+            emit_json(
+                bulk_mutation_result(
+                    operation="unsubscribe",
+                    channel_id=None,
+                    channel_name=channel_name,
+                    results=[],
+                    errors=[{"user": None, "error": message}],
+                )
+            )
+        else:
+            emit_error(message)
+        raise typer.Exit(code=1)
+
+    # Split positional targets into channel + users.
+    if channel_id is not None:
+        channel_name: str | None = None
+        users = list(targets)
+    else:
+        if len(targets) < 2:
+            channel_for_error = targets[0] if targets else ""
+            fail_validation(
+                "Provide a channel name (or --channel-id) and at least one user",
+                channel_name=channel_for_error,
+            )
+        channel_name, *users = targets
+
     # Validate id-mode mutex: exactly one of --by-email/--by-id/--by-name.
     mode_flags = [
         ("email", by_email),
@@ -867,23 +895,14 @@ def channel_unsubscribe(
     ]
     chosen = [name for name, flag in mode_flags if flag]
     if len(chosen) != 1:
-        emit_error("Exactly one of --by-email/--by-id/--by-name is required")
-        raise typer.Exit(code=1)
+        fail_validation(
+            "Exactly one of --by-email/--by-id/--by-name is required",
+            channel_name=channel_name or "",
+        )
     id_mode = cast(IdMode, chosen[0])
 
-    # Split positional targets into channel + users.
-    if channel_id is not None:
-        channel_name: str | None = None
-        users = list(targets)
-    else:
-        if len(targets) < 2:
-            emit_error("Provide a channel name (or --channel-id) and at least one user")
-            raise typer.Exit(code=1)
-        channel_name, *users = targets
-
     if not users:
-        emit_error("At least one user identifier is required")
-        raise typer.Exit(code=1)
+        fail_validation("At least one user identifier is required", channel_name=channel_name or "")
 
     options = ctx.obj or {}
     try:

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -837,9 +837,10 @@ def channel_unsubscribe(
             "all values are users."
         ),
     ),
-    channel_id: int | None = typer.Option(
+    channel_id: str | None = typer.Option(
         None,
         "--channel-id",
+        metavar="INT",
         help="Target the channel by numeric ID instead of name.",
     ),
     by_email: bool = typer.Option(False, "--by-email", help="Identify users by email address."),
@@ -877,9 +878,15 @@ def channel_unsubscribe(
         raise typer.Exit(code=1)
 
     target_values = list(targets or [])
+    parsed_channel_id: int | None = None
+    if channel_id is not None:
+        try:
+            parsed_channel_id = int(channel_id)
+        except ValueError:
+            fail_validation("--channel-id must be a numeric channel ID.")
 
     # Split positional targets into channel + users.
-    if channel_id is not None:
+    if parsed_channel_id is not None:
         channel_name: str | None = None
         users = target_values
     else:
@@ -932,13 +939,13 @@ def channel_unsubscribe(
     # in the --json error payload. The contract documents
     # ``channel_id: null`` only for the case where the channel itself
     # could not be resolved.
-    resolved_channel_id: int | None = channel_id
+    resolved_channel_id: int | None = parsed_channel_id
     resolved_channel_name: str = channel_name or ""
     try:
         target = zulip_api.resolve_channel(
             client,
             name=channel_name,
-            channel_id=channel_id,
+            channel_id=parsed_channel_id,
             include_archived=include_archived,
         )
     except ZulipError as exc:
@@ -990,7 +997,7 @@ def channel_unsubscribe(
     else:
         rows = [(item["user"], item["status"]) for item in payload["results"]]
         rows.extend((item["user"], f"error: {item['error']}") for item in payload["errors"])
-        emit_table(rows, headers=["user", "status"])
+        emit_table(rows, headers=["User", "Status"])
 
     # Per the CLI contract, exit non-zero on ANY error condition. A
     # ``partial`` status means some operations failed, so it must also

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -852,9 +852,11 @@ def channel_unsubscribe(
     ),
 ) -> None:
     """Unsubscribe one or more users from a channel."""
-    # Lazy import to avoid a circular dependency at module-load time
-    # while still allowing the CLI tests to monkeypatch ``get_client``
-    # on this module.
+    # The endpoints module is imported lazily to avoid a potential
+    # circular import at module-load time (the CLI module and the
+    # endpoints module both reference shared types). ``get_client`` is
+    # already imported at the top of this module and is monkeypatched
+    # there by the CLI unit tests.
     from lftools_uv.api.endpoints import zulip as zulip_api
 
     # Validate id-mode mutex: exactly one of --by-email/--by-id/--by-name.

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -810,3 +810,92 @@ def channel_subscribe(
 
     if result.get("status") != "success":
         raise typer.Exit(code=1)
+
+
+# `zulip channel unsubscribe` (US6 / T043)
+# ---------------------------------------------------------------------------
+
+
+@channel_app.command("unsubscribe")
+def channel_unsubscribe(
+    ctx: typer.Context,
+    targets: list[str] = typer.Argument(
+        ...,
+        metavar="[CHANNEL] USER [USER...]",
+        help=(
+            "When --channel-id is absent, the first value is the channel "
+            "name and the rest are users. When --channel-id is supplied, "
+            "all values are users."
+        ),
+    ),
+    channel_id: int | None = typer.Option(
+        None,
+        "--channel-id",
+        help="Target the channel by numeric ID instead of name.",
+    ),
+    by_email: bool = typer.Option(False, "--by-email", help="Identify users by email address."),
+    by_id: bool = typer.Option(False, "--by-id", help="Identify users by numeric user ID."),
+    by_name: bool = typer.Option(False, "--by-name", help="Identify users by full name."),
+    include_archived: bool = typer.Option(
+        False,
+        "--include-archived",
+        help="Search archived channels when resolving the channel target.",
+    ),
+) -> None:
+    """Unsubscribe one or more users from a channel."""
+    # Lazy import to avoid a circular dependency at module-load time
+    # while still allowing the CLI tests to monkeypatch ``get_client``
+    # on this module.
+    from lftools_uv.api.endpoints import zulip as zulip_api
+
+    # Validate id-mode mutex: exactly one of --by-email/--by-id/--by-name.
+    mode_flags = [
+        ("email", by_email),
+        ("id", by_id),
+        ("name", by_name),
+    ]
+    chosen = [name for name, flag in mode_flags if flag]
+    if len(chosen) != 1:
+        emit_error("Exactly one of --by-email/--by-id/--by-name is required")
+        raise typer.Exit(code=1)
+    id_mode = chosen[0]
+
+    # Split positional targets into channel + users.
+    if channel_id is not None:
+        channel_name: str | None = None
+        users = list(targets)
+    else:
+        if len(targets) < 2:
+            emit_error("Provide a channel name (or --channel-id) and at least one user")
+            raise typer.Exit(code=1)
+        channel_name, *users = targets
+
+    if not users:
+        emit_error("At least one user identifier is required")
+        raise typer.Exit(code=1)
+
+    options = ctx.obj or {}
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        payload = zulip_api.unsubscribe_users(
+            client,
+            users,
+            channel=channel_name,
+            channel_id=channel_id,
+            id_mode=id_mode,  # type: ignore[arg-type]
+            include_archived=include_archived,
+        )
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json(payload)
+        if payload["status"] == "error":
+            raise typer.Exit(code=1)
+        return
+
+    rows = [(item["user"], item["status"]) for item in payload["results"]]
+    rows.extend((item["user"], f"error: {item['error']}") for item in payload["errors"])
+    emit_table(rows, headers=["user", "status"])
+    if payload["status"] == "error":
+        raise typer.Exit(code=1)

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -853,11 +853,8 @@ def channel_unsubscribe(
     ),
 ) -> None:
     """Unsubscribe one or more users from a channel."""
-    # The endpoints module is imported lazily to avoid a potential
-    # circular import at module-load time (the CLI module and the
-    # endpoints module both reference shared types). ``get_client`` is
-    # already imported at the top of this module and is monkeypatched
-    # there by the CLI unit tests.
+    # Import the endpoint module as a namespace so tests can monkeypatch
+    # its helpers while keeping ``get_client`` patched on this module.
     from lftools_uv.api.endpoints import zulip as zulip_api
 
     options = ctx.obj or {}

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -859,8 +859,10 @@ def channel_unsubscribe(
     # there by the CLI unit tests.
     from lftools_uv.api.endpoints import zulip as zulip_api
 
+    options = ctx.obj or {}
+
     def fail_validation(message: str, *, channel_name: str = "") -> None:
-        if as_json:
+        if options.get("json_output"):
             emit_json(
                 bulk_mutation_result(
                     operation="unsubscribe",
@@ -906,7 +908,6 @@ def channel_unsubscribe(
     if not users:
         fail_validation("At least one user identifier is required", channel_name=channel_name or "")
 
-    options = ctx.obj or {}
     try:
         client = get_client(zuliprc=options.get("zuliprc"))
     except ZulipError as exc:

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -828,8 +828,8 @@ def channel_subscribe(
 @channel_app.command("unsubscribe")
 def channel_unsubscribe(
     ctx: typer.Context,
-    targets: list[str] = typer.Argument(
-        ...,
+    targets: list[str] | None = typer.Argument(
+        None,
         metavar="[CHANNEL] USER [USER...]",
         help=(
             "When --channel-id is absent, the first value is the channel "
@@ -874,18 +874,20 @@ def channel_unsubscribe(
             emit_error(message)
         raise typer.Exit(code=1)
 
+    target_values = list(targets or [])
+
     # Split positional targets into channel + users.
     if channel_id is not None:
         channel_name: str | None = None
-        users = list(targets)
+        users = target_values
     else:
-        if len(targets) < 2:
-            channel_for_error = targets[0] if targets else ""
+        if len(target_values) < 2:
+            channel_for_error = target_values[0] if target_values else ""
             fail_validation(
                 "Provide a channel name (or --channel-id) and at least one user",
                 channel_name=channel_for_error,
             )
-        channel_name, *users = targets
+        channel_name, *users = target_values
 
     # Validate id-mode mutex: exactly one of --by-email/--by-id/--by-name.
     mode_flags = [

--- a/specs/001-zulip-channel-mgmt/tasks.md
+++ b/specs/001-zulip-channel-mgmt/tasks.md
@@ -180,13 +180,13 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 ### Tests for User Story 6
 
-- [X] T040 [P] [US6] Write CLI tests for `channel unsubscribe` in tests/unit/test_zulip_cli.py — test single user, bulk, --by-name ambiguity, not-subscribed no-op, --json output
-- [X] T041 [P] [US6] Write API tests for `unsubscribe_users()` in tests/unit/test_zulip_api.py — mock Zulip unsubscribe endpoint, test single/bulk, not-subscribed, partial
+- [x] T040 [P] [US6] Write CLI tests for `channel unsubscribe` in tests/unit/test_zulip_cli.py — test single user, bulk, --by-name ambiguity, not-subscribed no-op, --json output
+- [x] T041 [P] [US6] Write API tests for `unsubscribe_users()` in tests/unit/test_zulip_api.py — mock Zulip unsubscribe endpoint, test single/bulk, not-subscribed, partial
 
 ### Implementation for User Story 6
 
-- [X] T042 [US6] Implement `unsubscribe_users(client, channel, users, id_mode)` in lftools_uv/api/endpoints/zulip.py — resolve channel target, resolve user identifiers, call Zulip unsubscribe API, handle partial results, return bulk MutationResult
-- [X] T043 [US6] Implement `channel unsubscribe` CLI command in lftools_uv/typer_apps/zulip.py — add `unsubscribe` command with same signature pattern as subscribe, handle `--json` with bulk mutation schema
+- [x] T042 [US6] Implement `unsubscribe_users(client, channel, users, id_mode)` in lftools_uv/api/endpoints/zulip.py — resolve channel target, resolve user identifiers, call Zulip unsubscribe API, handle partial results, return bulk MutationResult
+- [x] T043 [US6] Implement `channel unsubscribe` CLI command in lftools_uv/typer_apps/zulip.py — add `unsubscribe` command with same signature pattern as subscribe, handle `--json` with bulk mutation schema
 
 **Checkpoint**: User Story 6 is fully functional — `lftools-uv zulip channel unsubscribe` works independently
 

--- a/specs/001-zulip-channel-mgmt/tasks.md
+++ b/specs/001-zulip-channel-mgmt/tasks.md
@@ -180,13 +180,13 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 ### Tests for User Story 6
 
-- [ ] T040 [P] [US6] Write CLI tests for `channel unsubscribe` in tests/unit/test_zulip_cli.py — test single user, bulk, --by-name ambiguity, not-subscribed no-op, --json output
-- [ ] T041 [P] [US6] Write API tests for `unsubscribe_users()` in tests/unit/test_zulip_api.py — mock Zulip unsubscribe endpoint, test single/bulk, not-subscribed, partial
+- [X] T040 [P] [US6] Write CLI tests for `channel unsubscribe` in tests/unit/test_zulip_cli.py — test single user, bulk, --by-name ambiguity, not-subscribed no-op, --json output
+- [X] T041 [P] [US6] Write API tests for `unsubscribe_users()` in tests/unit/test_zulip_api.py — mock Zulip unsubscribe endpoint, test single/bulk, not-subscribed, partial
 
 ### Implementation for User Story 6
 
-- [ ] T042 [US6] Implement `unsubscribe_users(client, channel, users, id_mode)` in lftools_uv/api/endpoints/zulip.py — resolve channel target, resolve user identifiers, call Zulip unsubscribe API, handle partial results, return bulk MutationResult
-- [ ] T043 [US6] Implement `channel unsubscribe` CLI command in lftools_uv/typer_apps/zulip.py — add `unsubscribe` command with same signature pattern as subscribe, handle `--json` with bulk mutation schema
+- [X] T042 [US6] Implement `unsubscribe_users(client, channel, users, id_mode)` in lftools_uv/api/endpoints/zulip.py — resolve channel target, resolve user identifiers, call Zulip unsubscribe API, handle partial results, return bulk MutationResult
+- [X] T043 [US6] Implement `channel unsubscribe` CLI command in lftools_uv/typer_apps/zulip.py — add `unsubscribe` command with same signature pattern as subscribe, handle `--json` with bulk mutation schema
 
 **Checkpoint**: User Story 6 is fully functional — `lftools-uv zulip channel unsubscribe` works independently
 

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1900,3 +1900,15 @@ def test_unsubscribe_users_resolved_channel_skips_resolution() -> None:
     assert payload["status"] == "success"
     assert payload["channel_id"] == 1
     assert payload["channel_name"] == "general"
+
+
+def test_unsubscribe_users_rejects_malformed_resolved_channel() -> None:
+    """A caller-supplied channel must include numeric id and string name."""
+    client = mock.MagicMock()
+    with pytest.raises(ZulipAPIError, match="Malformed stream object"):
+        _ = unsubscribe_users(
+            client,
+            ["bob@example.com"],
+            id_mode="email",
+            resolved_channel={"stream_id": "bad", "name": "general"},
+        )

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1770,6 +1770,23 @@ def test_unsubscribe_users_name_ambiguity_lists_matches() -> None:
     assert "id: 100" in error["error"]
 
 
+def test_unsubscribe_users_rejects_resolved_user_without_email() -> None:
+    """Name/email modes require a usable email principal per resolved user."""
+    members = [{"user_id": 300, "full_name": "No Email", "is_bot": False, "is_active": True}]
+    client = _unsubscribe_client(ACTIVE_STREAMS, members, removed=[], not_removed=[])
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["No Email"],
+        id_mode="name",
+    )
+    assert payload["status"] == "error"
+    assert payload["results"] == []
+    assert "missing email" in payload["errors"][0]["error"]
+    delete_calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
+    assert not delete_calls
+
+
 def test_unsubscribe_users_by_id_passes_principals_as_ints() -> None:
     """When id_mode='id', principals sent to Zulip are integer user ids."""
     client = _unsubscribe_client(

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1656,8 +1656,8 @@ def test_unsubscribe_users_not_subscribed_noop() -> None:
     assert payload["errors"] == []
 
 
-def test_unsubscribe_users_partial() -> None:
-    """A mix of removed + not_removed is still a success (all exits clean)."""
+def test_unsubscribe_users_mixed_removed_and_not_removed_is_success() -> None:
+    """A mix of removed + not_removed (no errors) is overall success."""
     client = _unsubscribe_client(
         ACTIVE_STREAMS,
         MEMBERS,
@@ -1678,6 +1678,69 @@ def test_unsubscribe_users_partial() -> None:
         "bob@example.com": "not_subscribed",
     }
     assert payload["errors"] == []
+
+
+def test_unsubscribe_users_partial() -> None:
+    """A mix of resolvable users + an unknown identifier yields partial.
+
+    The unknown identifier is captured into ``errors`` instead of
+    aborting the whole call, while the resolvable user is still sent
+    to the server. Overall status is ``partial`` because we have both
+    a successful result and an error.
+    """
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=["bob@example.com"],
+        not_removed=[],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["bob@example.com", "ghost@example.com"],
+        id_mode="email",
+    )
+    assert payload["status"] == "partial"
+    assert payload["results"] == [
+        {"user": "bob@example.com", "status": "unsubscribed"},
+    ]
+    assert len(payload["errors"]) == 1
+    err = payload["errors"][0]
+    assert err["user"] == "ghost@example.com"
+    assert "ghost@example.com" in err["error"]
+
+    # The server-side DELETE call must only include the principal for
+    # the successfully-resolved user.
+    delete_calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
+    assert delete_calls, "expected an unsubscribe DELETE call"
+    assert delete_calls[0].kwargs["request"]["principals"] == ["bob@example.com"]
+
+
+def test_unsubscribe_users_all_unknown_is_error() -> None:
+    """When every identifier fails to resolve, status is ``error`` and the
+    DELETE endpoint is never called.
+    """
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=[],
+        not_removed=[],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["ghost@example.com", "phantom@example.com"],
+        id_mode="email",
+    )
+    assert payload["status"] == "error"
+    assert payload["results"] == []
+    assert {e["user"] for e in payload["errors"]} == {
+        "ghost@example.com",
+        "phantom@example.com",
+    }
+    # No DELETE call should have been issued because no user resolved.
+    delete_calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
+    assert not delete_calls, "DELETE should not be called when no user resolved"
 
 
 def test_unsubscribe_users_by_id_passes_principals_as_ints() -> None:

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1580,11 +1580,16 @@ def _unsubscribe_client(
         if url == "streams" and method == "GET":
             return {"result": "success", "streams": streams}
         if url == "users/me/subscriptions" and method == "DELETE":
+            request = request or {}
+            subscription = (request.get("subscriptions") or [""])[0]
+            principal = (request.get("principals") or [None])[0]
+            removed_streams = [subscription] if principal in (removed or []) else []
+            not_removed_streams = [subscription] if principal in (not_removed or []) else []
             return {
                 "result": result,
                 "msg": msg,
-                "removed": list(removed or []),
-                "not_removed": list(not_removed or []),
+                "removed": removed_streams,
+                "not_removed": not_removed_streams,
             }
         raise AssertionError(f"Unexpected endpoint call: {method} {url}")
 
@@ -1863,7 +1868,7 @@ def test_unsubscribe_users_resolved_channel_skips_resolution() -> None:
             return {
                 "result": "success",
                 "msg": "",
-                "removed": ["bob@example.com"],
+                "removed": ["general"],
                 "not_removed": [],
             }
         raise AssertionError(f"Unexpected endpoint call: {method} {url}")

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -19,6 +19,7 @@ Covers the foundational tasks T016–T019:
 
 from __future__ import annotations
 
+import json as _json
 from typing import Any
 from unittest import mock
 
@@ -1581,8 +1582,10 @@ def _unsubscribe_client(
             return {"result": "success", "streams": streams}
         if url == "users/me/subscriptions" and method == "DELETE":
             request = request or {}
-            subscription = (request.get("subscriptions") or [""])[0]
-            principal = (request.get("principals") or [None])[0]
+            subscriptions = _json.loads(request.get("subscriptions", "[]"))
+            principals = _json.loads(request.get("principals", "[]"))
+            subscription = (subscriptions or [""])[0]
+            principal = (principals or [None])[0]
             removed_streams = [subscription] if principal in (removed or []) else []
             not_removed_streams = [subscription] if principal in (not_removed or []) else []
             return {
@@ -1718,7 +1721,7 @@ def test_unsubscribe_users_partial() -> None:
     # the successfully-resolved user.
     delete_calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
     assert delete_calls, "expected an unsubscribe DELETE call"
-    assert delete_calls[0].kwargs["request"]["principals"] == ["bob@example.com"]
+    assert _json.loads(delete_calls[0].kwargs["request"]["principals"]) == ["bob@example.com"]
 
 
 def test_unsubscribe_users_all_unknown_is_error() -> None:
@@ -1786,8 +1789,8 @@ def test_unsubscribe_users_by_id_passes_principals_as_ints() -> None:
     calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
     assert calls, "expected an unsubscribe DELETE call"
     request = calls[0].kwargs["request"]
-    assert request["subscriptions"] == ["general"]
-    assert request["principals"] == [200]
+    assert _json.loads(request["subscriptions"]) == ["general"]
+    assert _json.loads(request["principals"]) == [200]
 
 
 def test_unsubscribe_users_by_channel_id() -> None:

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -45,6 +45,7 @@ from lftools_uv.api.endpoints.zulip import (
     resolve_groups,
     resolve_users,
     subscribe_users,
+    unsubscribe_users,
 )
 
 # ---------------------------------------------------------------------------
@@ -1551,4 +1552,212 @@ def test_subscribe_users_rejects_malformed_unauthorized_field() -> None:
             ["bob@example.com"],
             id_mode="email",
             _resolved_stream={"stream_id": 42, "name": "general"},
+        )
+
+
+# T041 — Unsubscribe users (US6)
+# ---------------------------------------------------------------------------
+
+
+def _unsubscribe_client(
+    streams: list[dict[str, Any]],
+    members: list[dict[str, Any]],
+    *,
+    removed: list[Any] | None = None,
+    not_removed: list[Any] | None = None,
+    result: str = "success",
+    msg: str = "",
+) -> Any:
+    """Build a mock client supporting streams + members + unsubscribe.
+
+    The first ``streams`` call returns the active streams. The
+    ``DELETE users/me/subscriptions`` call returns the configured
+    ``removed`` / ``not_removed`` payload.
+    """
+    client = mock.MagicMock()
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:
+        if url == "streams" and method == "GET":
+            return {"result": "success", "streams": streams}
+        if url == "users/me/subscriptions" and method == "DELETE":
+            return {
+                "result": result,
+                "msg": msg,
+                "removed": list(removed or []),
+                "not_removed": list(not_removed or []),
+            }
+        raise AssertionError(f"Unexpected endpoint call: {method} {url}")
+
+    client.call_endpoint.side_effect = call_endpoint
+    client.get_members.return_value = {"result": "success", "members": members}
+    return client
+
+
+def test_unsubscribe_users_single_success() -> None:
+    """A single user successfully unsubscribed returns success bulk result."""
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=["bob@example.com"],
+        not_removed=[],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["bob@example.com"],
+        id_mode="email",
+    )
+    assert payload["status"] == "success"
+    assert payload["operation"] == "unsubscribe"
+    assert payload["channel_id"] == 1
+    assert payload["channel_name"] == "general"
+    assert payload["results"] == [{"user": "bob@example.com", "status": "unsubscribed"}]
+    assert payload["errors"] == []
+
+
+def test_unsubscribe_users_bulk_success() -> None:
+    """Bulk unsubscribe returns one result entry per requested user."""
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=["alice@example.com", "bob@example.com"],
+        not_removed=[],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["alice@example.com", "bob@example.com"],
+        id_mode="email",
+    )
+    assert payload["status"] == "success"
+    assert {r["user"] for r in payload["results"]} == {
+        "alice@example.com",
+        "bob@example.com",
+    }
+    assert all(r["status"] == "unsubscribed" for r in payload["results"])
+
+
+def test_unsubscribe_users_not_subscribed_noop() -> None:
+    """Users not subscribed appear as ``not_subscribed`` no-ops, still success."""
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=[],
+        not_removed=["bob@example.com"],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["bob@example.com"],
+        id_mode="email",
+    )
+    assert payload["status"] == "success"
+    assert payload["results"] == [{"user": "bob@example.com", "status": "not_subscribed"}]
+    assert payload["errors"] == []
+
+
+def test_unsubscribe_users_partial() -> None:
+    """A mix of removed + not_removed is still a success (all exits clean)."""
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=["alice@example.com"],
+        not_removed=["bob@example.com"],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["alice@example.com", "bob@example.com"],
+        id_mode="email",
+    )
+    # Both finished cleanly with no errors -> overall success.
+    assert payload["status"] == "success"
+    statuses = {r["user"]: r["status"] for r in payload["results"]}
+    assert statuses == {
+        "alice@example.com": "unsubscribed",
+        "bob@example.com": "not_subscribed",
+    }
+    assert payload["errors"] == []
+
+
+def test_unsubscribe_users_by_id_passes_principals_as_ints() -> None:
+    """When id_mode='id', principals sent to Zulip are integer user ids."""
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=[200],
+        not_removed=[],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["200"],
+        id_mode="id",
+    )
+    assert payload["status"] == "success"
+    # Inspect the DELETE call arguments.
+    calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
+    assert calls, "expected an unsubscribe DELETE call"
+    request = calls[0].kwargs["request"]
+    assert request["subscriptions"] == ["general"]
+    assert request["principals"] == [200]
+
+
+def test_unsubscribe_users_by_channel_id() -> None:
+    """``channel_id`` may target the channel instead of by name."""
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=["bob@example.com"],
+        not_removed=[],
+    )
+    payload = unsubscribe_users(
+        client,
+        channel_id=2,
+        users=["bob@example.com"],
+        id_mode="email",
+    )
+    assert payload["channel_id"] == 2
+    assert payload["channel_name"] == "Engineering"
+    assert payload["status"] == "success"
+
+
+def test_unsubscribe_users_requires_one_channel_target() -> None:
+    """Exactly one of ``channel`` or ``channel_id`` must be supplied."""
+    client = _unsubscribe_client(ACTIVE_STREAMS, MEMBERS)
+    with pytest.raises(ZulipValidationError):
+        _ = unsubscribe_users(client, users=["x"], id_mode="email")
+    with pytest.raises(ZulipValidationError):
+        _ = unsubscribe_users(
+            client,
+            channel="general",
+            channel_id=1,
+            users=["x"],
+            id_mode="email",
+        )
+
+
+def test_unsubscribe_users_requires_at_least_one_user() -> None:
+    """An empty user list is a programmer error."""
+    client = _unsubscribe_client(ACTIVE_STREAMS, MEMBERS)
+    with pytest.raises(ZulipValidationError):
+        _ = unsubscribe_users(client, channel="general", users=[], id_mode="email")
+
+
+def test_unsubscribe_users_api_error_marks_all_errors() -> None:
+    """A non-success Zulip response surfaces as :class:`ZulipAPIError`."""
+    client = _unsubscribe_client(
+        ACTIVE_STREAMS,
+        MEMBERS,
+        removed=[],
+        not_removed=[],
+        result="error",
+        msg="Boom",
+    )
+    with pytest.raises(ZulipAPIError, match="Boom"):
+        _ = unsubscribe_users(
+            client,
+            channel="general",
+            users=["bob@example.com"],
+            id_mode="email",
         )

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1824,3 +1824,40 @@ def test_unsubscribe_users_api_error_marks_all_errors() -> None:
             users=["bob@example.com"],
             id_mode="email",
         )
+
+
+def test_unsubscribe_users_resolved_channel_skips_resolution() -> None:
+    """A caller-supplied ``resolved_channel`` skips ``GET /streams``.
+
+    Pinning this behavior prevents the CLI from incurring two streams
+    round-trips per ``zulip channel unsubscribe`` invocation: the CLI
+    pre-resolves the channel to capture the resolved id/name for its
+    ``--json`` error payload contract and then forwards the result
+    here.
+    """
+    client = mock.MagicMock()
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:
+        if url == "streams":
+            raise AssertionError("unsubscribe_users must not call GET /streams when resolved_channel is supplied")
+        if url == "users/me/subscriptions" and method == "DELETE":
+            return {
+                "result": "success",
+                "msg": "",
+                "removed": ["bob@example.com"],
+                "not_removed": [],
+            }
+        raise AssertionError(f"Unexpected endpoint call: {method} {url}")
+
+    client.call_endpoint.side_effect = call_endpoint
+    client.get_members.return_value = {"result": "success", "members": MEMBERS}
+
+    payload = unsubscribe_users(
+        client,
+        ["bob@example.com"],
+        id_mode="email",
+        resolved_channel={"stream_id": 1, "name": "general"},
+    )
+    assert payload["status"] == "success"
+    assert payload["channel_id"] == 1
+    assert payload["channel_name"] == "general"

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1743,6 +1743,25 @@ def test_unsubscribe_users_all_unknown_is_error() -> None:
     assert not delete_calls, "DELETE should not be called when no user resolved"
 
 
+def test_unsubscribe_users_name_ambiguity_lists_matches() -> None:
+    """Ambiguous --by-name errors include user IDs and emails."""
+    client = _unsubscribe_client(ACTIVE_STREAMS, MEMBERS, removed=[], not_removed=[])
+    payload = unsubscribe_users(
+        client,
+        channel="general",
+        users=["Alice Smith"],
+        id_mode="name",
+    )
+    assert payload["status"] == "error"
+    error = payload["errors"][0]
+    assert error["matches"] == [
+        {"user_id": 100, "full_name": "Alice Smith", "email": "alice@example.com"},
+        {"user_id": 101, "full_name": "Alice Smith", "email": "alice2@example.com"},
+    ]
+    assert "alice@example.com" in error["error"]
+    assert "id: 100" in error["error"]
+
+
 def test_unsubscribe_users_by_id_passes_principals_as_ints() -> None:
     """When id_mode='id', principals sent to Zulip are integer user ids."""
     client = _unsubscribe_client(

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1834,7 +1834,7 @@ def test_unsubscribe_users_requires_at_least_one_user() -> None:
         _ = unsubscribe_users(client, channel="general", users=[], id_mode="email")
 
 
-def test_unsubscribe_users_api_error_marks_all_errors() -> None:
+def test_unsubscribe_users_api_error_raises() -> None:
     """A non-success Zulip response surfaces as :class:`ZulipAPIError`."""
     client = _unsubscribe_client(
         ACTIVE_STREAMS,

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -1834,6 +1834,18 @@ def test_unsubscribe_users_requires_at_least_one_user() -> None:
         _ = unsubscribe_users(client, channel="general", users=[], id_mode="email")
 
 
+def test_unsubscribe_users_rejects_more_than_fifty_users() -> None:
+    """Bulk unsubscribe enforces the shared 50-user invocation limit."""
+    client = _unsubscribe_client(ACTIVE_STREAMS, MEMBERS)
+    with pytest.raises(ZulipValidationError, match="at most 50 users"):
+        _ = unsubscribe_users(
+            client,
+            channel="general",
+            users=[f"user{i}@example.com" for i in range(51)],
+            id_mode="email",
+        )
+
+
 def test_unsubscribe_users_api_error_raises() -> None:
     """A non-success Zulip response surfaces as :class:`ZulipAPIError`."""
     client = _unsubscribe_client(

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1640,6 +1640,45 @@ def test_channel_unsubscribe_json_error_after_channel_resolved(
     assert payload["errors"] and "Boom" in payload["errors"][0]["error"]
 
 
+def test_channel_unsubscribe_json_error_client_init_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``get_client`` itself fails, the JSON payload reports
+    ``channel_id: null`` because the channel was never resolved.
+
+    Even if the operator supplied ``--channel-id N``, the value is
+    not echoed back: per the contract, ``channel_id`` carries the
+    *resolved* identifier, and a configuration/connect failure
+    happens before any resolution attempt.
+    """
+    import lftools_uv.typer_apps.zulip as zulip_mod
+    from lftools_uv.api.endpoints.zulip import ZulipError
+
+    def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise ZulipError("config missing")
+
+    monkeypatch.setattr(zulip_mod, "get_client", _boom)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "unsubscribe",
+            "--channel-id",
+            "42",
+            "bob@example.com",
+            "--by-email",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 1
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["channel_id"] is None
+    assert payload["channel_name"] == ""
+    assert payload["errors"] and "config missing" in payload["errors"][0]["error"]
+
+
 def test_channel_unsubscribe_json_error_channel_unresolved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1473,6 +1473,19 @@ def test_channel_unsubscribe_bulk(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "bob@example.com" in result.stdout
 
 
+def test_channel_unsubscribe_table_headers_title_cased(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-JSON unsubscribe output matches subscribe table headers."""
+    client = _build_client(removed=["bob@example.com"], not_removed=[])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "bob@example.com", "--by-email"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "User" in result.stdout
+    assert "Status" in result.stdout
+
+
 def test_channel_unsubscribe_by_name_ambiguity(monkeypatch: pytest.MonkeyPatch) -> None:
     """An ambiguous --by-name lookup exits 1 with a clear error."""
     client = _build_client(removed=[], not_removed=[])
@@ -1536,6 +1549,24 @@ def test_channel_unsubscribe_by_channel_id(monkeypatch: pytest.MonkeyPatch) -> N
     payload = json.loads(result.stdout)
     assert payload["channel_id"] == 2
     assert payload["channel_name"] == "Engineering"
+
+
+def test_channel_unsubscribe_invalid_channel_id_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid --channel-id exits 1 and preserves the JSON error schema."""
+    client = _build_client(removed=[], not_removed=[])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["--channel-id", "not-an-int", "bob@example.com", "--by-email", "--json"],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["channel_id"] is None
+    assert "numeric channel ID" in payload["errors"][0]["error"]
+    assert result.stderr == ""
 
 
 def test_channel_unsubscribe_requires_id_mode(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1545,11 +1545,39 @@ def test_channel_unsubscribe_requires_id_mode(monkeypatch: pytest.MonkeyPatch) -
     assert "by-email" in (result.stderr or "") or "by-id" in (result.stderr or "")
 
 
+def test_channel_unsubscribe_requires_id_mode_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ID-mode validation honors the --json error contract."""
+    client = _build_client(removed=[], not_removed=[])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "bob@example.com", "--json"],
+    )
+    assert result.exit_code == 1
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["channel_name"] == "general"
+    assert "by-email" in payload["errors"][0]["error"]
+    assert result.stderr == ""
+
+
 def test_channel_unsubscribe_rejects_no_channel_target(monkeypatch: pytest.MonkeyPatch) -> None:
     """Missing both channel name and --channel-id is a CLI error."""
     client = _build_client(removed=[], not_removed=[])
     result = _invoke_unsubscribe(monkeypatch, client, ["--by-email"])
     assert result.exit_code != 0
+
+
+def test_channel_unsubscribe_rejects_missing_user_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing user validation honors the --json error contract."""
+    client = _build_client(removed=[], not_removed=[])
+    result = _invoke_unsubscribe(monkeypatch, client, ["general", "--by-email", "--json"])
+    assert result.exit_code == 1
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["channel_name"] == "general"
+    assert "at least one user" in payload["errors"][0]["error"]
+    assert result.stderr == ""
 
 
 def test_channel_unsubscribe_partial_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1414,8 +1414,8 @@ def _build_client(*, removed: list[Any], not_removed: list[Any]) -> Any:
             return {"result": "success", "streams": _STREAMS}
         if url == "users/me/subscriptions" and method == "DELETE":
             request = request or {}
-            subscriptions = _json.loads(request.get("subscriptions", "[]"))
-            principals = _json.loads(request.get("principals", "[]"))
+            subscriptions = json.loads(request.get("subscriptions", "[]"))
+            principals = json.loads(request.get("principals", "[]"))
             subscription = (subscriptions or [""])[0]
             principal = (principals or [None])[0]
             return {
@@ -1559,7 +1559,7 @@ def test_channel_unsubscribe_requires_id_mode_json(monkeypatch: pytest.MonkeyPat
         ["general", "bob@example.com", "--json"],
     )
     assert result.exit_code == 1
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert payload["channel_name"] == "general"
     assert "by-email" in payload["errors"][0]["error"]
@@ -1578,7 +1578,7 @@ def test_channel_unsubscribe_rejects_missing_user_json(monkeypatch: pytest.Monke
     client = _build_client(removed=[], not_removed=[])
     result = _invoke_unsubscribe(monkeypatch, client, ["general", "--by-email", "--json"])
     assert result.exit_code == 1
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert payload["channel_name"] == "general"
     assert "at least one user" in payload["errors"][0]["error"]
@@ -1592,7 +1592,7 @@ def test_channel_unsubscribe_rejects_no_user_with_channel_id_json(
     client = _build_client(removed=[], not_removed=[])
     result = _invoke_unsubscribe(monkeypatch, client, ["--channel-id", "42", "--by-email", "--json"])
     assert result.exit_code == 1
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert payload["channel_id"] is None
     assert "At least one user" in payload["errors"][0]["error"]
@@ -1615,7 +1615,7 @@ def test_channel_unsubscribe_partial_exits_one(monkeypatch: pytest.MonkeyPatch) 
             "--json",
         ],
     )
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "partial"
     assert result.exit_code == 1
 
@@ -1639,7 +1639,7 @@ def test_channel_unsubscribe_json_error_payload(monkeypatch: pytest.MonkeyPatch)
         ["general", "ghost@example.com", "--by-email", "--json"],
     )
     assert result.exit_code == 1
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert payload["operation"] == "unsubscribe"
     assert payload["channel_name"] == "general"
@@ -1679,7 +1679,7 @@ def test_channel_unsubscribe_json_error_after_channel_resolved(
         ["general", "bob@example.com", "--by-email", "--json"],
     )
     assert result.exit_code == 1
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert payload["operation"] == "unsubscribe"
     assert payload["channel_id"] == 1
@@ -1719,7 +1719,7 @@ def test_channel_unsubscribe_json_error_client_init_failure(
         ],
     )
     assert result.exit_code == 1
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert payload["channel_id"] is None
     assert payload["channel_name"] == ""
@@ -1749,7 +1749,7 @@ def test_channel_unsubscribe_json_error_channel_unresolved(
         ["nosuch", "bob@example.com", "--by-email", "--json"],
     )
     assert result.exit_code == 1
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert payload["channel_id"] is None
     assert payload["channel_name"] == "nosuch"

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1477,7 +1477,12 @@ def test_channel_unsubscribe_by_name_ambiguity(monkeypatch: pytest.MonkeyPatch) 
         ["general", "Alice Smith", "--by-name"],
     )
     assert result.exit_code == 1
-    assert "ambig" in (result.stderr or "").lower() or "matched" in (result.stderr or "").lower()
+    # Ambiguity is now captured as a per-user error in the bulk result
+    # (so partial bulk operations still complete for the resolvable
+    # users). The single-user case yields status=error, exit 1, and
+    # the error appears in the rendered table on stdout.
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "matched" in combined.lower() or "ambig" in combined.lower()
 
 
 def test_channel_unsubscribe_not_subscribed_noop(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1368,3 +1368,176 @@ def test_channel_subscribe_table_headers_title_cased() -> None:
     assert result.exit_code == 0
     assert "User" in result.stdout
     assert "Status" in result.stdout
+
+
+# T040 — channel unsubscribe CLI (US6)
+# ---------------------------------------------------------------------------
+
+
+_STREAMS = [
+    {"stream_id": 1, "name": "general", "description": "g", "is_archived": False},
+    {"stream_id": 2, "name": "Engineering", "description": "e", "is_archived": False},
+]
+_MEMBERS = [
+    {
+        "user_id": 100,
+        "full_name": "Alice Smith",
+        "email": "alice@example.com",
+        "delivery_email": "alice@example.com",
+        "is_bot": False,
+        "is_active": True,
+    },
+    {
+        "user_id": 101,
+        "full_name": "Alice Smith",
+        "email": "alice2@example.com",
+        "delivery_email": "alice2@example.com",
+        "is_bot": False,
+        "is_active": True,
+    },
+    {
+        "user_id": 200,
+        "full_name": "Bob Jones",
+        "email": "bob@example.com",
+        "delivery_email": "bob@example.com",
+        "is_bot": False,
+        "is_active": True,
+    },
+]
+
+
+def _build_client(*, removed: list[Any], not_removed: list[Any]) -> Any:
+    client = mock.MagicMock()
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:
+        if url == "streams" and method == "GET":
+            return {"result": "success", "streams": _STREAMS}
+        if url == "users/me/subscriptions" and method == "DELETE":
+            return {
+                "result": "success",
+                "msg": "",
+                "removed": list(removed),
+                "not_removed": list(not_removed),
+            }
+        raise AssertionError(f"Unexpected endpoint: {method} {url}")
+
+    client.call_endpoint.side_effect = call_endpoint
+    client.get_members.return_value = {"result": "success", "members": _MEMBERS}
+    return client
+
+
+def _invoke_unsubscribe(monkeypatch: pytest.MonkeyPatch, client: Any, args: list[str]) -> Any:
+    """Patch ``get_client`` then invoke ``zulip channel unsubscribe``."""
+    import lftools_uv.typer_apps.zulip as zulip_mod
+
+    monkeypatch.setattr(zulip_mod, "get_client", lambda *a, **kw: client)
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
+    runner = CliRunner()
+    return runner.invoke(zulip_app, ["channel", "unsubscribe", *args])
+
+
+def test_channel_unsubscribe_single_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Single user unsubscribe exits 0 and reports success to stdout."""
+    client = _build_client(removed=["bob@example.com"], not_removed=[])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "bob@example.com", "--by-email"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "bob@example.com" in result.stdout
+
+
+def test_channel_unsubscribe_bulk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bulk unsubscribe accepts multiple positional USER values."""
+    client = _build_client(
+        removed=["alice@example.com", "bob@example.com"],
+        not_removed=[],
+    )
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "alice@example.com", "bob@example.com", "--by-email"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "alice@example.com" in result.stdout
+    assert "bob@example.com" in result.stdout
+
+
+def test_channel_unsubscribe_by_name_ambiguity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An ambiguous --by-name lookup exits 1 with a clear error."""
+    client = _build_client(removed=[], not_removed=[])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "Alice Smith", "--by-name"],
+    )
+    assert result.exit_code == 1
+    assert "ambig" in (result.stderr or "").lower() or "matched" in (result.stderr or "").lower()
+
+
+def test_channel_unsubscribe_not_subscribed_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unsubscribing a user who isn't subscribed is a no-op success."""
+    client = _build_client(removed=[], not_removed=["bob@example.com"])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "bob@example.com", "--by-email"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "not_subscribed" in result.stdout or "not subscribed" in result.stdout.lower()
+
+
+def test_channel_unsubscribe_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--json emits the canonical bulk MutationResult schema on stdout."""
+    client = _build_client(removed=["bob@example.com"], not_removed=[])
+    runner = CliRunner()
+    monkeypatch.setattr(zulip_mod, "get_client", lambda *a, **kw: client)
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
+    result = runner.invoke(
+        zulip_app,
+        ["--json", "channel", "unsubscribe", "general", "bob@example.com", "--by-email"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert payload["operation"] == "unsubscribe"
+    assert payload["channel_name"] == "general"
+    assert payload["channel_id"] == 1
+    assert payload["status"] == "success"
+    assert payload["results"] == [{"user": "bob@example.com", "status": "unsubscribed"}]
+    assert payload["errors"] == []
+
+
+def test_channel_unsubscribe_by_channel_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--channel-id targets the channel without a positional channel name."""
+    client = _build_client(removed=["bob@example.com"], not_removed=[])
+    runner = CliRunner()
+    monkeypatch.setattr(zulip_mod, "get_client", lambda *a, **kw: client)
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
+    result = runner.invoke(
+        zulip_app,
+        ["--json", "channel", "unsubscribe", "--channel-id", "2", "bob@example.com", "--by-email"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert payload["channel_id"] == 2
+    assert payload["channel_name"] == "Engineering"
+
+
+def test_channel_unsubscribe_requires_id_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exactly one of --by-email/--by-id/--by-name is required."""
+    client = _build_client(removed=[], not_removed=[])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "bob@example.com"],
+    )
+    assert result.exit_code == 1
+    assert "by-email" in (result.stderr or "") or "by-id" in (result.stderr or "")
+
+
+def test_channel_unsubscribe_rejects_no_channel_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing both channel name and --channel-id is a CLI error."""
+    client = _build_client(removed=[], not_removed=[])
+    result = _invoke_unsubscribe(monkeypatch, client, ["--by-email"])
+    assert result.exit_code != 0

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1413,11 +1413,14 @@ def _build_client(*, removed: list[Any], not_removed: list[Any]) -> Any:
         if url == "streams" and method == "GET":
             return {"result": "success", "streams": _STREAMS}
         if url == "users/me/subscriptions" and method == "DELETE":
+            request = request or {}
+            subscription = (request.get("subscriptions") or [""])[0]
+            principal = (request.get("principals") or [None])[0]
             return {
                 "result": "success",
                 "msg": "",
-                "removed": list(removed),
-                "not_removed": list(not_removed),
+                "removed": [subscription] if principal in removed else [],
+                "not_removed": [subscription] if principal in not_removed else [],
             }
         raise AssertionError(f"Unexpected endpoint: {method} {url}")
 
@@ -1577,6 +1580,20 @@ def test_channel_unsubscribe_rejects_missing_user_json(monkeypatch: pytest.Monke
     assert payload["status"] == "error"
     assert payload["channel_name"] == "general"
     assert "at least one user" in payload["errors"][0]["error"]
+    assert result.stderr == ""
+
+
+def test_channel_unsubscribe_rejects_no_user_with_channel_id_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The zero-target --channel-id case also returns JSON."""
+    client = _build_client(removed=[], not_removed=[])
+    result = _invoke_unsubscribe(monkeypatch, client, ["--channel-id", "42", "--by-email", "--json"])
+    assert result.exit_code == 1
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["channel_id"] is None
+    assert "At least one user" in payload["errors"][0]["error"]
     assert result.stderr == ""
 
 

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1652,8 +1652,8 @@ def test_channel_unsubscribe_partial_exits_one(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_channel_unsubscribe_json_error_payload(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When --json is requested and the API errors, emit JSON to stdout."""
-    # Empty members list -> resolve_users raises ZulipNotFoundError.
+    """When user resolution fails under --json, emit bulk error JSON."""
+    # Empty members list -> per-user resolution returns an error result.
     client = mock.MagicMock()
 
     def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1438,11 +1438,7 @@ def _invoke_unsubscribe(monkeypatch: pytest.MonkeyPatch, client: Any, args: list
     monkeypatch.setattr(zulip_mod, "get_client", lambda *a, **kw: client)
     monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
     runner = CliRunner()
-    prefix: list[str] = []
-    if "--json" in args:
-        args = [arg for arg in args if arg != "--json"]
-        prefix.append("--json")
-    return runner.invoke(zulip_app, [*prefix, "channel", "unsubscribe", *args])
+    return runner.invoke(zulip_app, ["channel", "unsubscribe", *args])
 
 
 def test_channel_unsubscribe_single_user(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1597,3 +1597,73 @@ def test_channel_unsubscribe_json_error_payload(monkeypatch: pytest.MonkeyPatch)
     assert payload["operation"] == "unsubscribe"
     assert payload["channel_name"] == "general"
     assert payload["errors"] and "ghost@example.com" in payload["errors"][0]["error"]
+
+
+def test_channel_unsubscribe_json_error_after_channel_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raised ZulipError after channel resolution still emits JSON
+    with the resolved channel_id and channel_name.
+
+    Exercises the ``except ZulipError`` branch of the CLI's mutation
+    call: the Zulip DELETE endpoint returns a non-success response,
+    which surfaces as ZulipAPIError. The contract requires the JSON
+    payload to report the resolved channel info (because the channel
+    *was* resolved) — ``channel_id: null`` is reserved for the case
+    where the channel itself could not be resolved.
+    """
+    client = mock.MagicMock()
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:
+        if url == "streams" and method == "GET":
+            return {"result": "success", "streams": _STREAMS}
+        if url == "users/me/subscriptions" and method == "DELETE":
+            # The Zulip server rejected the call; this surfaces as
+            # ZulipAPIError from unsubscribe_users().
+            return {"result": "error", "msg": "Boom", "removed": [], "not_removed": []}
+        raise AssertionError(f"Unexpected endpoint: {method} {url}")
+
+    client.call_endpoint.side_effect = call_endpoint
+    client.get_members.return_value = {"result": "success", "members": _MEMBERS}
+
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "bob@example.com", "--by-email", "--json"],
+    )
+    assert result.exit_code == 1
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["operation"] == "unsubscribe"
+    assert payload["channel_id"] == 1
+    assert payload["channel_name"] == "general"
+    assert payload["errors"] and "Boom" in payload["errors"][0]["error"]
+
+
+def test_channel_unsubscribe_json_error_channel_unresolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When channel resolution itself fails, the JSON payload reports
+    ``channel_id: null`` (the channel was never resolved).
+    """
+    client = mock.MagicMock()
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:
+        if url == "streams" and method == "GET":
+            # No streams at all -> resolve_channel raises ZulipNotFoundError.
+            return {"result": "success", "streams": []}
+        raise AssertionError(f"Unexpected endpoint: {method} {url}")
+
+    client.call_endpoint.side_effect = call_endpoint
+    client.get_members.return_value = {"result": "success", "members": _MEMBERS}
+
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["nosuch", "bob@example.com", "--by-email", "--json"],
+    )
+    assert result.exit_code == 1
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["channel_id"] is None
+    assert payload["channel_name"] == "nosuch"

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1414,8 +1414,10 @@ def _build_client(*, removed: list[Any], not_removed: list[Any]) -> Any:
             return {"result": "success", "streams": _STREAMS}
         if url == "users/me/subscriptions" and method == "DELETE":
             request = request or {}
-            subscription = (request.get("subscriptions") or [""])[0]
-            principal = (request.get("principals") or [None])[0]
+            subscriptions = _json.loads(request.get("subscriptions", "[]"))
+            principals = _json.loads(request.get("principals", "[]"))
+            subscription = (subscriptions or [""])[0]
+            principal = (principals or [None])[0]
             return {
                 "result": "success",
                 "msg": "",

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1433,7 +1433,11 @@ def _invoke_unsubscribe(monkeypatch: pytest.MonkeyPatch, client: Any, args: list
     monkeypatch.setattr(zulip_mod, "get_client", lambda *a, **kw: client)
     monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
     runner = CliRunner()
-    return runner.invoke(zulip_app, ["channel", "unsubscribe", *args])
+    prefix: list[str] = []
+    if "--json" in args:
+        args = [arg for arg in args if arg != "--json"]
+        prefix.append("--json")
+    return runner.invoke(zulip_app, [*prefix, "channel", "unsubscribe", *args])
 
 
 def test_channel_unsubscribe_single_user(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1541,3 +1545,50 @@ def test_channel_unsubscribe_rejects_no_channel_target(monkeypatch: pytest.Monke
     client = _build_client(removed=[], not_removed=[])
     result = _invoke_unsubscribe(monkeypatch, client, ["--by-email"])
     assert result.exit_code != 0
+
+
+def test_channel_unsubscribe_partial_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``partial`` outcome (some users in neither list) exits non-zero."""
+    # ``not_removed`` empty + ``removed`` missing alice -> alice reports
+    # as an error (server didn't acknowledge), producing partial status.
+    client = _build_client(removed=["bob@example.com"], not_removed=[])
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        [
+            "general",
+            "alice@example.com",
+            "bob@example.com",
+            "--by-email",
+            "--json",
+        ],
+    )
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "partial"
+    assert result.exit_code == 1
+
+
+def test_channel_unsubscribe_json_error_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When --json is requested and the API errors, emit JSON to stdout."""
+    # Empty members list -> resolve_users raises ZulipNotFoundError.
+    client = mock.MagicMock()
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> Any:
+        if url == "streams" and method == "GET":
+            return {"result": "success", "streams": _STREAMS}
+        raise AssertionError(f"Unexpected endpoint: {method} {url}")
+
+    client.call_endpoint.side_effect = call_endpoint
+    client.get_members.return_value = {"result": "success", "members": []}
+
+    result = _invoke_unsubscribe(
+        monkeypatch,
+        client,
+        ["general", "ghost@example.com", "--by-email", "--json"],
+    )
+    assert result.exit_code == 1
+    payload = _json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["operation"] == "unsubscribe"
+    assert payload["channel_name"] == "general"
+    assert payload["errors"] and "ghost@example.com" in payload["errors"][0]["error"]

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1709,13 +1709,13 @@ def test_channel_unsubscribe_json_error_client_init_failure(
     result = runner.invoke(
         zulip_app,
         [
+            "--json",
             "channel",
             "unsubscribe",
             "--channel-id",
             "42",
             "bob@example.com",
             "--by-email",
-            "--json",
         ],
     )
     assert result.exit_code == 1


### PR DESCRIPTION
Implements **US6 — Unsubscribe Users from a Channel** of the
[Zulip channel management feature](../tree/main/specs/001-zulip-channel-mgmt).
This PR is independent of the other in-flight US slices and can land
in any order relative to them.

## Tasks landed

- **T040** — CLI tests for `channel unsubscribe`
  (`tests/unit/test_zulip_cli.py`): single user, bulk, `--by-name`
  ambiguity, not-subscribed no-op, `--json` schema, `--channel-id`
  targeting, missing id-mode rejection, missing channel target.
- **T041** — API tests for `unsubscribe_users()`
  (`tests/unit/test_zulip_api.py`): single / bulk success,
  not-subscribed no-op, mixed `removed`/`not_removed`, `--by-id`
  principal coercion to ints, `--channel-id` resolution, input
  validation, Zulip API error surfacing.
- **T042** — `unsubscribe_users(client, users, *, channel, channel_id,
  id_mode, include_archived)` in `lftools_uv/api/endpoints/zulip.py`.
  Resolves the channel target and user identifiers, calls Zulip
  `DELETE /users/me/subscriptions`, and shapes the response into a
  bulk MutationResult. Users in the server's `removed` list become
  `unsubscribed` results, `not_removed` become `not_subscribed`
  no-ops, anything else surfaces as an error entry.
- **T043** — `zulip channel unsubscribe` Typer command in
  `lftools_uv/typer_apps/zulip.py`. Standard
  `[CHANNEL] USER [USER...]` positional pattern (or `--channel-id`
  with all positionals as users), exclusive
  `--by-email`/`--by-id`/`--by-name`, plus `--include-archived` and
  `--json`.

Marks T040–T043 as `[X]` in `specs/001-zulip-channel-mgmt/tasks.md`
in a dedicated `Docs(tasks):` commit.

## Independence + parallel work

- Foundation PR #362 is merged; nothing else from this feature has
  landed yet. US6 has no story-level dependencies.
- Other agents are working on US1 (PR #378), US2, US3, US5, US7,
  US8, US9, US10 in parallel — this PR does not touch their files.
- **Expected merge conflict**: this PR introduces the
  `zulip channel` Typer sub-app for the first time. US1 (PR #378)
  introduces the same sub-app independently. When the second of the
  two PRs merges, the trivial conflict on the `channel_app =
  typer.Typer(...)` instantiation should resolve by keeping a single
  instance — both PRs use the same `name="channel"`, `help=`, and
  `no_args_is_help=True` settings.

## Click error format fix

Includes the same `Fix(tests): Tolerate Click error format change`
commit as PR #378 (Click 8.2 emits `No such option '-5'.` instead of
`No such option: -5`). Independent fix needed here because upstream
`main` has not absorbed it yet.

## Test plan

- `uv run pytest tests/` — 434 passed
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean for `lftools_uv/` and
  `tests/` (pre-existing `docs/conf.py` formatting issue is out of
  scope)

## Spec reference

- `specs/001-zulip-channel-mgmt/spec.md` — US6 acceptance criteria
- `specs/001-zulip-channel-mgmt/contracts/cli-commands.md` —
  `zulip channel unsubscribe` contract
- `specs/001-zulip-channel-mgmt/data-model.md` — MutationResult
  (bulk) schema