### PR TITLE
Feat(zulip): Update channel settings (US8)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,12 +39,11 @@ author = 'Linux Foundation Release Engineering'
 # in the build environment, and the build environment to have access to
 # git tags so hatch-vcs can derive the version at install time.
 try:
-    from importlib.metadata import PackageNotFoundError
-    from importlib.metadata import version as _pkg_version
+    import importlib.metadata as importlib_metadata
 
     try:
-        version = _pkg_version("lftools-uv")
-    except PackageNotFoundError:
+        version = importlib_metadata.version("lftools-uv")
+    except importlib_metadata.PackageNotFoundError:
         version = "0.0.0"
 except Exception:
     version = "0.0.0"

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1702,7 +1702,10 @@ def update_channel(
     if not isinstance(stream_id_raw, int):
         raise ZulipAPIError(f"Resolved channel missing stream_id: {channel!r}")
     stream_id = stream_id_raw
-    resolved_name = str(channel.get("name", ""))
+    name_raw = channel.get("name")
+    if not isinstance(name_raw, str):
+        raise ZulipAPIError(f"Resolved channel missing name: {channel!r}")
+    resolved_name = name_raw
 
     # ------------------------------------------------------------------
     # Resolve --allow-group (with lockout-aware allow_nobody)
@@ -1781,8 +1784,8 @@ def update_channel(
                 url="users/me/subscriptions",
                 method="POST",
                 request={
-                    "subscriptions": [{"name": resolved_name}],
-                    "principals": principals,
+                    "subscriptions": json.dumps([{"name": resolved_name}]),
+                    "principals": json.dumps(principals),
                 },
             )
         except Exception as exc:  # pragma: no cover - network errors

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -265,9 +265,9 @@ def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None
     """
     if zuliprc is not None and config is not None:
         raise ZulipValidationError("Pass either 'zuliprc' or 'config', not both")
+    zulip_module = _require_zulip()
     resolved = config or resolve_config(zuliprc)
     if resolved.config_path is not None:
-        zulip_module = _require_zulip()
         return zulip_module.Client(config_file=str(resolved.config_path))
     # No zuliprc file — all three credential fields must be populated.
     missing: list[str] = []
@@ -279,7 +279,6 @@ def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None
         missing.append("site")
     if missing:
         raise ZulipConfigError(f"Incomplete Zulip credentials from {resolved.source}: missing {', '.join(missing)}")
-    zulip_module = _require_zulip()
     return zulip_module.Client(
         email=resolved.email,
         api_key=resolved.api_key,

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1644,27 +1644,39 @@ def update_channel(
     # Feature-level gating (FR-019)
     # ------------------------------------------------------------------
     if channel_type == "web-public":
-        check_feature_level(client, FEATURE_LEVELS["web-public"], feature_name="web-public")
-        # Spectator access must also be enabled on the realm (spec
-        # scenario 8). The setting is exposed by the server_settings
-        # endpoint as ``realm_enable_spectator_access`` on recent
-        # servers; defensively allow the transition when the field is
-        # absent (older servers leave enforcement to the API itself).
+        # Fetch server settings ONCE and reuse for both the feature-
+        # level check (by priming the cached level) and the spectator-
+        # access validation (spec scenario 8). Avoids two HTTP calls
+        # when the cache is cold.
         try:
             settings_response = client.get_server_settings()
         except Exception as exc:  # pragma: no cover - network errors
             raise ZulipAPIError(f"Failed to query server settings: {exc}") from exc
         if not isinstance(settings_response, dict) or settings_response.get("result") != "success":
             raise ZulipAPIError(f"Unexpected server-settings response: {settings_response!r}")
+        # Prime the feature-level cache so the following check_feature_level
+        # call does not issue a second HTTP request.
+        level_value = settings_response.get("zulip_feature_level")
+        if isinstance(level_value, int):
+            try:
+                client._lftools_feature_level = level_value
+            except AttributeError:  # pragma: no cover - defensive
+                pass
+        check_feature_level(client, FEATURE_LEVELS["web-public"], feature_name="web-public")
         # ``realm_enable_spectator_access`` is present on recent Zulip
         # servers; defensively allow the transition when the field is
         # absent (older servers leave enforcement to the API itself).
         spectator = settings_response.get("realm_enable_spectator_access")
         if spectator is False:
-            raise ZulipFeatureLevelError(
-                required=FEATURE_LEVELS["web-public"],
-                actual=get_server_feature_level(client),
-                feature_name="web-public (spectator access disabled on realm)",
+            # Use ZulipValidationError (not ZulipFeatureLevelError) so
+            # the user sees the actual cause — feature-level error
+            # messages are formatted as version mismatches and would
+            # be misleading when the realm has explicitly disabled
+            # spectator access.
+            raise ZulipValidationError(
+                "Cannot convert channel to web-public: spectator access "
+                "is disabled on this Zulip realm (realm_enable_spectator_access=false). "
+                "Enable spectator access in the realm settings first."
             )
     if topic_policy is not None:
         check_feature_level(client, FEATURE_LEVELS["topic-policy"], feature_name="topic-policy")

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1678,15 +1678,20 @@ def update_channel(
     # ------------------------------------------------------------------
     subscribe_list: list[str] = list(subscribe_user_specs or [])
 
+    # ``allow_group`` is always resolved with allow_nobody=True; the
+    # lockout-prevention block below decides whether a Nobody-only
+    # value is acceptable in the current context. (Per spec, Nobody is
+    # only forbidden when converting to private with 0 existing
+    # subscribers and no --subscribe targets; on a channel that
+    # already has subscribers, Nobody is allowed and simply disables
+    # future joins.)
     allow_group_value: GroupSettingValue | None = None
+    allow_group_resolved: list[dict[str, Any]] | None = None
     if allow_group is not None:
-        # When converting to private with no existing subscribers and no
-        # --subscribe targets, the allow-group cannot be Nobody.
-        nobody_forbidden = channel_type == "private" and not subscribe_list
-        _, allow_group_value = resolve_groups(
+        allow_group_resolved, allow_group_value = resolve_groups(
             client,
             allow_group,
-            allow_nobody=not nobody_forbidden,
+            allow_nobody=True,
         )
 
     can_remove_value: GroupSettingValue | None = None
@@ -1697,9 +1702,18 @@ def update_channel(
     # Lockout prevention on type→private (spec scenarios 13/14, FR-004)
     # ------------------------------------------------------------------
     if channel_type == "private":
-        has_subs = bool(subscribe_list)
-        has_allow_group = allow_group_value is not None
-        if not has_subs and not has_allow_group:
+        has_subs_to_add = bool(subscribe_list)
+        # An allow-group satisfies lockout prevention only if it
+        # resolves to something other than just the Nobody system role
+        # (which would disable the permission entirely).
+        allow_group_is_only_nobody = (
+            allow_group_resolved is not None
+            and len(allow_group_resolved) == 1
+            and allow_group_resolved[0].get("name") == "role:nobody"
+        )
+        allow_group_satisfies = allow_group_value is not None and not allow_group_is_only_nobody
+
+        if not has_subs_to_add and not allow_group_satisfies:
             # Inspect current subscriber count; if zero, refuse.
             current = _subscriber_count(client, stream_id)
             if current == 0:

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1580,18 +1580,17 @@ def update_channel(
       the channel currently has 0 subscribers, the caller must supply
       either ``subscribe_user_specs`` (a non-empty list) or a non-Nobody
       ``allow_group`` value. ``Nobody`` does NOT satisfy this rule.
+      When ``subscribe_user_specs`` is supplied, the users are
+      resolved AND actually subscribed via
+      ``POST /api/v1/users/me/subscriptions`` before the PATCH so that
+      access is genuinely retained (the API call would otherwise lock
+      the channel out, despite passing client-side validation).
     * Resolves group specs and wraps them using the group-setting-update
       ``{"new": value}`` envelope required by the Zulip PATCH endpoints.
       Note that this wrapping differs from the POST endpoints
       (``streams`` create), which take the raw value.
     * Returns the standard ``MutationResult`` dict
       (``status``/``channel_id``/``channel_name``/``operation``).
-
-    The caller is responsible for any follow-on operations (e.g.
-    actually subscribing ``subscribe_user_specs`` to the channel via
-    the existing ``channel subscribe`` flow); the ``--subscribe`` flag
-    on ``channel update`` exists primarily to satisfy lockout
-    prevention.
     """
     # ------------------------------------------------------------------
     # Argument validation
@@ -1614,11 +1613,40 @@ def update_channel(
             "or --can-remove-subscribers-group)"
         )
 
+    valid_channel_types = {"public", "private", "web-public"}
+    if channel_type is not None and channel_type not in valid_channel_types:
+        raise ZulipValidationError(
+            f"Invalid channel_type {channel_type!r}; expected one of {', '.join(sorted(valid_channel_types))}"
+        )
+    valid_topic_policies = {"allow", "deny", "follow-default"}
+    if topic_policy is not None and topic_policy not in valid_topic_policies:
+        raise ZulipValidationError(
+            f"Invalid topic_policy {topic_policy!r}; expected one of {', '.join(sorted(valid_topic_policies))}"
+        )
+
     # ------------------------------------------------------------------
     # Feature-level gating (FR-019)
     # ------------------------------------------------------------------
     if channel_type == "web-public":
         check_feature_level(client, FEATURE_LEVELS["web-public"], feature_name="web-public")
+        # Spectator access must also be enabled on the realm (spec
+        # scenario 8). The setting is exposed by the server_settings
+        # endpoint as ``realm_enable_spectator_access`` on recent
+        # servers; defensively allow the transition when the field is
+        # absent (older servers leave enforcement to the API itself).
+        try:
+            settings_response = client.get_server_settings()
+        except Exception as exc:  # pragma: no cover - network errors
+            raise ZulipAPIError(f"Failed to query server settings: {exc}") from exc
+        spectator = None
+        if isinstance(settings_response, dict):
+            spectator = settings_response.get("realm_enable_spectator_access")
+        if spectator is False:
+            raise ZulipFeatureLevelError(
+                required=FEATURE_LEVELS["web-public"],
+                actual=get_server_feature_level(client),
+                feature_name="web-public (spectator access disabled on realm)",
+            )
     if topic_policy is not None:
         check_feature_level(client, FEATURE_LEVELS["topic-policy"], feature_name="topic-policy")
     if allow_group is not None:
@@ -1682,14 +1710,42 @@ def update_channel(
                 )
 
     # ------------------------------------------------------------------
-    # Resolve --subscribe identifiers. Actual subscription is performed
-    # by the dedicated ``channel subscribe`` command — on update, the
-    # flag exists primarily to satisfy lockout prevention. We still
-    # require an explicit id-mode for parity with the subscribe command
-    # so callers do not get a surprising "by-name" silent behavior.
+    # Resolve --subscribe identifiers. When supplied we actually
+    # subscribe the users BEFORE issuing the PATCH so that
+    # type-to-private conversions truly retain access — relying on the
+    # lockout-prevention bypass without actually subscribing would
+    # still lock the channel out.
     # ------------------------------------------------------------------
     if subscribe_list and user_id_mode is None:
         raise ZulipValidationError("--subscribe requires one of --by-email/--by-id/--by-name")
+    if subscribe_list:
+        assert user_id_mode is not None  # for type narrowing (validated above)
+        resolved_users = resolve_users(client, subscribe_list, mode=user_id_mode)
+        principals: list[Any] = []
+        for user in resolved_users:
+            user_id_value = user.get("user_id")
+            if isinstance(user_id_value, int):
+                principals.append(user_id_value)
+            else:
+                email = user.get("delivery_email") or user.get("email")
+                if isinstance(email, str):
+                    principals.append(email)
+        try:
+            sub_response = client.call_endpoint(
+                url="users/me/subscriptions",
+                method="POST",
+                request={
+                    "subscriptions": [{"name": resolved_name}],
+                    "principals": principals,
+                },
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            raise ZulipAPIError(f"Failed to subscribe users during update: {exc}") from exc
+        if not isinstance(sub_response, dict) or sub_response.get("result") != "success":
+            msg = ""
+            if isinstance(sub_response, dict):
+                msg = str(sub_response.get("msg") or sub_response)
+            raise ZulipAPIError(f"Subscribe-during-update failed: {msg or sub_response!r}")
 
     # ------------------------------------------------------------------
     # Build PATCH request

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1731,7 +1731,8 @@ def update_channel(
     # ------------------------------------------------------------------
     # Lockout prevention on type→private (spec scenarios 13/14, FR-004)
     # ------------------------------------------------------------------
-    if channel_type == "private":
+    is_type_to_private = channel_type == "private" and not bool(channel.get("invite_only"))
+    if is_type_to_private:
         has_subs_to_add = bool(subscribe_list)
         # An allow-group satisfies lockout prevention only if it
         # resolves to something other than just the Nobody system role

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1514,3 +1514,223 @@ def unsubscribe_users(
         "results": results,
         "errors": errors,
     }
+
+
+# Channel update (US8 — FR-004)
+# ---------------------------------------------------------------------------
+
+
+#: Allowed values for the ``--type`` flag on ``channel update``.
+ChannelType = Literal["public", "private", "web-public"]
+
+#: Allowed values for the ``--topic-policy`` flag.
+TopicPolicy = Literal["allow", "deny", "follow-default"]
+
+
+def _subscriber_count(client: Any, stream_id: int) -> int:
+    """Return the number of subscribers to ``stream_id`` via the members endpoint.
+
+    Uses ``GET /api/v1/streams/{stream_id}/members``. The response includes
+    a ``subscribers`` list of user IDs; the length is returned. Used by
+    :func:`update_channel` to decide whether the lockout-prevention rule
+    applies when converting a channel to private (FR-004 / spec scenario
+    13/14).
+    """
+    try:
+        response = client.call_endpoint(
+            url=f"streams/{stream_id}/members",
+            method="GET",
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to query channel members: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        raise ZulipAPIError(f"Unexpected members response: {response!r}")
+    subscribers = response.get("subscribers", [])
+    if not isinstance(subscribers, list):
+        raise ZulipAPIError(f"Malformed members payload: {response!r}")
+    return len(subscribers)
+
+
+def update_channel(
+    client: Any,
+    *,
+    name: str | None = None,
+    channel_id: int | None = None,
+    new_name: str | None = None,
+    description: str | None = None,
+    channel_type: ChannelType | None = None,
+    topic_policy: TopicPolicy | None = None,
+    subscribe_user_specs: Iterable[str] | None = None,
+    user_id_mode: IdMode | None = None,
+    allow_group: str | None = None,
+    can_remove_subscribers_group: str | None = None,
+    include_archived: bool = False,
+) -> dict[str, Any]:
+    """Update channel settings via ``PATCH /api/v1/streams/{stream_id}``.
+
+    Implements FR-004 (channel update) end-to-end:
+
+    * Validates that at least one setting flag is supplied (rename,
+      description, type, topic-policy, allow-group, or
+      can-remove-subscribers-group).
+    * Applies the FR-019 feature-level checks for web-public,
+      topic-policy, can-access-group (``--allow-group``) and
+      can-remove-subscribers-group.
+    * Enforces lockout prevention when converting to ``private``: if
+      the channel currently has 0 subscribers, the caller must supply
+      either ``subscribe_user_specs`` (a non-empty list) or a non-Nobody
+      ``allow_group`` value. ``Nobody`` does NOT satisfy this rule.
+    * Resolves group specs and wraps them using the group-setting-update
+      ``{"new": value}`` envelope required by the Zulip PATCH endpoints.
+      Note that this wrapping differs from the POST endpoints
+      (``streams`` create), which take the raw value.
+    * Returns the standard ``MutationResult`` dict
+      (``status``/``channel_id``/``channel_name``/``operation``).
+
+    The caller is responsible for any follow-on operations (e.g.
+    actually subscribing ``subscribe_user_specs`` to the channel via
+    the existing ``channel subscribe`` flow); the ``--subscribe`` flag
+    on ``channel update`` exists primarily to satisfy lockout
+    prevention.
+    """
+    # ------------------------------------------------------------------
+    # Argument validation
+    # ------------------------------------------------------------------
+    settings_specified = any(
+        v is not None
+        for v in (
+            new_name,
+            description,
+            channel_type,
+            topic_policy,
+            allow_group,
+            can_remove_subscribers_group,
+        )
+    )
+    if not settings_specified:
+        raise ZulipValidationError(
+            "channel update requires at least one setting to change "
+            "(--name, --description, --type, --topic-policy, --allow-group, "
+            "or --can-remove-subscribers-group)"
+        )
+
+    # ------------------------------------------------------------------
+    # Feature-level gating (FR-019)
+    # ------------------------------------------------------------------
+    if channel_type == "web-public":
+        check_feature_level(client, FEATURE_LEVELS["web-public"], feature_name="web-public")
+    if topic_policy is not None:
+        check_feature_level(client, FEATURE_LEVELS["topic-policy"], feature_name="topic-policy")
+    if allow_group is not None:
+        check_feature_level(client, FEATURE_LEVELS["can-access-group"], feature_name="can-access-group")
+    if can_remove_subscribers_group is not None:
+        check_feature_level(
+            client,
+            FEATURE_LEVELS["can-remove-subscribers-group"],
+            feature_name="can-remove-subscribers-group",
+        )
+
+    # ------------------------------------------------------------------
+    # Resolve target channel
+    # ------------------------------------------------------------------
+    channel = resolve_channel(
+        client,
+        name=name,
+        channel_id=channel_id,
+        include_archived=include_archived,
+    )
+    stream_id_raw = channel.get("stream_id")
+    if not isinstance(stream_id_raw, int):
+        raise ZulipAPIError(f"Resolved channel missing stream_id: {channel!r}")
+    stream_id = stream_id_raw
+    resolved_name = str(channel.get("name", ""))
+
+    # ------------------------------------------------------------------
+    # Resolve --allow-group (with lockout-aware allow_nobody)
+    # ------------------------------------------------------------------
+    subscribe_list: list[str] = list(subscribe_user_specs or [])
+
+    allow_group_value: GroupSettingValue | None = None
+    if allow_group is not None:
+        # When converting to private with no existing subscribers and no
+        # --subscribe targets, the allow-group cannot be Nobody.
+        nobody_forbidden = channel_type == "private" and not subscribe_list
+        _, allow_group_value = resolve_groups(
+            client,
+            allow_group,
+            allow_nobody=not nobody_forbidden,
+        )
+
+    can_remove_value: GroupSettingValue | None = None
+    if can_remove_subscribers_group is not None:
+        _, can_remove_value = resolve_groups(client, can_remove_subscribers_group)
+
+    # ------------------------------------------------------------------
+    # Lockout prevention on type→private (spec scenarios 13/14, FR-004)
+    # ------------------------------------------------------------------
+    if channel_type == "private":
+        has_subs = bool(subscribe_list)
+        has_allow_group = allow_group_value is not None
+        if not has_subs and not has_allow_group:
+            # Inspect current subscriber count; if zero, refuse.
+            current = _subscriber_count(client, stream_id)
+            if current == 0:
+                raise ZulipLockoutError(
+                    "Converting channel to private with no existing subscribers "
+                    "would lock everyone out. Specify --subscribe users or a "
+                    "non-Nobody --allow-group to retain access."
+                )
+
+    # ------------------------------------------------------------------
+    # Resolve --subscribe identifiers. Actual subscription is performed
+    # by the dedicated ``channel subscribe`` command — on update, the
+    # flag exists primarily to satisfy lockout prevention. We still
+    # require an explicit id-mode for parity with the subscribe command
+    # so callers do not get a surprising "by-name" silent behavior.
+    # ------------------------------------------------------------------
+    if subscribe_list and user_id_mode is None:
+        raise ZulipValidationError("--subscribe requires one of --by-email/--by-id/--by-name")
+
+    # ------------------------------------------------------------------
+    # Build PATCH request
+    # ------------------------------------------------------------------
+    request: dict[str, Any] = {}
+    if new_name is not None:
+        request["new_name"] = new_name
+    if description is not None:
+        request["description"] = description
+    if channel_type is not None:
+        request["is_private"] = channel_type == "private"
+        request["is_web_public"] = channel_type == "web-public"
+    if topic_policy is not None:
+        request["topic_policy"] = topic_policy
+    if allow_group_value is not None:
+        request["can_access_group"] = {"new": allow_group_value}
+    if can_remove_value is not None:
+        request["can_remove_subscribers_group"] = {"new": can_remove_value}
+
+    # ------------------------------------------------------------------
+    # PATCH /api/v1/streams/{stream_id}
+    # ------------------------------------------------------------------
+    try:
+        response = client.call_endpoint(
+            url=f"streams/{stream_id}",
+            method="PATCH",
+            request=request,
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to update channel: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = ""
+        if isinstance(response, dict):
+            msg = str(response.get("msg") or response)
+        raise ZulipAPIError(f"Update failed: {msg or response!r}")
+
+    # Reflect rename in the returned channel_name.
+    effective_name = new_name if new_name is not None else resolved_name
+    return {
+        "status": "success",
+        "channel_id": stream_id,
+        "channel_name": effective_name,
+        "operation": "update",
+    }

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1527,15 +1527,31 @@ ChannelType = Literal["public", "private", "web-public"]
 TopicPolicy = Literal["allow", "deny", "follow-default"]
 
 
-def _subscriber_count(client: Any, stream_id: int) -> int:
-    """Return the number of subscribers to ``stream_id`` via the members endpoint.
+def _subscriber_count(
+    client: Any,
+    stream_id: int,
+    *,
+    channel: dict[str, Any] | None = None,
+) -> int:
+    """Return the number of subscribers to ``stream_id``.
 
-    Uses ``GET /api/v1/streams/{stream_id}/members``. The response includes
-    a ``subscribers`` list of user IDs; the length is returned. Used by
-    :func:`update_channel` to decide whether the lockout-prevention rule
-    applies when converting a channel to private (FR-004 / spec scenario
-    13/14).
+    Fast path: when the already-resolved ``channel`` dict carries a
+    ``subscriber_count`` integer (exposed by recent Zulip servers), use
+    it directly to avoid an extra round-trip.
+
+    Slow path: fall back to ``GET /api/v1/streams/{stream_id}/members``
+    and count the returned ``subscribers`` list. This is materially
+    more expensive on large channels because it fetches the full
+    subscriber-ID list just to answer a yes/no question.
+
+    Used by :func:`update_channel` to decide whether the lockout-
+    prevention rule applies when converting a channel to private
+    (FR-004 / spec scenario 13/14).
     """
+    if channel is not None:
+        hint = channel.get("subscriber_count")
+        if isinstance(hint, int) and hint >= 0:
+            return hint
     try:
         response = client.call_endpoint(
             url=f"streams/{stream_id}/members",
@@ -1638,9 +1654,12 @@ def update_channel(
             settings_response = client.get_server_settings()
         except Exception as exc:  # pragma: no cover - network errors
             raise ZulipAPIError(f"Failed to query server settings: {exc}") from exc
-        spectator = None
-        if isinstance(settings_response, dict):
-            spectator = settings_response.get("realm_enable_spectator_access")
+        if not isinstance(settings_response, dict) or settings_response.get("result") != "success":
+            raise ZulipAPIError(f"Unexpected server-settings response: {settings_response!r}")
+        # ``realm_enable_spectator_access`` is present on recent Zulip
+        # servers; defensively allow the transition when the field is
+        # absent (older servers leave enforcement to the API itself).
+        spectator = settings_response.get("realm_enable_spectator_access")
         if spectator is False:
             raise ZulipFeatureLevelError(
                 required=FEATURE_LEVELS["web-public"],
@@ -1715,7 +1734,7 @@ def update_channel(
 
         if not has_subs_to_add and not allow_group_satisfies:
             # Inspect current subscriber count; if zero, refuse.
-            current = _subscriber_count(client, stream_id)
+            current = _subscriber_count(client, stream_id, channel=channel)
             if current == 0:
                 raise ZulipLockoutError(
                     "Converting channel to private with no existing subscribers "

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1775,10 +1775,12 @@ def update_channel(
             user_id_value = user.get("user_id")
             if isinstance(user_id_value, int):
                 principals.append(user_id_value)
-            else:
-                email = user.get("delivery_email") or user.get("email")
-                if isinstance(email, str):
-                    principals.append(email)
+                continue
+            email = user.get("delivery_email") or user.get("email")
+            if isinstance(email, str) and email:
+                principals.append(email)
+                continue
+            raise ZulipAPIError(f"Resolved user missing usable principal: {user!r}")
         try:
             sub_response = client.call_endpoint(
                 url="users/me/subscriptions",
@@ -1808,7 +1810,7 @@ def update_channel(
         request["is_private"] = channel_type == "private"
         request["is_web_public"] = channel_type == "web-public"
     if topic_policy is not None:
-        request["topic_policy"] = topic_policy
+        request["topics_policy"] = TOPIC_POLICY_MAP[topic_policy]
     if allow_group_value is not None:
         request["can_access_group"] = {"new": allow_group_value}
     if can_remove_value is not None:

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1611,6 +1611,7 @@ def update_channel(
     # ------------------------------------------------------------------
     # Argument validation
     # ------------------------------------------------------------------
+    subscribe_list: list[str] = list(subscribe_user_specs or [])
     settings_specified = any(
         v is not None
         for v in (
@@ -1621,12 +1622,12 @@ def update_channel(
             allow_group,
             can_remove_subscribers_group,
         )
-    )
+    ) or bool(subscribe_list)
     if not settings_specified:
         raise ZulipValidationError(
             "channel update requires at least one setting to change "
             "(--name, --description, --type, --topic-policy, --allow-group, "
-            "or --can-remove-subscribers-group)"
+            "--subscribe, or --can-remove-subscribers-group)"
         )
 
     valid_channel_types = {"public", "private", "web-public"}
@@ -1707,8 +1708,6 @@ def update_channel(
     # ------------------------------------------------------------------
     # Resolve --allow-group (with lockout-aware allow_nobody)
     # ------------------------------------------------------------------
-    subscribe_list: list[str] = list(subscribe_user_specs or [])
-
     # ``allow_group`` is always resolved with allow_nobody=True; the
     # lockout-prevention block below decides whether a Nobody-only
     # value is acceptable in the current context. (Per spec, Nobody is

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1761,6 +1761,8 @@ def update_channel(
     # lockout-prevention bypass without actually subscribing would
     # still lock the channel out.
     # ------------------------------------------------------------------
+    if subscribe_list and channel_type != "private":
+        raise ZulipValidationError("--subscribe is only valid when using --type private")
     if subscribe_list and user_id_mode is None:
         raise ZulipValidationError("--subscribe requires one of --by-email/--by-id/--by-name")
     if subscribe_list:

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -1191,12 +1191,12 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
             allow_group,
             can_remove_subscribers_group,
         )
-    )
+    ) or bool(subscribe)
     if not any_setting:
         emit_error(
             "channel update requires at least one setting to change "
             "(--name, --description, --type, --topic-policy, --allow-group, "
-            "or --can-remove-subscribers-group)"
+            "--subscribe, or --can-remove-subscribers-group)"
         )
         raise typer.Exit(code=1)
 

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -1087,3 +1087,141 @@ def channel_unsubscribe(
     # produce a non-zero exit code alongside ``error``.
     if payload["status"] in ("error", "partial"):
         raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# Channel update (US8)
+# ---------------------------------------------------------------------------
+
+
+def _validate_single_channel_target(
+    channel: str | None,
+    channel_id: int | None,
+) -> None:
+    """Enforce FR-018: exactly one of [channel] or --channel-id."""
+    if channel is None and channel_id is None:
+        emit_error("Exactly one of [channel] or --channel-id is required")
+        raise typer.Exit(code=1)
+    if channel is not None and channel_id is not None:
+        emit_error("Specify only one of [channel] or --channel-id, not both")
+        raise typer.Exit(code=1)
+
+
+@channel_app.command("update")
+def channel_update(  # noqa: PLR0913 - CLI parity with contract
+    ctx: typer.Context,
+    channel: str | None = typer.Argument(
+        None,
+        help="Channel name (optional if --channel-id is given).",
+    ),
+    channel_id: int | None = typer.Option(
+        None,
+        "--channel-id",
+        help="Target channel by numeric ID.",
+    ),
+    new_name: str | None = typer.Option(
+        None,
+        "--name",
+        help="New channel name.",
+    ),
+    description: str | None = typer.Option(
+        None,
+        "--description",
+        help="New channel description.",
+    ),
+    channel_type: str | None = typer.Option(
+        None,
+        "--type",
+        help="New channel type: public, private, or web-public.",
+    ),
+    topic_policy: str | None = typer.Option(
+        None,
+        "--topic-policy",
+        help="New topic policy: allow, deny, or follow-default.",
+    ),
+    subscribe: list[str] = typer.Option(
+        [],
+        "--subscribe",
+        help="User identifier(s) to retain access on type-to-private (repeatable).",
+    ),
+    by_email: bool = typer.Option(False, "--by-email", help="Identify --subscribe users by email."),
+    by_id: bool = typer.Option(False, "--by-id", help="Identify --subscribe users by numeric ID."),
+    by_name: bool = typer.Option(False, "--by-name", help="Identify --subscribe users by full name."),
+    allow_group: str | None = typer.Option(
+        None,
+        "--allow-group",
+        help="Group(s) allowed to join. Comma-separated names; use 'id:NUM' for ID lookup.",
+    ),
+    can_remove_subscribers_group: str | None = typer.Option(
+        None,
+        "--can-remove-subscribers-group",
+        help="Group(s) permitted to remove subscribers (group-setting syntax).",
+    ),
+    include_archived: bool = typer.Option(
+        False,
+        "--include-archived",
+        help="Include archived channels when resolving the target.",
+    ),
+) -> None:
+    """Update channel settings.
+
+    Implements US8 (FR-004). Exactly one of ``[channel]`` or
+    ``--channel-id`` must be supplied. At least one setting flag is
+    required; the API layer also enforces this constraint (the
+    duplication keeps the user-facing error fast and clear).
+    """
+    _validate_single_channel_target(channel, channel_id)
+
+    # Validate --type choice locally so the error is presented before
+    # any network calls are made.
+    valid_types = {"public", "private", "web-public"}
+    if channel_type is not None and channel_type not in valid_types:
+        emit_error(f"Invalid --type {channel_type!r}; expected one of {', '.join(sorted(valid_types))}")
+        raise typer.Exit(code=1)
+
+    valid_policies = {"allow", "deny", "follow-default"}
+    if topic_policy is not None and topic_policy not in valid_policies:
+        emit_error(f"Invalid --topic-policy {topic_policy!r}; expected one of {', '.join(sorted(valid_policies))}")
+        raise typer.Exit(code=1)
+
+    # Validate --by-* mutex: at most one, and required when --subscribe
+    # is used.
+    by_count = sum(1 for v in (by_email, by_id, by_name) if v)
+    if by_count > 1:
+        emit_error("Specify only one of --by-email, --by-id, --by-name")
+        raise typer.Exit(code=1)
+    if subscribe and by_count == 0:
+        emit_error("--subscribe requires one of --by-email, --by-id, --by-name")
+        raise typer.Exit(code=1)
+    user_id_mode: str | None = None
+    if by_email:
+        user_id_mode = "email"
+    elif by_id:
+        user_id_mode = "id"
+    elif by_name:
+        user_id_mode = "name"
+
+    options = ctx.obj or {}
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        result = update_channel(
+            client,
+            name=channel,
+            channel_id=channel_id,
+            new_name=new_name,
+            description=description,
+            channel_type=channel_type,  # type: ignore[arg-type]
+            topic_policy=topic_policy,  # type: ignore[arg-type]
+            subscribe_user_specs=list(subscribe) if subscribe else None,
+            user_id_mode=user_id_mode,  # type: ignore[arg-type]
+            allow_group=allow_group,
+            can_remove_subscribers_group=can_remove_subscribers_group,
+            include_archived=include_archived,
+        )
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json(result)
+    else:
+        typer.echo(f"Updated channel '{result['channel_name']}' (id={result['channel_id']})")

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -1166,11 +1166,36 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
     """Update channel settings.
 
     Implements US8 (FR-004). Exactly one of ``[channel]`` or
-    ``--channel-id`` must be supplied. At least one setting flag is
-    required; the API layer also enforces this constraint (the
-    duplication keeps the user-facing error fast and clear).
+    ``--channel-id`` must be supplied. The API layer
+    (:func:`update_channel`) enforces the at-least-one-setting
+    constraint and surfaces it as a :class:`ZulipValidationError`; this
+    CLI layer validates flag-shape constraints (choice values, the
+    ``--by-*`` mutex, and ``--subscribe`` requiring an id-mode) before
+    contacting the server so that obvious errors are reported quickly.
     """
     _validate_single_channel_target(channel, channel_id)
+
+    # Local at-least-one-setting check so the user-facing error is
+    # presented before any network calls are made; the API layer also
+    # enforces the same constraint as a defence-in-depth check.
+    any_setting = any(
+        v is not None
+        for v in (
+            new_name,
+            description,
+            channel_type,
+            topic_policy,
+            allow_group,
+            can_remove_subscribers_group,
+        )
+    )
+    if not any_setting:
+        emit_error(
+            "channel update requires at least one setting to change "
+            "(--name, --description, --type, --topic-policy, --allow-group, "
+            "or --can-remove-subscribers-group)"
+        )
+        raise typer.Exit(code=1)
 
     # Validate --type choice locally so the error is presented before
     # any network calls are made.

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -1218,6 +1218,9 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
     if by_count > 1:
         emit_error("Specify only one of --by-email, --by-id, --by-name")
         raise typer.Exit(code=1)
+    if subscribe and channel_type != "private":
+        emit_error("--subscribe is only valid when using --type private")
+        raise typer.Exit(code=1)
     if subscribe and by_count == 0:
         emit_error("--subscribe requires one of --by-email, --by-id, --by-name")
         raise typer.Exit(code=1)

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -33,7 +33,9 @@ import typer
 from tabulate import tabulate
 
 from lftools_uv.api.endpoints.zulip import (
+    ChannelType,
     IdMode,
+    TopicPolicy,
     ZulipAmbiguityError,
     ZulipError,
     get_client,
@@ -43,6 +45,7 @@ from lftools_uv.api.endpoints.zulip import (
     list_users,
     resolve_channel,
     subscribe_users,
+    update_channel,
     zulip_available,
 )
 
@@ -1235,10 +1238,10 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
             channel_id=channel_id,
             new_name=new_name,
             description=description,
-            channel_type=channel_type,  # type: ignore[arg-type]
-            topic_policy=topic_policy,  # type: ignore[arg-type]
+            channel_type=cast(ChannelType | None, channel_type),
+            topic_policy=cast(TopicPolicy | None, topic_policy),
             subscribe_user_specs=list(subscribe) if subscribe else None,
-            user_id_mode=user_id_mode,  # type: ignore[arg-type]
+            user_id_mode=cast(IdMode | None, user_id_mode),
             allow_group=allow_group,
             can_remove_subscribers_group=can_remove_subscribers_group,
             include_archived=include_archived,

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -1099,7 +1099,7 @@ def channel_unsubscribe(
 
 def _validate_single_channel_target(
     channel: str | None,
-    channel_id: int | None,
+    channel_id: str | None,
 ) -> None:
     """Enforce FR-018: exactly one of [channel] or --channel-id."""
     if channel is None and channel_id is None:
@@ -1117,7 +1117,7 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
         None,
         help="Channel name (optional if --channel-id is given).",
     ),
-    channel_id: int | None = typer.Option(
+    channel_id: str | None = typer.Option(
         None,
         "--channel-id",
         help="Target channel by numeric ID.",
@@ -1177,6 +1177,14 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
     contacting the server so that obvious errors are reported quickly.
     """
     _validate_single_channel_target(channel, channel_id)
+
+    parsed_channel_id: int | None = None
+    if channel_id is not None:
+        try:
+            parsed_channel_id = int(channel_id)
+        except ValueError:
+            emit_error("--channel-id must be a numeric channel ID.")
+            raise typer.Exit(code=1) from None
 
     # Local at-least-one-setting check so the user-facing error is
     # presented before any network calls are made; the API layer also
@@ -1238,7 +1246,7 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
         result = update_channel(
             client,
             name=channel,
-            channel_id=channel_id,
+            channel_id=parsed_channel_id,
             new_name=new_name,
             description=description,
             channel_type=cast(ChannelType | None, channel_type),

--- a/specs/001-zulip-channel-mgmt/tasks.md
+++ b/specs/001-zulip-channel-mgmt/tasks.md
@@ -220,7 +220,7 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 ### Tests for User Story 8
 
-- [X] T048 [P] [US8] Write CLI tests for `channel update` in tests/unit/test_zulip_cli.py — test name update, description update, type change (all transitions), topic-policy set/clear, --allow-group with type change to private, lockout prevention, no-op success, --json output, feature-level errors, --can-remove-subscribers-group, at-least-one-setting validation
+- [X] T048 [P] [US8] Write CLI tests for `channel update` in tests/unit/test_zulip_cli.py — test name update, description update, type change (all transitions), topic-policy set/clear, --allow-group with type change to private, lockout prevention, no-op rejection, --json output, feature-level errors, --can-remove-subscribers-group, at-least-one-setting validation
 - [X] T049 [P] [US8] Write API tests for `update_channel()` in tests/unit/test_zulip_api.py — mock Zulip PATCH endpoint, test all parameter combinations, group-setting-update wrapper format `{"new": value}`, lockout validation for type-to-private, feature-level checks
 
 ### Implementation for User Story 8

--- a/specs/001-zulip-channel-mgmt/tasks.md
+++ b/specs/001-zulip-channel-mgmt/tasks.md
@@ -220,13 +220,13 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 ### Tests for User Story 8
 
-- [ ] T048 [P] [US8] Write CLI tests for `channel update` in tests/unit/test_zulip_cli.py — test name update, description update, type change (all transitions), topic-policy set/clear, --allow-group with type change to private, lockout prevention, no-op success, --json output, feature-level errors, --can-remove-subscribers-group, at-least-one-setting validation
-- [ ] T049 [P] [US8] Write API tests for `update_channel()` in tests/unit/test_zulip_api.py — mock Zulip PATCH endpoint, test all parameter combinations, group-setting-update wrapper format `{"new": value}`, lockout validation for type-to-private, feature-level checks
+- [X] T048 [P] [US8] Write CLI tests for `channel update` in tests/unit/test_zulip_cli.py — test name update, description update, type change (all transitions), topic-policy set/clear, --allow-group with type change to private, lockout prevention, no-op success, --json output, feature-level errors, --can-remove-subscribers-group, at-least-one-setting validation
+- [X] T049 [P] [US8] Write API tests for `update_channel()` in tests/unit/test_zulip_api.py — mock Zulip PATCH endpoint, test all parameter combinations, group-setting-update wrapper format `{"new": value}`, lockout validation for type-to-private, feature-level checks
 
 ### Implementation for User Story 8
 
-- [ ] T050 [US8] Implement `update_channel()` in lftools_uv/api/endpoints/zulip.py — validate at least one setting change, check feature levels (topic-policy, web-public, group-access, can-remove-subscribers-group), validate lockout prevention on type-to-private (check subscriber count, require --subscribe or --allow-group), resolve groups with `{"new": value}` wrapper format for PATCH, call PATCH `/streams/{stream_id}`, return MutationResult
-- [ ] T051 [US8] Implement `channel update` CLI command in lftools_uv/typer_apps/zulip.py — add `update` command with positional `[channel]`, `--channel-id`, `--name`, `--description`, `--type`, `--topic-policy`, `--subscribe` (multi), `--by-email`/`--by-id`/`--by-name`, `--allow-group`, `--can-remove-subscribers-group`, `--include-archived`, `--json` flags
+- [X] T050 [US8] Implement `update_channel()` in lftools_uv/api/endpoints/zulip.py — validate at least one setting change, check feature levels (topic-policy, web-public, group-access, can-remove-subscribers-group), validate lockout prevention on type-to-private (check subscriber count, require --subscribe or --allow-group), resolve groups with `{"new": value}` wrapper format for PATCH, call PATCH `/streams/{stream_id}`, return MutationResult
+- [X] T051 [US8] Implement `channel update` CLI command in lftools_uv/typer_apps/zulip.py — add `update` command with positional `[channel]`, `--channel-id`, `--name`, `--description`, `--type`, `--topic-policy`, `--subscribe` (multi), `--by-email`/`--by-id`/`--by-name`, `--allow-group`, `--can-remove-subscribers-group`, `--include-archived`, `--json` flags
 
 **Checkpoint**: User Story 8 is fully functional — `lftools-uv zulip channel update` works independently
 

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2312,6 +2312,19 @@ def test_update_channel_type_to_private_with_subscribe_satisfies_lockout() -> No
     assert 100 in sub_request["principals"]
 
 
+def test_update_channel_rejects_subscribe_without_private_type() -> None:
+    """``subscribe_user_specs`` is only valid for type→private updates."""
+    client = _update_client()
+    with pytest.raises(ZulipValidationError, match="--type private"):
+        _ = update_channel(
+            client,
+            name="general",
+            description="new description",
+            subscribe_user_specs=["alice@example.com"],
+            user_id_mode="email",
+        )
+
+
 def test_update_channel_type_to_private_with_allow_group_satisfies_lockout() -> None:
     """type→private with non-Nobody --allow-group satisfies lockout."""
     client = _update_client(subscribers=[])

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2337,6 +2337,20 @@ def test_update_channel_type_to_private_with_subscribe_satisfies_lockout() -> No
     assert 100 in _json.loads(sub_request["principals"])
 
 
+def test_update_channel_subscribe_requires_usable_principal() -> None:
+    """Resolved subscribe users must have an ID or email principal."""
+    members = [{"full_name": "Ghost", "is_active": True}]
+    client = _update_client(subscribers=[], members=members)
+    with pytest.raises(ZulipAPIError, match="usable principal"):
+        _ = update_channel(
+            client,
+            name="general",
+            channel_type="private",
+            subscribe_user_specs=["Ghost"],
+            user_id_mode="name",
+        )
+
+
 def test_update_channel_rejects_subscribe_without_private_type() -> None:
     """``subscribe_user_specs`` is only valid for type→private updates."""
     client = _update_client()
@@ -2440,11 +2454,11 @@ def test_update_channel_topic_policy_feature_level() -> None:
 
 
 def test_update_channel_topic_policy_passthrough() -> None:
-    """``topic_policy`` value is forwarded to the PATCH payload."""
+    """``topic_policy`` value maps to the Zulip PATCH payload."""
     client = _update_client()
     _ = update_channel(client, name="general", topic_policy="deny")
     payload = client.last_patch["request"]
-    assert payload["topic_policy"] == "deny"
+    assert payload["topics_policy"] == 2
 
 
 def test_update_channel_multiple_settings() -> None:

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2292,6 +2292,15 @@ def test_update_channel_type_to_private_lockout_without_subs_or_group() -> None:
         _ = update_channel(client, name="general", channel_type="private")
 
 
+def test_update_channel_already_private_skips_lockout() -> None:
+    """Already-private channels may be updated without conversion checks."""
+    streams = [{"stream_id": 1, "name": "general", "description": "g", "invite_only": True}]
+    client = _update_client(streams=streams, subscribers=[])
+    result = update_channel(client, name="general", channel_type="private", description="new")
+    assert result["status"] == "success"
+    assert client.last_patch["request"]["description"] == "new"
+
+
 def test_update_channel_type_to_private_with_subscribe_satisfies_lockout() -> None:
     """type→private with --subscribe targets actually subscribes + bypasses lockout."""
     client = _update_client(subscribers=[])

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2328,7 +2328,7 @@ def test_update_channel_type_to_private_with_allow_group_satisfies_lockout() -> 
 
 
 def test_update_channel_type_to_private_rejects_nobody_group() -> None:
-    """``Nobody`` does not satisfy lockout prevention for type→private."""
+    """``Nobody`` does not satisfy lockout prevention for type→private (empty channel)."""
     client = _update_client(subscribers=[])
     with pytest.raises(ZulipLockoutError):
         _ = update_channel(
@@ -2337,6 +2337,27 @@ def test_update_channel_type_to_private_rejects_nobody_group() -> None:
             channel_type="private",
             allow_group="Nobody",
         )
+
+
+def test_update_channel_type_to_private_allows_nobody_with_existing_subscribers() -> None:
+    """``Nobody`` is allowed on type→private when channel already has subscribers.
+
+    Per spec: lockout prevention only rejects converting an EMPTY
+    channel to private without retainable access. An already-populated
+    channel may freely set ``can_access_group`` to Nobody — it simply
+    disables future joins.
+    """
+    client = _update_client(subscribers=[100, 101])
+    _ = update_channel(
+        client,
+        name="general",
+        channel_type="private",
+        allow_group="Nobody",
+    )
+    payload = client.last_patch["request"]
+    assert payload["is_private"] is True
+    # The Nobody system group resolves to id 21 in the test fixture.
+    assert payload["can_access_group"] == {"new": 21}
 
 
 def test_update_channel_allow_group_uses_new_wrapper_format() -> None:

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2181,20 +2181,26 @@ def _update_client(
     feature_level: int = 1000,
     subscribers: list[int] | None = None,
     groups: list[dict[str, Any]] | None = None,
+    members: list[dict[str, Any]] | None = None,
     patch_response: dict[str, Any] | None = None,
+    spectator_access: bool = True,
 ) -> Any:
     """Build a mock client wired for update_channel scenarios."""
     streams = streams if streams is not None else ACTIVE_STREAMS
     archived_streams = archived_streams if archived_streams is not None else ARCHIVED_STREAMS
     subscribers = subscribers if subscribers is not None else [100, 101]
     groups = groups if groups is not None else GROUPS
+    members = members if members is not None else MEMBERS
     patch_response = patch_response if patch_response is not None else {"result": "success"}
 
     client = mock.MagicMock()
     client.get_server_settings.return_value = {
         "result": "success",
         "zulip_feature_level": feature_level,
+        "realm_enable_spectator_access": spectator_access,
     }
+    client.get_members.return_value = {"result": "success", "members": members}
+    client.subscribe_calls = []
 
     def call_endpoint(*, url: str, method: str = "GET", request: dict[str, Any] | None = None) -> Any:
         if url == "streams" and method == "GET":
@@ -2205,6 +2211,9 @@ def _update_client(
             return {"result": "success", "user_groups": groups}
         if url.startswith("streams/") and url.endswith("/members") and method == "GET":
             return {"result": "success", "subscribers": subscribers}
+        if url == "users/me/subscriptions" and method == "POST":
+            client.subscribe_calls.append(request)
+            return {"result": "success", "subscribed": {}, "already_subscribed": {}}
         if url.startswith("streams/") and method == "PATCH":
             # Record the PATCH request for assertions.
             client.last_patch = {"url": url, "request": request}
@@ -2284,7 +2293,7 @@ def test_update_channel_type_to_private_lockout_without_subs_or_group() -> None:
 
 
 def test_update_channel_type_to_private_with_subscribe_satisfies_lockout() -> None:
-    """type→private with --subscribe targets bypasses lockout check."""
+    """type→private with --subscribe targets actually subscribes + bypasses lockout."""
     client = _update_client(subscribers=[])
     _ = update_channel(
         client,
@@ -2295,6 +2304,12 @@ def test_update_channel_type_to_private_with_subscribe_satisfies_lockout() -> No
     )
     payload = client.last_patch["request"]
     assert payload["is_private"] is True
+    # The subscription POST must have been issued before the PATCH so
+    # that the new subscriber retains access to the now-private channel.
+    assert client.subscribe_calls, "expected POST /users/me/subscriptions"
+    sub_request = client.subscribe_calls[0]
+    assert sub_request["subscriptions"] == [{"name": "general"}]
+    assert 100 in sub_request["principals"]
 
 
 def test_update_channel_type_to_private_with_allow_group_satisfies_lockout() -> None:
@@ -2406,3 +2421,25 @@ def test_update_channel_api_error_propagates() -> None:
     client = _update_client(patch_response={"result": "error", "msg": "boom"})
     with pytest.raises(ZulipAPIError, match="boom"):
         _ = update_channel(client, name="general", description="x")
+
+
+def test_update_channel_rejects_invalid_channel_type() -> None:
+    """Unknown ``channel_type`` values are rejected with ``ZulipValidationError``."""
+    client = _update_client()
+    with pytest.raises(ZulipValidationError, match="channel_type"):
+        _ = update_channel(client, name="general", channel_type="bogus")  # type: ignore[arg-type]
+
+
+def test_update_channel_rejects_invalid_topic_policy() -> None:
+    """Unknown ``topic_policy`` values are rejected with ``ZulipValidationError``."""
+    client = _update_client()
+    with pytest.raises(ZulipValidationError, match="topic_policy"):
+        _ = update_channel(client, name="general", topic_policy="bogus")  # type: ignore[arg-type]
+
+
+def test_update_channel_web_public_requires_spectator_access() -> None:
+    """``--type web-public`` errors when the realm has spectator access disabled."""
+    client = _update_client(feature_level=1000, spectator_access=False)
+    with pytest.raises(ZulipFeatureLevelError) as exc_info:
+        _ = update_channel(client, name="general", channel_type="web-public")
+    assert "spectator" in exc_info.value.feature_name

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2260,6 +2260,14 @@ def test_update_channel_description_only() -> None:
     assert payload == {"description": "new desc"}
 
 
+def test_update_channel_rejects_missing_channel_name() -> None:
+    """Resolved channels must include a string name for subscription calls."""
+    streams = [{"stream_id": 1, "description": "g", "invite_only": False}]
+    client = _update_client(streams=streams)
+    with pytest.raises(ZulipAPIError, match="missing name"):
+        _ = update_channel(client, channel_id=1, description="new desc")
+
+
 def test_update_channel_type_to_public() -> None:
     """Type→public sends ``is_private=False`` and ``is_web_public=False``."""
     client = _update_client()
@@ -2325,8 +2333,8 @@ def test_update_channel_type_to_private_with_subscribe_satisfies_lockout() -> No
     # that the new subscriber retains access to the now-private channel.
     assert client.subscribe_calls, "expected POST /users/me/subscriptions"
     sub_request = client.subscribe_calls[0]
-    assert sub_request["subscriptions"] == [{"name": "general"}]
-    assert 100 in sub_request["principals"]
+    assert _json.loads(sub_request["subscriptions"]) == [{"name": "general"}]
+    assert 100 in _json.loads(sub_request["principals"])
 
 
 def test_update_channel_rejects_subscribe_without_private_type() -> None:

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -379,6 +379,14 @@ def test_get_client_rejects_incomplete_credentials(monkeypatch: pytest.MonkeyPat
         _ = get_client(config=config)
 
 
+def test_get_client_requires_zulip_before_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing optional dependency is reported before credential issues."""
+    monkeypatch.setattr("lftools_uv.api.endpoints.zulip._zulip_module", None)
+    config = ZulipConfig(email="bot@example.com", source="lftools.ini[zulip]")
+    with pytest.raises(ZulipConfigError, match="not installed"):
+        _ = get_client(config=config)
+
+
 def test_get_client_rejects_both_inputs() -> None:
     """``zuliprc`` and ``config`` are mutually exclusive inputs."""
     config = ZulipConfig(

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2319,7 +2319,6 @@ def test_update_channel_rejects_subscribe_without_private_type() -> None:
         _ = update_channel(
             client,
             name="general",
-            description="new description",
             subscribe_user_specs=["alice@example.com"],
             user_id_mode="email",
         )

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -47,6 +47,7 @@ from lftools_uv.api.endpoints.zulip import (
     resolve_users,
     subscribe_users,
     unsubscribe_users,
+    update_channel,
 )
 
 # ---------------------------------------------------------------------------
@@ -2167,3 +2168,241 @@ def test_unsubscribe_users_rejects_malformed_resolved_channel() -> None:
             id_mode="email",
             resolved_channel={"stream_id": "bad", "name": "general"},
         )
+
+
+# T049 — update_channel() (US8)
+# ---------------------------------------------------------------------------
+
+
+def _update_client(
+    *,
+    streams: list[dict[str, Any]] | None = None,
+    archived_streams: list[dict[str, Any]] | None = None,
+    feature_level: int = 1000,
+    subscribers: list[int] | None = None,
+    groups: list[dict[str, Any]] | None = None,
+    patch_response: dict[str, Any] | None = None,
+) -> Any:
+    """Build a mock client wired for update_channel scenarios."""
+    streams = streams if streams is not None else ACTIVE_STREAMS
+    archived_streams = archived_streams if archived_streams is not None else ARCHIVED_STREAMS
+    subscribers = subscribers if subscribers is not None else [100, 101]
+    groups = groups if groups is not None else GROUPS
+    patch_response = patch_response if patch_response is not None else {"result": "success"}
+
+    client = mock.MagicMock()
+    client.get_server_settings.return_value = {
+        "result": "success",
+        "zulip_feature_level": feature_level,
+    }
+
+    def call_endpoint(*, url: str, method: str = "GET", request: dict[str, Any] | None = None) -> Any:
+        if url == "streams" and method == "GET":
+            if request and request.get("include_archived"):
+                return {"result": "success", "streams": archived_streams}
+            return {"result": "success", "streams": streams}
+        if url == "user_groups" and method == "GET":
+            return {"result": "success", "user_groups": groups}
+        if url.startswith("streams/") and url.endswith("/members") and method == "GET":
+            return {"result": "success", "subscribers": subscribers}
+        if url.startswith("streams/") and method == "PATCH":
+            # Record the PATCH request for assertions.
+            client.last_patch = {"url": url, "request": request}
+            return patch_response
+        raise AssertionError(f"unexpected call_endpoint url={url!r} method={method!r}")
+
+    client.call_endpoint.side_effect = call_endpoint
+    return client
+
+
+def test_update_channel_requires_at_least_one_setting() -> None:
+    """No-op invocation (no settings supplied) is rejected (contract)."""
+    client = _update_client()
+    with pytest.raises(ZulipValidationError, match="at least one"):
+        _ = update_channel(client, name="general")
+
+
+def test_update_channel_rename_only() -> None:
+    """Renaming maps to ``new_name`` in the PATCH request."""
+    client = _update_client()
+    result = update_channel(client, name="general", new_name="general2")
+    assert result["status"] == "success"
+    assert result["operation"] == "update"
+    assert result["channel_id"] == 1
+    assert result["channel_name"] == "general2"
+    assert client.last_patch["url"] == "streams/1"
+    assert client.last_patch["request"]["new_name"] == "general2"
+
+
+def test_update_channel_description_only() -> None:
+    """Description-only updates produce a minimal PATCH payload."""
+    client = _update_client()
+    result = update_channel(client, channel_id=1, description="new desc")
+    assert result["status"] == "success"
+    payload = client.last_patch["request"]
+    assert payload == {"description": "new desc"}
+
+
+def test_update_channel_type_to_public() -> None:
+    """Type→public sends ``is_private=False`` and ``is_web_public=False``."""
+    client = _update_client()
+    _ = update_channel(client, name="general", channel_type="public")
+    payload = client.last_patch["request"]
+    assert payload["is_private"] is False
+    assert payload["is_web_public"] is False
+
+
+def test_update_channel_type_to_web_public_requires_feature_level() -> None:
+    """web-public requires the documented feature level."""
+    client = _update_client(feature_level=1)
+    with pytest.raises(ZulipFeatureLevelError):
+        _ = update_channel(client, name="general", channel_type="web-public")
+
+
+def test_update_channel_type_to_web_public_succeeds_when_supported() -> None:
+    """web-public with sufficient feature level passes through."""
+    client = _update_client(feature_level=1000)
+    _ = update_channel(client, name="general", channel_type="web-public")
+    payload = client.last_patch["request"]
+    assert payload["is_web_public"] is True
+    assert payload["is_private"] is False
+
+
+def test_update_channel_type_to_private_with_subscribers_ok() -> None:
+    """type→private succeeds when channel has existing subscribers (FR-014)."""
+    client = _update_client(subscribers=[100, 101])
+    _ = update_channel(client, name="general", channel_type="private")
+    payload = client.last_patch["request"]
+    assert payload["is_private"] is True
+
+
+def test_update_channel_type_to_private_lockout_without_subs_or_group() -> None:
+    """type→private with empty channel + no subs/group raises lockout."""
+    client = _update_client(subscribers=[])
+    with pytest.raises(ZulipLockoutError):
+        _ = update_channel(client, name="general", channel_type="private")
+
+
+def test_update_channel_type_to_private_with_subscribe_satisfies_lockout() -> None:
+    """type→private with --subscribe targets bypasses lockout check."""
+    client = _update_client(subscribers=[])
+    _ = update_channel(
+        client,
+        name="general",
+        channel_type="private",
+        subscribe_user_specs=["alice@example.com"],
+        user_id_mode="email",
+    )
+    payload = client.last_patch["request"]
+    assert payload["is_private"] is True
+
+
+def test_update_channel_type_to_private_with_allow_group_satisfies_lockout() -> None:
+    """type→private with non-Nobody --allow-group satisfies lockout."""
+    client = _update_client(subscribers=[])
+    _ = update_channel(
+        client,
+        name="general",
+        channel_type="private",
+        allow_group="design",
+    )
+    payload = client.last_patch["request"]
+    assert payload["is_private"] is True
+    # group-setting-update wrapper for PATCH endpoints.
+    assert payload["can_access_group"] == {"new": 30}
+
+
+def test_update_channel_type_to_private_rejects_nobody_group() -> None:
+    """``Nobody`` does not satisfy lockout prevention for type→private."""
+    client = _update_client(subscribers=[])
+    with pytest.raises(ZulipLockoutError):
+        _ = update_channel(
+            client,
+            name="general",
+            channel_type="private",
+            allow_group="Nobody",
+        )
+
+
+def test_update_channel_allow_group_uses_new_wrapper_format() -> None:
+    """``--allow-group`` always wraps with ``{"new": value}`` for PATCH."""
+    client = _update_client()
+    _ = update_channel(client, name="general", allow_group="design")
+    payload = client.last_patch["request"]
+    assert payload["can_access_group"] == {"new": 30}
+
+
+def test_update_channel_allow_group_multiple_uses_complex_form() -> None:
+    """Multiple groups produce the direct_subgroups complex form, still wrapped."""
+    client = _update_client()
+    _ = update_channel(client, name="general", allow_group="design, id:10")
+    payload = client.last_patch["request"]
+    assert payload["can_access_group"] == {"new": {"direct_members": [], "direct_subgroups": [30, 10]}}
+
+
+def test_update_channel_can_remove_subscribers_group_wrapper() -> None:
+    """``--can-remove-subscribers-group`` is wrapped with ``{"new": value}``."""
+    client = _update_client()
+    _ = update_channel(client, name="general", can_remove_subscribers_group="design")
+    payload = client.last_patch["request"]
+    assert payload["can_remove_subscribers_group"] == {"new": 30}
+
+
+def test_update_channel_can_remove_subscribers_group_feature_level() -> None:
+    """``--can-remove-subscribers-group`` requires the documented feature level."""
+    client = _update_client(feature_level=1)
+    with pytest.raises(ZulipFeatureLevelError):
+        _ = update_channel(
+            client,
+            name="general",
+            can_remove_subscribers_group="design",
+        )
+
+
+def test_update_channel_topic_policy_feature_level() -> None:
+    """``--topic-policy`` requires the documented feature level."""
+    client = _update_client(feature_level=1)
+    with pytest.raises(ZulipFeatureLevelError):
+        _ = update_channel(client, name="general", topic_policy="allow")
+
+
+def test_update_channel_topic_policy_passthrough() -> None:
+    """``topic_policy`` value is forwarded to the PATCH payload."""
+    client = _update_client()
+    _ = update_channel(client, name="general", topic_policy="deny")
+    payload = client.last_patch["request"]
+    assert payload["topic_policy"] == "deny"
+
+
+def test_update_channel_multiple_settings() -> None:
+    """Multiple fields combine in a single PATCH request (FR-004)."""
+    client = _update_client()
+    _ = update_channel(
+        client,
+        name="general",
+        new_name="renamed",
+        description="d",
+        allow_group="design",
+    )
+    payload = client.last_patch["request"]
+    assert payload["new_name"] == "renamed"
+    assert payload["description"] == "d"
+    assert payload["can_access_group"] == {"new": 30}
+
+
+def test_update_channel_returns_channel_id_and_name() -> None:
+    """The MutationResult includes the resolved channel id and name."""
+    client = _update_client()
+    result = update_channel(client, channel_id=2, description="d")
+    assert result["channel_id"] == 2
+    assert result["channel_name"] == "Engineering"
+    assert result["operation"] == "update"
+
+
+def test_update_channel_api_error_propagates() -> None:
+    """A non-success PATCH response surfaces as ``ZulipAPIError``."""
+    from lftools_uv.api.endpoints.zulip import ZulipAPIError
+
+    client = _update_client(patch_response={"result": "error", "msg": "boom"})
+    with pytest.raises(ZulipAPIError, match="boom"):
+        _ = update_channel(client, name="general", description="x")

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2459,8 +2459,14 @@ def test_update_channel_rejects_invalid_topic_policy() -> None:
 
 
 def test_update_channel_web_public_requires_spectator_access() -> None:
-    """``--type web-public`` errors when the realm has spectator access disabled."""
+    """``--type web-public`` errors when the realm has spectator access disabled.
+
+    Spectator-disabled is reported as a ``ZulipValidationError`` (with
+    an explicit message) rather than ``ZulipFeatureLevelError``: a
+    feature-level mismatch error would be misleading because the
+    server-side feature level is in fact sufficient.
+    """
     client = _update_client(feature_level=1000, spectator_access=False)
-    with pytest.raises(ZulipFeatureLevelError) as exc_info:
+    with pytest.raises(ZulipValidationError) as exc_info:
         _ = update_channel(client, name="general", channel_type="web-public")
-    assert "spectator" in exc_info.value.feature_name
+    assert "spectator" in str(exc_info.value).lower()

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -2053,6 +2053,27 @@ def test_channel_update_subscribe_requires_id_mode(monkeypatch: pytest.MonkeyPat
     assert "by-email" in result.output or "by-email" in (result.stderr or "")
 
 
+def test_channel_update_subscribe_requires_private_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--subscribe`` is scoped to type-to-private lockout prevention."""
+    _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "update",
+            "general",
+            "--description",
+            "new description",
+            "--subscribe",
+            "alice@example.com",
+            "--by-email",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--type private" in result.output or "--type private" in (result.stderr or "")
+
+
 def test_channel_update_subscribe_with_by_email(monkeypatch: pytest.MonkeyPatch) -> None:
     """Multi-valued ``--subscribe`` plus ``--by-email`` forwards correctly."""
     fake = _patch_update(monkeypatch)

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -2099,8 +2099,13 @@ def test_channel_update_can_remove_subscribers_group(monkeypatch: pytest.MonkeyP
 
 
 def test_channel_update_no_settings_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Invocation with no setting flags errors via ZulipValidationError."""
-    _patch_update(
+    """No-settings invocation fails locally before reaching the API.
+
+    The CLI performs an "at least one setting must change" check
+    before dispatching to ``update_channel``; this test verifies the
+    local guard fires (the side-effect set on the mock is unused).
+    """
+    fake = _patch_update(
         monkeypatch,
         side_effect=ZulipValidationError("at least one setting must change"),
     )
@@ -2109,6 +2114,8 @@ def test_channel_update_no_settings_errors(monkeypatch: pytest.MonkeyPatch) -> N
     assert result.exit_code != 0
     out = result.output + (result.stderr or "")
     assert "at least one" in out
+    # The CLI guard should short-circuit BEFORE the API layer.
+    assert fake.call_count == 0
 
 
 def test_channel_update_lockout_error_surfaces(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -2208,6 +2208,31 @@ def test_channel_update_requires_exactly_one_target(monkeypatch: pytest.MonkeyPa
     assert result.exit_code != 0
 
 
+def test_channel_update_invalid_channel_id_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid ``--channel-id`` values follow the exit-1 contract."""
+    _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        ["channel", "update", "--channel-id", "abc", "--description", "x"],
+    )
+    assert result.exit_code == 1
+    combined = result.output + (result.stderr or "")
+    assert "--channel-id must be a numeric channel ID" in combined
+
+
+def test_channel_update_channel_id_parses_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--channel-id`` is parsed manually and forwarded as an int."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        ["channel", "update", "--channel-id", "42", "--description", "x"],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["channel_id"] == 42
+
+
 def test_channel_update_include_archived_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     """``--include-archived`` forwards to the API layer."""
     fake = _patch_update(monkeypatch)

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -2063,8 +2063,6 @@ def test_channel_update_subscribe_requires_private_type(monkeypatch: pytest.Monk
             "channel",
             "update",
             "general",
-            "--description",
-            "new description",
             "--subscribe",
             "alice@example.com",
             "--by-email",

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -28,10 +28,10 @@ import lftools_uv.typer_apps.zulip as zulip_mod
 from lftools_uv.api.endpoints.zulip import (
     ZulipAmbiguityError,
     ZulipConfigError,
-    ZulipValidationError,
-    ZulipLockoutError,
     ZulipFeatureLevelError,
+    ZulipLockoutError,
     ZulipNotFoundError,
+    ZulipValidationError,
 )
 from lftools_uv.typer_apps.zulip import (
     MISSING_EXTRA_MESSAGE,
@@ -1939,7 +1939,6 @@ def _patch_update(monkeypatch: pytest.MonkeyPatch, **side_effect: Any) -> mock.M
     monkeypatch.setattr(zulip_mod, "get_client", lambda *a, **kw: mock.MagicMock())
     monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
     return fake
-
 
 
 def test_channel_update_name(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -28,6 +28,9 @@ import lftools_uv.typer_apps.zulip as zulip_mod
 from lftools_uv.api.endpoints.zulip import (
     ZulipAmbiguityError,
     ZulipConfigError,
+    ZulipValidationError,
+    ZulipLockoutError,
+    ZulipFeatureLevelError,
     ZulipNotFoundError,
 )
 from lftools_uv.typer_apps.zulip import (
@@ -1908,3 +1911,292 @@ def test_channel_unsubscribe_json_error_channel_unresolved(
     assert payload["status"] == "error"
     assert payload["channel_id"] is None
     assert payload["channel_name"] == "nosuch"
+
+
+# T048 — `channel update` CLI command (US8)
+# ---------------------------------------------------------------------------
+
+
+def _patch_update(monkeypatch: pytest.MonkeyPatch, **side_effect: Any) -> mock.MagicMock:
+    """Patch ``update_channel`` in the typer module and return the mock."""
+    import lftools_uv.typer_apps.zulip as zulip_mod
+
+    fake = mock.MagicMock()
+    if "side_effect" in side_effect:
+        fake.side_effect = side_effect["side_effect"]
+    else:
+        fake.return_value = side_effect.get(
+            "return_value",
+            {
+                "status": "success",
+                "channel_id": 42,
+                "channel_name": "renamed",
+                "operation": "update",
+            },
+        )
+
+    monkeypatch.setattr(zulip_mod, "update_channel", fake, raising=False)
+    monkeypatch.setattr(zulip_mod, "get_client", lambda *a, **kw: mock.MagicMock())
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
+    return fake
+
+
+
+def test_channel_update_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`channel update --name X` forwards ``new_name`` to the API."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--name", "renamed"])
+    assert result.exit_code == 0, result.output
+    kwargs = fake.call_args.kwargs
+    assert kwargs["name"] == "general"
+    assert kwargs["new_name"] == "renamed"
+
+
+def test_channel_update_description(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`channel update --description X` forwards ``description``."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--description", "new desc"])
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["description"] == "new desc"
+
+
+def test_channel_update_type_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--type public`` forwards ``channel_type='public'``."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--type", "public"])
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["channel_type"] == "public"
+
+
+def test_channel_update_type_private(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--type", "private"])
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["channel_type"] == "private"
+
+
+def test_channel_update_type_web_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--type", "web-public"])
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["channel_type"] == "web-public"
+
+
+def test_channel_update_topic_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--topic-policy`` choices are forwarded."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    for value in ("allow", "deny", "follow-default"):
+        result = runner.invoke(
+            zulip_app,
+            ["channel", "update", "general", "--topic-policy", value],
+        )
+        assert result.exit_code == 0, result.output
+        assert fake.call_args.kwargs["topic_policy"] == value
+
+
+def test_channel_update_allow_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--allow-group`` value is forwarded verbatim."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        ["channel", "update", "general", "--allow-group", "design"],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["allow_group"] == "design"
+
+
+def test_channel_update_allow_group_with_type_private(monkeypatch: pytest.MonkeyPatch) -> None:
+    """type-to-private + --allow-group is the documented atomic path."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "update",
+            "general",
+            "--type",
+            "private",
+            "--allow-group",
+            "design",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["channel_type"] == "private"
+    assert fake.call_args.kwargs["allow_group"] == "design"
+
+
+def test_channel_update_subscribe_requires_id_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--subscribe`` requires exactly one of ``--by-email``/``--by-id``/``--by-name``."""
+    _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "update",
+            "general",
+            "--type",
+            "private",
+            "--subscribe",
+            "alice@example.com",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "by-email" in result.output or "by-email" in (result.stderr or "")
+
+
+def test_channel_update_subscribe_with_by_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Multi-valued ``--subscribe`` plus ``--by-email`` forwards correctly."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "update",
+            "general",
+            "--type",
+            "private",
+            "--subscribe",
+            "alice@example.com",
+            "--subscribe",
+            "bob@example.com",
+            "--by-email",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    kwargs = fake.call_args.kwargs
+    assert list(kwargs["subscribe_user_specs"]) == [
+        "alice@example.com",
+        "bob@example.com",
+    ]
+    assert kwargs["user_id_mode"] == "email"
+
+
+def test_channel_update_can_remove_subscribers_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "update",
+            "general",
+            "--can-remove-subscribers-group",
+            "design",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["can_remove_subscribers_group"] == "design"
+
+
+def test_channel_update_no_settings_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invocation with no setting flags errors via ZulipValidationError."""
+    _patch_update(
+        monkeypatch,
+        side_effect=ZulipValidationError("at least one setting must change"),
+    )
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general"])
+    assert result.exit_code != 0
+    out = result.output + (result.stderr or "")
+    assert "at least one" in out
+
+
+def test_channel_update_lockout_error_surfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lockout errors from the API exit non-zero with a clear message."""
+    _patch_update(monkeypatch, side_effect=ZulipLockoutError("lockout"))
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--type", "private"])
+    assert result.exit_code != 0
+    out = result.output + (result.stderr or "")
+    assert "lockout" in out
+
+
+def test_channel_update_feature_level_error_surfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Feature-level errors carry the FR-019 canonical message."""
+    _patch_update(
+        monkeypatch,
+        side_effect=ZulipFeatureLevelError(required=334, actual=200, feature_name="topic-policy"),
+    )
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--topic-policy", "deny"])
+    assert result.exit_code != 0
+    out = result.output + (result.stderr or "")
+    assert "feature level 334" in out
+    assert "server has 200" in out
+
+
+def test_channel_update_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--json`` prints the MutationResult as JSON."""
+    _patch_update(
+        monkeypatch,
+        return_value={
+            "status": "success",
+            "channel_id": 42,
+            "channel_name": "renamed",
+            "operation": "update",
+        },
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        ["--json", "channel", "update", "general", "--description", "x"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "success"
+    assert payload["operation"] == "update"
+    assert payload["channel_id"] == 42
+
+
+def test_channel_update_requires_exactly_one_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exactly one of [channel] positional or --channel-id is required (FR-018)."""
+    _patch_update(monkeypatch)
+    runner = CliRunner()
+    # Neither provided
+    result = runner.invoke(zulip_app, ["channel", "update", "--description", "x"])
+    assert result.exit_code != 0
+    out = result.output + (result.stderr or "")
+    assert "channel" in out.lower()
+    # Both provided
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "update",
+            "general",
+            "--channel-id",
+            "1",
+            "--description",
+            "x",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_channel_update_include_archived_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--include-archived`` forwards to the API layer."""
+    fake = _patch_update(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        [
+            "channel",
+            "update",
+            "old-channel",
+            "--include-archived",
+            "--description",
+            "x",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.call_args.kwargs["include_archived"] is True


### PR DESCRIPTION
## Summary

Implements **User Story 8 — Update Channel Settings** from the
[001-zulip-channel-mgmt spec](../tree/main/specs/001-zulip-channel-mgmt).
Adds `lftools-uv zulip channel update` with the full flag surface
documented in `specs/001-zulip-channel-mgmt/contracts/cli-commands.md`
and the API-layer `update_channel()` it dispatches to.

Tasks completed: **T048**, **T049**, **T050**, **T051** (Phase 10).

## Independence

US8 has no strict story dependencies (uses foundational helpers only).
It is independent of and parallel to the other in-flight P3 slices
(US9 archive, US10 unarchive, US7 unsubscribe, US5/US6 subscribe).
Foundation (#362) is merged.

## Implementation notes

- **PATCH endpoint**: `PATCH /api/v1/streams/{stream_id}`. Group-setting
  fields (`can_access_group`, `can_remove_subscribers_group`) are wrapped
  in the **`{"new": value}` group-setting-update envelope** that the
  PATCH endpoints require — distinct from the POST endpoints which take
  the raw value. This is explicitly tested.
- **Lockout prevention** (spec scenarios 13/14, FR-004): when converting
  a channel to private, if it currently has **zero subscribers**, the
  caller MUST provide either `--subscribe` users OR a non-Nobody
  `--allow-group`. `--allow-group Nobody` does NOT satisfy this — it
  disables the permission entirely. Existing-subscriber paths flow
  through unchanged.
- **Feature-level gating** (FR-019) is applied for `--type web-public`,
  `--topic-policy`, `--allow-group` (can-access-group) and
  `--can-remove-subscribers-group`, using the shared `check_feature_level`
  helper introduced by the foundation.
- **At-least-one-setting validation** is enforced in the API layer and
  surfaced as a `ZulipValidationError`.
- The `channel` sub-app is introduced here. Other parallel P3 slices
  (archive/unarchive/subscribe) will add commands to the same sub-app;
  **expect benign merge conflicts** in that small registration block
  when slices land.

## Tests

- **T049 (API)**: 20 unit tests for `update_channel()` — PATCH endpoint
  mock, every parameter combination, group-setting-update `{"new":}`
  wrapper format, lockout validation (no subscribers / subscribers /
  with allow-group / Nobody refusal), feature-level errors,
  multi-setting payloads, and PATCH error propagation.
- **T048 (CLI)**: 18 unit tests for `channel update` — name /
  description / all three type transitions / topic-policy /
  allow-group / can-remove-subscribers-group / subscribe with
  --by-email, --json output, lockout & feature-level error surfacing,
  FR-018 channel-target validation, `--include-archived`.

Local run: `pytest tests/unit/test_zulip_*.py` ⇒ 79 passed.
Full suite: 453 passed, pre-existing `test_version.*` fixture-mutation
failures unrelated to this change.

## Commits

- \`Fix(tests): Tolerate Click error format change\` — mirrors PR #378,
  needed because the Click upgrade changed the unknown-option wording.
- \`Feat(zulip): Update channel settings (US8)\` — T048 + T049 + T050 + T051.
- \`Docs(tasks): Mark T048-T051 complete\` — tasks.md sync.