### PR TITLE
Feat(zulip): Topic policy convenience command (PR L, Phase 13)

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -984,6 +984,7 @@ TOPIC_POLICY_MAP: dict[str, int] = {
     "deny": 2,
     "follow-default": 0,
 }
+TOPIC_POLICY_REVERSE_MAP: dict[int, str] = {value: key for key, value in TOPIC_POLICY_MAP.items()}
 
 
 def create_channel(
@@ -1841,6 +1842,114 @@ def update_channel(
         "channel_id": stream_id,
         "channel_name": effective_name,
         "operation": "update",
+    }
+
+
+# Topic policy convenience helpers (FR-021)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_topic_policy(raw_policy: Any) -> TopicPolicy:
+    """Translate Zulip topic-policy API values to CLI policy strings."""
+    if isinstance(raw_policy, str) and raw_policy in VALID_TOPIC_POLICIES:
+        return raw_policy  # type: ignore[return-value]
+    if isinstance(raw_policy, int) and raw_policy in TOPIC_POLICY_REVERSE_MAP:
+        return TOPIC_POLICY_REVERSE_MAP[raw_policy]  # type: ignore[return-value]
+    raise ZulipAPIError(f"Malformed topic-policy value from server: {raw_policy!r}")
+
+
+def _resolve_topic_policy_channel(
+    client: Any,
+    channel: str | int | dict[str, Any],
+    *,
+    include_archived: bool = False,
+) -> dict[str, Any]:
+    """Resolve a topic-policy target passed as name, ID, or stream dict."""
+    if isinstance(channel, bool) or channel is None:
+        raise ZulipValidationError("topic-policy requires a channel name or id")
+    if isinstance(channel, dict):
+        return channel
+    if isinstance(channel, int):
+        return resolve_channel(client, channel_id=channel, include_archived=include_archived)
+    if isinstance(channel, str):
+        channel_name = channel.strip()
+        if not channel_name:
+            raise ZulipValidationError("topic-policy requires a non-empty channel name")
+        return resolve_channel(client, name=channel_name, include_archived=include_archived)
+    raise ZulipValidationError(f"Unsupported channel target type: {type(channel).__name__}")
+
+
+def get_topic_policy(
+    client: Any,
+    channel: str | int | dict[str, Any],
+    *,
+    include_archived: bool = False,
+) -> dict[str, Any]:
+    """Return the current topic-editing policy for a channel."""
+    check_feature_level(client, FEATURE_LEVELS["topic-policy"], feature_name="topic-policy")
+    target = _resolve_topic_policy_channel(client, channel, include_archived=include_archived)
+    stream_id = target.get("stream_id")
+    channel_name = target.get("name")
+    if not isinstance(stream_id, int) or not isinstance(channel_name, str):
+        raise ZulipAPIError(f"Resolved channel missing stream_id/name: {target!r}")
+
+    try:
+        response = client.call_endpoint(url=f"streams/{stream_id}", method="GET")
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to read topic policy for {channel_name!r}: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = response.get("msg") if isinstance(response, dict) else None
+        raise ZulipAPIError(f"Failed to read topic policy for {channel_name!r}: {msg or response!r}")
+    stream_info = response.get("stream")
+    if not isinstance(stream_info, dict):
+        raise ZulipAPIError(f"Malformed stream-info response for {channel_name!r}: {response!r}")
+
+    raw_policy = stream_info.get("topics_policy", stream_info.get("topic_policy"))
+    topic_policy = _normalize_topic_policy(raw_policy)
+    return {
+        "channel_id": stream_id,
+        "channel_name": channel_name,
+        "topic_policy": topic_policy,
+    }
+
+
+def set_topic_policy(
+    client: Any,
+    channel: str | int | dict[str, Any],
+    policy: TopicPolicy,
+    *,
+    include_archived: bool = False,
+) -> dict[str, Any]:
+    """Set a channel topic-editing policy via the Zulip PATCH endpoint."""
+    if policy not in VALID_TOPIC_POLICIES:
+        raise ZulipValidationError(
+            f"Invalid topic-policy value: {policy!r}. Valid values are: {', '.join(sorted(VALID_TOPIC_POLICIES))}"
+        )
+    check_feature_level(client, FEATURE_LEVELS["topic-policy"], feature_name="topic-policy")
+    target = _resolve_topic_policy_channel(client, channel, include_archived=include_archived)
+    stream_id = target.get("stream_id")
+    channel_name = target.get("name")
+    if not isinstance(stream_id, int) or not isinstance(channel_name, str):
+        raise ZulipAPIError(f"Resolved channel missing stream_id/name: {target!r}")
+
+    try:
+        response = client.call_endpoint(
+            url=f"streams/{stream_id}",
+            method="PATCH",
+            request={"topics_policy": TOPIC_POLICY_MAP[policy]},
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to set topic policy for {channel_name!r}: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = response.get("msg") if isinstance(response, dict) else None
+        raise ZulipAPIError(f"Failed to set topic policy for {channel_name!r}: {msg or response!r}")
+
+    return {
+        "status": "success",
+        "channel_id": stream_id,
+        "channel_name": channel_name,
+        "operation": "topic-policy",
+        "topic_policy": policy,
     }
 
 

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -40,11 +40,13 @@ from lftools_uv.api.endpoints.zulip import (
     ZulipError,
     archive_channel,
     get_client,
+    get_topic_policy,
     list_channels,
     list_groups,
     list_subscribers,
     list_users,
     resolve_channel,
+    set_topic_policy,
     subscribe_users,
     unarchive_channel,
     update_channel,
@@ -1266,6 +1268,92 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
         emit_json(result)
     else:
         typer.echo(f"Updated channel '{result['channel_name']}' (id={result['channel_id']})")
+
+
+# ---------------------------------------------------------------------------
+# Topic policy convenience command (FR-021)
+# ---------------------------------------------------------------------------
+
+
+@channel_app.command("topic-policy")
+def channel_topic_policy(
+    ctx: typer.Context,
+    channel: str | None = typer.Argument(
+        None,
+        help="Channel name (optional if --channel-id is given).",
+    ),
+    channel_id: str | None = typer.Option(
+        None,
+        "--channel-id",
+        help="Target channel by numeric ID.",
+    ),
+    policy: str | None = typer.Option(
+        None,
+        "--policy",
+        help="Topic policy: allow, deny, or follow-default.",
+    ),
+    include_archived: bool = typer.Option(
+        False,
+        "--include-archived",
+        help="Include archived channels when resolving the target.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of text.",
+        hidden=True,
+    ),
+) -> None:
+    """View or set a channel's topic editing policy."""
+    _validate_single_channel_target(channel, channel_id)
+
+    parsed_channel_id: int | None = None
+    if channel_id is not None:
+        try:
+            parsed_channel_id = int(channel_id)
+        except ValueError:
+            emit_error("--channel-id must be a numeric channel ID.")
+            raise typer.Exit(code=1) from None
+
+    valid_policies = {"allow", "deny", "follow-default"}
+    if policy is not None and policy not in valid_policies:
+        emit_error(f"Invalid --policy {policy!r}; expected one of {', '.join(sorted(valid_policies))}")
+        raise typer.Exit(code=1)
+
+    options = {**(ctx.obj or {})}
+    if json_output:
+        options["json_output"] = True
+
+    target: str | int
+    if parsed_channel_id is not None:
+        target = parsed_channel_id
+    else:
+        assert channel is not None
+        target = channel
+
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        if policy is None:
+            result = get_topic_policy(client, target, include_archived=include_archived)
+        else:
+            result = set_topic_policy(
+                client,
+                target,
+                cast(TopicPolicy, policy),
+                include_archived=include_archived,
+            )
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json(result)
+    elif policy is None:
+        typer.echo(result["topic_policy"])
+    else:
+        typer.echo(
+            f"Updated topic policy for '{result['channel_name']}' "
+            f"(id={result['channel_id']}) to {result['topic_policy']}"
+        )
 
 
 @channel_app.command("archive")

--- a/specs/001-zulip-channel-mgmt/tasks.md
+++ b/specs/001-zulip-channel-mgmt/tasks.md
@@ -276,10 +276,10 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 **Goal**: Provide `lftools-uv zulip channel topic-policy` convenience command for viewing/setting topic policy
 
-- [ ] T060 [P] Write CLI tests for `channel topic-policy` in tests/unit/test_zulip_cli.py — test read mode (no --policy), write mode (--policy allow/deny/follow-default), invalid policy value rejection, feature-level error, --json output for both modes
-- [ ] T061 [P] Write API tests for `get_topic_policy()` and `set_topic_policy()` in tests/unit/test_zulip_api.py — mock Zulip stream info endpoint for read, PATCH for write
-- [ ] T062 Implement `get_topic_policy(client, channel)` and `set_topic_policy(client, channel, policy)` in lftools_uv/api/endpoints/zulip.py — check feature level, read or update topic policy field, return result
-- [ ] T063 Implement `channel topic-policy` CLI command in lftools_uv/typer_apps/zulip.py — add `topic-policy` command with positional `[channel]`, `--channel-id`, `--policy` (optional), `--include-archived`, `--json` flags, display current policy in read mode, update in write mode
+- [x] T060 [P] Write CLI tests for `channel topic-policy` in tests/unit/test_zulip_cli.py — test read mode (no --policy), write mode (--policy allow/deny/follow-default), invalid policy value rejection, feature-level error, --json output for both modes
+- [x] T061 [P] Write API tests for `get_topic_policy()` and `set_topic_policy()` in tests/unit/test_zulip_api.py — mock Zulip stream info endpoint for read, PATCH for write
+- [x] T062 Implement `get_topic_policy(client, channel)` and `set_topic_policy(client, channel, policy)` in lftools_uv/api/endpoints/zulip.py — check feature level, read or update topic policy field, return result
+- [x] T063 Implement `channel topic-policy` CLI command in lftools_uv/typer_apps/zulip.py — add `topic-policy` command with positional `[channel]`, `--channel-id`, `--policy` (optional), `--include-archived`, `--json` flags, display current policy in read mode, update in write mode
 
 ---
 

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -20,7 +20,7 @@ Covers the foundational tasks T016–T019:
 from __future__ import annotations
 
 import json as _json
-from typing import Any
+from typing import Any, cast
 from unittest import mock
 
 import pytest
@@ -40,12 +40,14 @@ from lftools_uv.api.endpoints.zulip import (
     check_feature_level,
     get_client,
     get_server_feature_level,
+    get_topic_policy,
     list_channels,
     list_groups,
     list_users,
     resolve_channel,
     resolve_groups,
     resolve_users,
+    set_topic_policy,
     subscribe_users,
     unarchive_channel,
     unsubscribe_users,
@@ -2858,3 +2860,108 @@ def test_unarchive_channel_server_error_propagates() -> None:
     )
     with pytest.raises(ZulipAPIError, match="boom"):
         _ = unarchive_channel(client, channel="broken", include_archived=True)
+
+
+# ---------------------------------------------------------------------------
+# T061 — topic-policy API helpers (FR-021)
+# ---------------------------------------------------------------------------
+
+
+def _topic_policy_client(
+    *,
+    feature_level: int = 334,
+    stream_info_policy: int | str | None = 1,
+    patch_response: dict[str, Any] | None = None,
+) -> mock.MagicMock:
+    """Return a mock client for topic-policy read/write helpers."""
+    client = mock.MagicMock()
+    client.get_server_settings.return_value = {
+        "result": "success",
+        "zulip_feature_level": feature_level,
+    }
+
+    def side_effect(*, url: str, method: str, request: dict[str, Any] | None = None) -> dict[str, Any]:
+        if url == "streams" and method == "GET":
+            return {
+                "result": "success",
+                "streams": [
+                    {
+                        "stream_id": 42,
+                        "name": "general",
+                        "description": "General discussion",
+                        "is_archived": False,
+                    }
+                ],
+            }
+        if url == "streams/42" and method == "GET":
+            return {
+                "result": "success",
+                "stream": {"stream_id": 42, "name": "general", "topics_policy": stream_info_policy},
+            }
+        if url == "streams/42" and method == "PATCH":
+            assert request == {"topics_policy": 2}
+            return patch_response or {"result": "success"}
+        raise AssertionError(f"unexpected endpoint: {method} {url} {request}")
+
+    client.call_endpoint.side_effect = side_effect
+    return client
+
+
+def test_get_topic_policy_reads_stream_info_endpoint() -> None:
+    """Read mode resolves the channel and reads the stream-info policy field."""
+    client = _topic_policy_client(stream_info_policy=1)
+    result = get_topic_policy(client, "general")
+    assert result == {
+        "channel_id": 42,
+        "channel_name": "general",
+        "topic_policy": "allow",
+    }
+    client.call_endpoint.assert_any_call(url="streams/42", method="GET")
+
+
+def test_get_topic_policy_accepts_string_policy_field() -> None:
+    """Servers/tests may expose the normalized string policy field."""
+    client = _topic_policy_client(stream_info_policy="follow-default")
+    result = get_topic_policy(client, "general")
+    assert result["topic_policy"] == "follow-default"
+
+
+def test_set_topic_policy_patches_stream() -> None:
+    """Write mode maps policy strings to Zulip's integer PATCH payload."""
+    client = _topic_policy_client()
+    result = set_topic_policy(client, "general", "deny")
+    assert result == {
+        "status": "success",
+        "channel_id": 42,
+        "channel_name": "general",
+        "operation": "topic-policy",
+        "topic_policy": "deny",
+    }
+    client.call_endpoint.assert_any_call(
+        url="streams/42",
+        method="PATCH",
+        request={"topics_policy": 2},
+    )
+
+
+def test_set_topic_policy_rejects_invalid_policy() -> None:
+    """Only allow/deny/follow-default are accepted."""
+    client = _topic_policy_client()
+    with pytest.raises(ZulipValidationError, match="allow"):
+        set_topic_policy(client, "general", cast(Any, "maybe"))
+
+
+def test_get_topic_policy_checks_feature_level_first() -> None:
+    """Read mode fails before endpoint calls when the server is too old."""
+    client = _topic_policy_client(feature_level=333)
+    with pytest.raises(ZulipFeatureLevelError):
+        get_topic_policy(client, "general")
+    client.call_endpoint.assert_not_called()
+
+
+def test_set_topic_policy_checks_feature_level_first() -> None:
+    """Write mode fails before endpoint calls when the server is too old."""
+    client = _topic_policy_client(feature_level=333)
+    with pytest.raises(ZulipFeatureLevelError):
+        set_topic_policy(client, "general", "deny")
+    client.call_endpoint.assert_not_called()

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -2548,3 +2548,151 @@ def test_channel_unarchive_requires_some_target(
     result = runner.invoke(zulip_app, ["channel", "unarchive", "--yes"])
     assert result.exit_code == 1
     unarchive_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# T060 — ``channel topic-policy`` CLI (FR-021)
+# ---------------------------------------------------------------------------
+
+
+def _patch_topic_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    get_return: dict[str, Any] | None = None,
+    set_return: dict[str, Any] | None = None,
+    get_exc: BaseException | None = None,
+    set_exc: BaseException | None = None,
+) -> tuple[mock.MagicMock, mock.MagicMock]:
+    """Patch topic-policy API helpers for CLI tests."""
+    client = mock.MagicMock()
+    monkeypatch.setattr(zulip_mod, "get_client", lambda **_kw: client)
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
+
+    get_mock = mock.MagicMock()
+    set_mock = mock.MagicMock()
+    if get_exc is not None:
+        get_mock.side_effect = get_exc
+    else:
+        get_mock.return_value = get_return or {
+            "channel_id": 42,
+            "channel_name": "general",
+            "topic_policy": "allow",
+        }
+    if set_exc is not None:
+        set_mock.side_effect = set_exc
+    else:
+        set_mock.return_value = set_return or {
+            "status": "success",
+            "channel_id": 42,
+            "channel_name": "general",
+            "operation": "topic-policy",
+            "topic_policy": "deny",
+        }
+    monkeypatch.setattr(zulip_mod, "get_topic_policy", get_mock, raising=False)
+    monkeypatch.setattr(zulip_mod, "set_topic_policy", set_mock, raising=False)
+    return get_mock, set_mock
+
+
+def test_channel_topic_policy_read_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``--policy`` the command displays the current policy."""
+    get_mock, set_mock = _patch_topic_policy(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "topic-policy", "general"])
+    assert result.exit_code == 0, result.stdout
+    assert "allow" in result.stdout
+    get_mock.assert_called_once()
+    _, args, kwargs = get_mock.mock_calls[0]
+    assert args[1] == "general"
+    assert kwargs["include_archived"] is False
+    set_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("policy", ["allow", "deny", "follow-default"])
+def test_channel_topic_policy_write_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    policy: str,
+) -> None:
+    """With ``--policy`` the command updates and displays the policy."""
+    _, set_mock = _patch_topic_policy(
+        monkeypatch,
+        set_return={
+            "status": "success",
+            "channel_id": 42,
+            "channel_name": "general",
+            "operation": "topic-policy",
+            "topic_policy": policy,
+        },
+    )
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "topic-policy", "general", "--policy", policy])
+    assert result.exit_code == 0, result.stdout
+    assert policy in result.stdout
+    set_mock.assert_called_once()
+    _, args, kwargs = set_mock.mock_calls[0]
+    assert args[1] == "general"
+    assert args[2] == policy
+    assert kwargs["include_archived"] is False
+
+
+def test_channel_topic_policy_invalid_policy_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid policy values are rejected before contacting the API."""
+    get_mock, set_mock = _patch_topic_policy(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "topic-policy", "general", "--policy", "maybe"])
+    assert result.exit_code == 1
+    combined = result.stdout + result.stderr
+    assert "allow" in combined
+    assert "deny" in combined
+    assert "follow-default" in combined
+    get_mock.assert_not_called()
+    set_mock.assert_not_called()
+
+
+def test_channel_topic_policy_feature_level_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Feature-level guard errors are surfaced as CLI failures."""
+    _patch_topic_policy(
+        monkeypatch,
+        get_exc=ZulipFeatureLevelError(required=334, actual=333, feature_name="topic-policy"),
+    )
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["channel", "topic-policy", "general"])
+    assert result.exit_code == 1
+    combined = result.stdout + result.stderr
+    assert "feature level 334" in combined
+    assert "server has 333" in combined
+
+
+def test_channel_topic_policy_read_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read mode supports machine-readable JSON output."""
+    _patch_topic_policy(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(zulip_app, ["--json", "channel", "topic-policy", "general"])
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout) == {
+        "channel_id": 42,
+        "channel_name": "general",
+        "topic_policy": "allow",
+    }
+
+
+def test_channel_topic_policy_write_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write mode supports machine-readable JSON output."""
+    _patch_topic_policy(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        zulip_app,
+        ["channel", "topic-policy", "--channel-id", "42", "--policy", "deny", "--json"],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "status": "success",
+        "channel_id": 42,
+        "channel_name": "general",
+        "operation": "topic-policy",
+        "topic_policy": "deny",
+    }


### PR DESCRIPTION
## Summary

Adds the `lftools-uv zulip channel topic-policy` convenience command for reading and updating Zulip channel topic editing policy.

## Tasks

- T060: CLI tests for `channel topic-policy`
- T061: API tests for `get_topic_policy()` and `set_topic_policy()`
- T062: Topic-policy API helpers with feature-level checks
- T063: `channel topic-policy` CLI command

Implements FR-021 and Phase 13 of the `001-zulip-channel-mgmt` feature.

## Validation

- `uv run pytest tests/ -x -q`
- `uv run ruff check .`
- `SKIP=basedpyright pre-commit run --all-files`