### PR TITLE
Test(cli): Accept new Click error format for passgen

### DIFF
--- a/tests/test_cli/test_typer_migration.py
+++ b/tests/test_cli/test_typer_migration.py
@@ -114,7 +114,12 @@ class TestTyperUtilsPassgen:
         result = self.runner.invoke(utils_app, ["passgen", "-5"])
         # Negative numbers cause argument parsing errors (exit code 2)
         assert result.exit_code == 2
-        assert_in_output("No such option: -5", result.stderr)
+        # Click's error message format has varied across versions:
+        #   older: "No such option: -5"
+        #   newer: "No such option '-5'."
+        # Match both by asserting on the stable substrings.
+        assert_in_output("No such option", result.stderr)
+        assert_in_output("-5", result.stderr)
 
     def test_passgen_invalid_length_too_large(self):
         """Test passgen with invalid length (too large)."""


### PR DESCRIPTION
## Problem

The CI matrix test job [failed](https://github.com/lfreleng-actions/lftools-uv/actions/runs/26162005587/job/76956422715) on `test_passgen_invalid_length_negative`:

```
AssertionError: Expected 'No such option: -5' not found in cleaned output

Cleaned output:
Usage: utils passgen [OPTIONS] [LENGTH]
Try 'utils passgen --help' for help.
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ No such option '-5'.                                                         │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Click 8.3+ changed its `No such option` error format from `No such option: -5` to `No such option '-5'.` (quoted, with a trailing period).

## Fix

Relax the assertion to match the stable substrings (`No such option` and `-5`) rather than the exact phrasing, so the test is portable across Click versions.

Note: this PR does not address the unrelated `python-audit-action` CVE — no patched release of the affected module is yet available upstream.