### PR TITLE
Fix(zulip): Use can_subscribe_group field for --allow-group

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -302,14 +302,14 @@ def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None
 #: * Feature level 1 — initial introduction of the
 #:   ``zulip_feature_level`` field; all servers we target report >= 1.
 #: * Feature level 12 — web-public streams and spectator access.
-#: * Feature level 197 — group-based access control via
-#:   ``can_access_group``.
+#: * Feature level 357 — group-based channel subscription via
+#:   ``can_subscribe_group``.
 #: * Feature level 161 — ``can_remove_subscribers_group`` permission.
 #: * Feature level 334 — ``topic_policy`` per-channel field.
 #: * Feature level 59 — stream reactivation via stream update API.
 FEATURE_LEVELS: dict[str, int] = {
     "web-public": 12,
-    "can-access-group": 197,
+    "can-subscribe-group": 357,
     "can-remove-subscribers-group": 161,
     "topic-policy": 334,
     "unarchive": 59,
@@ -1014,7 +1014,7 @@ def create_channel(
     subscribe_user_ids
         List of user IDs to subscribe on creation.
     allow_group_value
-        Resolved group-setting value for ``can_access_group`` field.
+        Resolved group-setting value for ``can_subscribe_group`` field.
         For private channels, callers should validate this is not the
         ``Nobody`` group before calling (to prevent lockout).
     can_remove_subscribers_group_value
@@ -1057,7 +1057,7 @@ def create_channel(
         check_feature_level(client, FEATURE_LEVELS["topic-policy"], "topic-policy")
 
     if allow_group_value is not None:
-        check_feature_level(client, FEATURE_LEVELS["can-access-group"], "group-based access control")
+        check_feature_level(client, FEATURE_LEVELS["can-subscribe-group"], "group-based channel subscription")
 
     if can_remove_subscribers_group_value is not None:
         check_feature_level(client, FEATURE_LEVELS["can-remove-subscribers-group"], "can-remove-subscribers-group")
@@ -1095,7 +1095,7 @@ def create_channel(
     # None = API default (no key)
 
     if allow_group_value is not None:
-        request["can_access_group"] = allow_group_value
+        request["can_subscribe_group"] = allow_group_value
 
     if can_remove_subscribers_group_value is not None:
         request["can_remove_subscribers_group"] = can_remove_subscribers_group_value
@@ -1591,7 +1591,7 @@ def update_channel(
       description, type, topic-policy, allow-group, or
       can-remove-subscribers-group).
     * Applies the FR-019 feature-level checks for web-public,
-      topic-policy, can-access-group (``--allow-group``) and
+      topic-policy, can-subscribe-group (``--allow-group``) and
       can-remove-subscribers-group.
     * Enforces lockout prevention when converting to ``private``: if
       the channel currently has 0 subscribers, the caller must supply
@@ -1683,7 +1683,7 @@ def update_channel(
     if topic_policy is not None:
         check_feature_level(client, FEATURE_LEVELS["topic-policy"], feature_name="topic-policy")
     if allow_group is not None:
-        check_feature_level(client, FEATURE_LEVELS["can-access-group"], feature_name="can-access-group")
+        check_feature_level(client, FEATURE_LEVELS["can-subscribe-group"], feature_name="can-subscribe-group")
     if can_remove_subscribers_group is not None:
         check_feature_level(
             client,
@@ -1814,7 +1814,7 @@ def update_channel(
     if topic_policy is not None:
         request["topics_policy"] = TOPIC_POLICY_MAP[topic_policy]
     if allow_group_value is not None:
-        request["can_access_group"] = {"new": allow_group_value}
+        request["can_subscribe_group"] = {"new": allow_group_value}
     if can_remove_value is not None:
         request["can_remove_subscribers_group"] = {"new": can_remove_value}
 

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1043,7 +1043,8 @@ def create_channel(
         is either missing or only contains ``Nobody``.
     ZulipFeatureLevelError
         When the server lacks the required feature level for web-public,
-        topic-policy, or can-remove-subscribers-group features.
+        topic-policy, can-subscribe-group, or can-remove-subscribers-group
+        features.
     ZulipAPIError
         For transport or server errors.
     """

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -608,6 +608,10 @@ def _resolve_single_group_token(token: str, groups: list[dict[str, Any]]) -> dic
         grp for grp in groups if str(grp.get("name", "")).casefold() == target and not grp.get("is_system_group", False)
     ]
     if not matches:
+        if token.isdigit():
+            raise ZulipNotFoundError(
+                f"No user group named {token!r}. If you meant a numeric group ID, use 'id:{token}'."
+            )
         raise ZulipNotFoundError(f"No user group named {token!r}")
     if len(matches) > 1:
         raise ZulipAmbiguityError(

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -443,12 +443,12 @@ def channel_create(
     allow_group: str | None = typer.Option(
         None,
         "--allow-group",
-        help="Comma-separated groups allowed to join the channel.",
+        help="Comma-separated groups allowed to join; use 'id:NUM' for ID lookup.",
     ),
     can_remove_subscribers_group: str | None = typer.Option(
         None,
         "--can-remove-subscribers-group",
-        help="Comma-separated groups that can remove subscribers.",
+        help="Comma-separated groups that can remove subscribers; use 'id:NUM' for ID lookup.",
     ),
     announce: bool = typer.Option(
         False,

--- a/specs/001-zulip-channel-mgmt/contracts/cli-commands.md
+++ b/specs/001-zulip-channel-mgmt/contracts/cli-commands.md
@@ -124,7 +124,7 @@ This translation is transparent to the user.
   error explaining the lockout risk.
 - `--allow-group` is valid on ALL channel types (unified semantics: "who
   can join"); server enforces on private, accepts-but-does-not-enforce on
-  public/web-public. Maps to Zulip API field `can_access_group`.
+  public/web-public. Maps to Zulip API field `can_subscribe_group`.
 - `--can-remove-subscribers-group` is valid on ALL channel types. Maps to
   Zulip API field `can_remove_subscribers_group`. Requires minimum
   feature level (threshold hardcoded during implementation, checked at
@@ -194,7 +194,7 @@ wraps automatically; user syntax is identical to `channel create`.
   requirement — it disables the permission entirely, leaving no path
   for anyone to join.
 - `--allow-group` is valid on ALL channel types (unified semantics).
-  Maps to Zulip API field `can_access_group`.
+  Maps to Zulip API field `can_subscribe_group`.
 - `--can-remove-subscribers-group` is valid on ALL channel types. Maps to
   Zulip API field `can_remove_subscribers_group`. Requires minimum
   feature level (threshold hardcoded during implementation, checked at

--- a/specs/001-zulip-channel-mgmt/data-model.md
+++ b/specs/001-zulip-channel-mgmt/data-model.md
@@ -20,7 +20,7 @@ Represents a Zulip channel (internally called a "stream" in the Zulip API).
 | `topic_policy` | `str \| None` | Policy: allow/deny/follow-default |
 | `is_archived` | `bool` | Channel is deactivated/archived |
 | `subscriber_count` | `int` | Number of current subscribers |
-| `can_access_group` | `GroupSettingValue \| None` | Access perm group |
+| `can_subscribe_group` | `GroupSettingValue \| None` | Subscribe perm |
 | `can_remove_subscribers_group` | `GroupSettingValue \| None` | Removal perm |
 
 **GroupSettingValue** (Zulip API "group-setting value"):
@@ -236,7 +236,7 @@ ZulipConfig 1──── Client Session
 
 - A Channel has zero or more Subscribers (ZulipUser instances)
 - A Channel may have zero or more allowed UserGroups (via `--allow-group` /
-  `can_access_group`) — enforced on private, accepted on public/web-public
+  `can_subscribe_group`) — enforced on private, accepted on public/web-public
 - A Channel may have a subscriber-removal permission group (via
   `--can-remove-subscribers-group` / `can_remove_subscribers_group`) —
   valid on ALL channel types

--- a/specs/001-zulip-channel-mgmt/plan.md
+++ b/specs/001-zulip-channel-mgmt/plan.md
@@ -19,7 +19,7 @@ the official `zulip` Python client library with a separated API layer
 (`lftools_uv/typer_apps/zulip.py`), following existing project conventions.
 Runtime feature-level detection ensures graceful degradation on older Zulip
 servers. Group-based permissions use two distinct flags: `--allow-group`
-(who can join — maps to `can_access_group`) and
+(who can join — maps to `can_subscribe_group`) and
 `--can-remove-subscribers-group` (who can remove subscribers — maps to
 `can_remove_subscribers_group`), both accepting comma-separated inline
 group identification with `id:` prefix disambiguation.

--- a/specs/001-zulip-channel-mgmt/research.md
+++ b/specs/001-zulip-channel-mgmt/research.md
@@ -206,7 +206,7 @@ The `zulip.Client` makes standard HTTP requests that can be intercepted by the
 **Decision**: Use two distinct flags for group-based channel permissions:
 
 - `--allow-group` — defines who is allowed to join the channel. Maps to
-  Zulip API field `can_access_group`. Valid on ALL channel types (server
+  Zulip API field `can_subscribe_group`. Valid on ALL channel types (server
   enforces on private; accepts but does not enforce on public/web-public).
 - `--can-remove-subscribers-group` — defines who can remove subscribers.
   Maps to Zulip API field `can_remove_subscribers_group`. Valid on ALL

--- a/specs/001-zulip-channel-mgmt/spec.md
+++ b/specs/001-zulip-channel-mgmt/spec.md
@@ -146,7 +146,7 @@ a single Zulip server."
   `--include-archived` was not specified, the CLI errors with a helpful
   suggestion to use `--include-archived`.
 - Q: What happens when `--allow-group` is used against a Zulip server
-  that doesn't support group-based access control? → A: Command returns
+  that doesn't support group-based self-subscribe permission? → A: Command returns
   a clear feature-level error following the FR-019 pattern.
 - Q: Does Zulip support more than two channel types? → A: Yes — Zulip
   supports three types: public (visible to organization members),
@@ -221,8 +221,9 @@ a single Zulip server."
 - Q: Should `--allow-group` be accepted during update-to-private type conversion?
   → A: Yes — when using `channel update` to convert a public or web-public
   channel to private, `--allow-group` MUST be accepted in the same command to
-  atomically set group-based access control during conversion. The Zulip API
-  supports setting `is_private=true` and `can_access_group` in a single PATCH
+  atomically set group-based self-subscribe permission during conversion. The
+  Zulip API supports setting `is_private=true` and `can_subscribe_group` in a
+  single PATCH
   request. The lockout prevention policy still applies — converting to private
   without existing subscribers requires `--subscribe` or `--allow-group`.
 - Q: Should `--allow-group` be restricted to private channels only? → A: No —
@@ -266,7 +267,7 @@ a single Zulip server."
   Note: `--group-name`/`--group-id` remain for `lftools-uv zulip group list`
   filtering only.
 - Q: What Zulip API field does `--allow-group` map to on public/web-public
-  channels? → A: Same field (`can_access_group`) on ALL channel types. The
+  channels? → A: Same field (`can_subscribe_group`) on ALL channel types. The
   CLI passes the setting through to the API regardless of channel type; it is
   the server's responsibility to enforce or not enforce based on channel type.
 - Q: Should `--can-remove-subscribers-group` require runtime feature-level
@@ -376,7 +377,7 @@ As a Zulip administrator, I want to list all user groups on the Zulip server —
 both custom user groups and built-in system role groups (Owners, Administrators,
 Moderators, Full Members, Members, Everyone, Nobody) — so that I can discover
 group identifiers (especially system role group names) to use when creating private
-channels with group-based access control.
+channels with group-based self-subscribe permission.
 
 **Why this priority**: Group discovery is a prerequisite for private channel
 creation when specifying allowed groups. System role groups are the primary
@@ -469,7 +470,7 @@ it appears in the channel list with the correct name, description, and type.
 8. **Given** a channel with the same name already exists, **When** I attempt to
    create a channel with that name, **Then** I see an error message indicating
    the name conflict and the command exits with a non-zero exit code.
-9. **Given** a Zulip server that does not support group-based access control,
+9. **Given** a Zulip server that does not support group-based self-subscribe permission,
    **When** I create a private channel with `--allow-group`, **Then** the
    command returns a clear error message indicating the required Zulip feature
    level and the server's current level, and exits with a non-zero exit code.
@@ -827,13 +828,13 @@ and verifying it reappears in the active channel list.
   does NOT enforce it (anyone can still join).
 - What happens when updating a channel type from public/web-public to private
   with `--allow-group`? The command MUST apply both the type conversion and
-  group-based access control atomically in a single Zulip API PATCH request
-  (setting `is_private=true` and `can_access_group` together).
+  group-based self-subscribe permission atomically in a single Zulip API PATCH request
+  (setting `is_private=true` and `can_subscribe_group` together).
 - What happens when a command uses a feature unsupported by the target Zulip
   server version? The system MUST detect the missing capability at runtime and
   return a clear error like "This operation requires Zulip feature level X
   (server has Y)" and exit with a non-zero code. This applies to `unarchive`,
-  `--allow-group` (group-based access control), `--can-remove-subscribers-group`,
+  `--allow-group` (group-based self-subscribe permission), `--can-remove-subscribers-group`,
   `--topic-policy`, and web-public channel type (requires spectator access).
 - What happens when a mutation is a no-op (e.g., archiving an already-archived
   channel, subscribing an already-subscribed user)? The command MUST succeed
@@ -906,7 +907,7 @@ and verifying it reappears in the active channel list.
   web-public channels, `--subscribe` is optional (anyone can join later) and
   `--allow-group` is accepted with the same semantics (defines who is allowed to
   join) but the server does NOT enforce the restriction on public/web-public
-  channels. The CLI maps `--allow-group` to the Zulip API `can_access_group`
+  channels. The CLI maps `--allow-group` to the Zulip API `can_subscribe_group`
   field on ALL channel types (pass-through; enforcement is the server's
   responsibility). Both custom user groups AND system role groups (Everyone,
   Members, Full Members, Moderators, Administrators, Owners, Nobody) are valid
@@ -933,7 +934,7 @@ and verifying it reappears in the active channel list.
   targeting different permissions. Each takes a direct comma-separated, quoted
   string value (e.g., `--allow-group 'foo, bar, id:123'`). Values are interpreted
   as group names by default; `id:NUM` forces ID lookup.
-  **API Translation (Group-Setting Values)**: The Zulip API `can_access_group`
+  **API Translation (Group-Setting Values)**: The Zulip API `can_subscribe_group`
   and `can_remove_subscribers_group` fields use a "group-setting value" format:
   - **Simple form**: A single integer user group ID (used when only one group is
     specified).
@@ -982,7 +983,7 @@ and verifying it reappears in the active channel list.
   API allows it), topic policy (`--topic-policy` with values `allow`,
   `deny`, or `follow-default`; also available as a standalone command per
   FR-021), `--allow-group` (who is allowed to join —
-  maps to Zulip API `can_access_group`), and `--can-remove-subscribers-group`
+  maps to Zulip API `can_subscribe_group`), and `--can-remove-subscribers-group`
   (who can remove subscribers — maps to Zulip API
   `can_remove_subscribers_group`). These are the only fields supported for v1;
   no other settings are in scope. When `--subscribe` is used in the update
@@ -997,8 +998,9 @@ and verifying it reappears in the active channel list.
   does NOT satisfy this requirement. At least one non-`Nobody` allowed group OR
   at least one `--subscribe` target is required.
   `--allow-group` MUST be accepted during type conversion to private in the same
-  command, enabling atomic setting of group-based access control via a single
-  Zulip API PATCH request (`is_private=true` + `can_access_group`). For updates
+  command, enabling atomic setting of group-based self-subscribe permission via
+  a single Zulip API PATCH request (`is_private=true` + `can_subscribe_group`).
+  For updates
   to public/web-public channels (or updates that do not change type),
   `--allow-group` is accepted with the same semantics (defines who is allowed to
   join) but the server does NOT enforce the restriction on non-private channels.
@@ -1138,7 +1140,7 @@ and verifying it reappears in the active channel list.
   channel), the flag is a no-op and the command proceeds normally (the unarchive
   command succeeds silently per its idempotency rule).
 - **FR-019**: Commands that rely on Zulip features not universally available
-  (e.g., unarchive, group-based access control, topic policy, web-public
+  (e.g., unarchive, group-based self-subscribe permission, topic policy, web-public
   channels, `can_remove_subscribers_group`) MUST detect server capabilities at
   runtime via the Zulip API feature level. If a required feature is unsupported,
   the command MUST return a clear error message in the format "This operation

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -106,7 +106,7 @@ def test_feature_level_table_contains_expected_keys() -> None:
     """The hardcoded threshold table covers every feature the spec mentions."""
     for key in (
         "web-public",
-        "can-access-group",
+        "can-subscribe-group",
         "can-remove-subscribers-group",
         "topic-policy",
         "unarchive",
@@ -1270,11 +1270,11 @@ def test_create_channel_can_remove_subscribers_group_checks_feature_level() -> N
     assert exc.value.required == FEATURE_LEVELS["can-remove-subscribers-group"]
 
 
-def test_create_channel_can_access_group_checks_feature_level() -> None:
-    """can-access-group requires sufficient feature level."""
+def test_create_channel_can_subscribe_group_checks_feature_level() -> None:
+    """can-subscribe-group requires sufficient feature level."""
     from lftools_uv.api.endpoints.zulip import create_channel
 
-    # Feature level below threshold (197)
+    # Feature level below threshold (357)
     client = _create_channel_client(feature_level=100)
     with pytest.raises(ZulipFeatureLevelError) as exc:
         create_channel(
@@ -1282,7 +1282,7 @@ def test_create_channel_can_access_group_checks_feature_level() -> None:
             name="with-access-group",
             allow_group_value=10,
         )
-    assert exc.value.required == FEATURE_LEVELS["can-access-group"]
+    assert exc.value.required == FEATURE_LEVELS["can-subscribe-group"]
 
 
 def test_create_channel_invalid_topic_policy_rejected() -> None:
@@ -1342,7 +1342,7 @@ def test_create_channel_passes_group_setting_value_simple() -> None:
     )
     calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
     request = calls[0].kwargs.get("request", {})
-    assert request.get("can_access_group") == 42
+    assert request.get("can_subscribe_group") == 42
 
 
 def test_create_channel_passes_group_setting_value_complex() -> None:
@@ -1358,7 +1358,7 @@ def test_create_channel_passes_group_setting_value_complex() -> None:
     )
     calls = [c for c in client.call_endpoint.call_args_list if c.kwargs.get("url") == "users/me/subscriptions"]
     request = calls[0].kwargs.get("request", {})
-    assert request.get("can_access_group") == complex_value
+    assert request.get("can_subscribe_group") == complex_value
 
 
 def test_create_channel_passes_can_remove_subscribers_group() -> None:
@@ -2379,7 +2379,7 @@ def test_update_channel_type_to_private_with_allow_group_satisfies_lockout() -> 
     payload = client.last_patch["request"]
     assert payload["is_private"] is True
     # group-setting-update wrapper for PATCH endpoints.
-    assert payload["can_access_group"] == {"new": 30}
+    assert payload["can_subscribe_group"] == {"new": 30}
 
 
 def test_update_channel_type_to_private_rejects_nobody_group() -> None:
@@ -2399,7 +2399,7 @@ def test_update_channel_type_to_private_allows_nobody_with_existing_subscribers(
 
     Per spec: lockout prevention only rejects converting an EMPTY
     channel to private without retainable access. An already-populated
-    channel may freely set ``can_access_group`` to Nobody — it simply
+    channel may freely set ``can_subscribe_group`` to Nobody — it simply
     disables future joins.
     """
     client = _update_client(subscribers=[100, 101])
@@ -2412,7 +2412,7 @@ def test_update_channel_type_to_private_allows_nobody_with_existing_subscribers(
     payload = client.last_patch["request"]
     assert payload["is_private"] is True
     # The Nobody system group resolves to id 21 in the test fixture.
-    assert payload["can_access_group"] == {"new": 21}
+    assert payload["can_subscribe_group"] == {"new": 21}
 
 
 def test_update_channel_allow_group_uses_new_wrapper_format() -> None:
@@ -2420,7 +2420,7 @@ def test_update_channel_allow_group_uses_new_wrapper_format() -> None:
     client = _update_client()
     _ = update_channel(client, name="general", allow_group="design")
     payload = client.last_patch["request"]
-    assert payload["can_access_group"] == {"new": 30}
+    assert payload["can_subscribe_group"] == {"new": 30}
 
 
 def test_update_channel_allow_group_multiple_uses_complex_form() -> None:
@@ -2428,7 +2428,7 @@ def test_update_channel_allow_group_multiple_uses_complex_form() -> None:
     client = _update_client()
     _ = update_channel(client, name="general", allow_group="design, id:10")
     payload = client.last_patch["request"]
-    assert payload["can_access_group"] == {"new": {"direct_members": [], "direct_subgroups": [30, 10]}}
+    assert payload["can_subscribe_group"] == {"new": {"direct_members": [], "direct_subgroups": [30, 10]}}
 
 
 def test_update_channel_can_remove_subscribers_group_wrapper() -> None:
@@ -2478,7 +2478,7 @@ def test_update_channel_multiple_settings() -> None:
     payload = client.last_patch["request"]
     assert payload["new_name"] == "renamed"
     assert payload["description"] == "d"
-    assert payload["can_access_group"] == {"new": 30}
+    assert payload["can_subscribe_group"] == {"new": 30}
 
 
 def test_update_channel_returns_channel_id_and_name() -> None:

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -239,6 +239,23 @@ def test_resolve_groups_id_prefix() -> None:
     assert value == 11
 
 
+def test_resolve_groups_numeric_name_not_found_hints_id_prefix() -> None:
+    """Numeric bare tokens hint at ``id:NUM`` when no name matches."""
+    client = _groups_client(GROUPS)
+    with pytest.raises(ZulipNotFoundError) as exc:
+        _ = resolve_groups(client, "123")
+    assert "No user group named '123'" in str(exc.value)
+    assert "use 'id:123'" in str(exc.value)
+
+
+def test_resolve_groups_name_not_found_keeps_original_message() -> None:
+    """Non-numeric missing group names keep the original error format."""
+    client = _groups_client(GROUPS)
+    with pytest.raises(ZulipNotFoundError) as exc:
+        _ = resolve_groups(client, "missing")
+    assert str(exc.value) == "No user group named 'missing'"
+
+
 def test_resolve_groups_system_role_display_name() -> None:
     """System role display names map to their internal ``role:`` API name."""
     client = _groups_client(GROUPS)


### PR DESCRIPTION
## Summary

Fix a silent data bug in Zulip channel create/update where `--allow-group` populated the non-existent Zulip API field `can_access_group`. Zulip silently ignores unknown fields, so the intended "who can subscribe to this channel" permission was not applied.

## Details

- Send `--allow-group` values as `can_subscribe_group` for both `channel create` and `channel update`.
- Gate that permission on Zulip feature level 357 instead of the unrelated 197 threshold.
- Update API tests and spec docs to reference `can_subscribe_group`.
- Polish UX by documenting `id:NUM` in create help text and hinting at `id:` when a bare numeric group token is not found by name.

## Validation

- `uv run pytest tests/ -x -q`
- `uv run ruff check .`
- `SKIP=basedpyright pre-commit run --all-files`
