### PR TITLE
Fix(zulip): Harden topic policy checks

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1853,7 +1853,7 @@ def _normalize_topic_policy(raw_policy: Any) -> TopicPolicy:
     """Translate Zulip topic-policy API values to CLI policy strings."""
     if isinstance(raw_policy, str) and raw_policy in VALID_TOPIC_POLICIES:
         return raw_policy  # type: ignore[return-value]
-    if isinstance(raw_policy, int) and raw_policy in TOPIC_POLICY_REVERSE_MAP:
+    if not isinstance(raw_policy, bool) and isinstance(raw_policy, int) and raw_policy in TOPIC_POLICY_REVERSE_MAP:
         return TOPIC_POLICY_REVERSE_MAP[raw_policy]  # type: ignore[return-value]
     raise ZulipAPIError(f"Malformed topic-policy value from server: {raw_policy!r}")
 
@@ -1870,6 +1870,8 @@ def _resolve_topic_policy_channel(
     if isinstance(channel, dict):
         return channel
     if isinstance(channel, int):
+        if channel <= 0:
+            raise ZulipValidationError(f"topic-policy requires a positive channel id (got {channel})")
         return resolve_channel(client, channel_id=channel, include_archived=include_archived)
     if isinstance(channel, str):
         channel_name = channel.strip()

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -2951,6 +2951,23 @@ def test_set_topic_policy_rejects_invalid_policy() -> None:
         set_topic_policy(client, "general", cast(Any, "maybe"))
 
 
+@pytest.mark.parametrize("channel", [0, -1])
+def test_topic_policy_rejects_non_positive_channel_id(channel: int) -> None:
+    """Numeric topic-policy targets must be positive channel IDs."""
+    client = _topic_policy_client()
+    with pytest.raises(ZulipValidationError, match="positive channel id"):
+        get_topic_policy(client, channel)
+    with pytest.raises(ZulipValidationError, match="positive channel id"):
+        set_topic_policy(client, channel, "deny")
+
+
+def test_get_topic_policy_rejects_bool_policy_field() -> None:
+    """Boolean topic-policy values from the server are malformed."""
+    client = _topic_policy_client(stream_info_policy=cast(Any, True))
+    with pytest.raises(ZulipAPIError, match="Malformed topic-policy"):
+        get_topic_policy(client, "general")
+
+
 def test_get_topic_policy_checks_feature_level_first() -> None:
     """Read mode fails before endpoint calls when the server is too old."""
     client = _topic_policy_client(feature_level=333)

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -2601,7 +2601,7 @@ def test_channel_topic_policy_read_mode(monkeypatch: pytest.MonkeyPatch) -> None
     assert result.exit_code == 0, result.stdout
     assert "allow" in result.stdout
     get_mock.assert_called_once()
-    _, args, kwargs = get_mock.mock_calls[0]
+    args, kwargs = get_mock.call_args
     assert args[1] == "general"
     assert kwargs["include_archived"] is False
     set_mock.assert_not_called()
@@ -2628,7 +2628,7 @@ def test_channel_topic_policy_write_mode(
     assert result.exit_code == 0, result.stdout
     assert policy in result.stdout
     set_mock.assert_called_once()
-    _, args, kwargs = set_mock.mock_calls[0]
+    args, kwargs = set_mock.call_args
     assert args[1] == "general"
     assert args[2] == policy
     assert kwargs["include_archived"] is False
@@ -2642,7 +2642,7 @@ def test_channel_topic_policy_invalid_policy_rejected(
     runner = CliRunner()
     result = runner.invoke(zulip_app, ["channel", "topic-policy", "general", "--policy", "maybe"])
     assert result.exit_code == 1
-    combined = result.stdout + result.stderr
+    combined = result.stdout + (result.stderr or "")
     assert "allow" in combined
     assert "deny" in combined
     assert "follow-default" in combined
@@ -2661,7 +2661,7 @@ def test_channel_topic_policy_feature_level_error(
     runner = CliRunner()
     result = runner.invoke(zulip_app, ["channel", "topic-policy", "general"])
     assert result.exit_code == 1
-    combined = result.stdout + result.stderr
+    combined = result.stdout + (result.stderr or "")
     assert "feature level 334" in combined
     assert "server has 333" in combined
 


### PR DESCRIPTION
This commit was developed during the PR #420 (Topic Policy) Copilot review cycle, but landed on the branch after #420 was already merged.

This separate PR preserves the hardening work:

- rejects malformed boolean `--policy` values before channel resolution
- rejects non-positive numeric channel IDs before channel resolution
- tightens CLI tests with stable mock inspection and robust stderr handling

The change is cherry-picked from orphan commit `a64f1f23691d906c818f8e85259146c570413bae`.