### PR TITLE
Feat(zulip): Add channel ID column to channel list

### DIFF
--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -263,7 +263,11 @@ def channel_list(
         hidden=True,
     ),
 ) -> None:
-    """List channels visible to the authenticated user (US1)."""
+    """List channels visible to the authenticated user (US1).
+
+    The Channel ID column is the value to pass to ``--channel-id`` on
+    other channel commands.
+    """
     options = {**(ctx.obj or {})}
     if json_output:
         options["json_output"] = True

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -277,12 +277,13 @@ def channel_list(
         emit_json({"channels": channels})
         return
 
-    headers = ["Name", "Description", "Type", "Subscribers"]
+    headers = ["Channel ID", "Name", "Description", "Type", "Subscribers"]
     if include_archived:
         headers.append("Status")
     rows: list[list[Any]] = []
     for c in channels:
         row: list[Any] = [
+            c.get("stream_id", ""),
             c.get("name", ""),
             c.get("description", ""),
             c.get("type", ""),

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -18,6 +18,7 @@ alongside the user-story slices that introduce them.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, cast
 from unittest import mock
 
@@ -195,8 +196,8 @@ def test_channel_list_table_output(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Subscribers" in result.stdout
     assert "general" in result.stdout
     assert "secret" in result.stdout
-    assert "1  general" in result.stdout
-    assert "2  secret" in result.stdout
+    assert re.search(r"^\s*1\s+general\s+", result.stdout, re.MULTILINE)
+    assert re.search(r"^\s*2\s+secret\s+", result.stdout, re.MULTILINE)
     # Status column is hidden unless --include-archived
     assert "Status" not in result.stdout
 

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -188,12 +188,15 @@ def test_channel_list_table_output(monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
     result = runner.invoke(zulip_app, ["channel", "list"])
     assert result.exit_code == 0, result.stdout
+    assert "Channel ID" in result.stdout
     assert "Name" in result.stdout
     assert "Description" in result.stdout
     assert "Type" in result.stdout
     assert "Subscribers" in result.stdout
     assert "general" in result.stdout
     assert "secret" in result.stdout
+    assert "1  general" in result.stdout
+    assert "2  secret" in result.stdout
     # Status column is hidden unless --include-archived
     assert "Status" not in result.stdout
 
@@ -289,6 +292,7 @@ def test_channel_list_empty_table(monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
     result = runner.invoke(zulip_app, ["channel", "list"])
     assert result.exit_code == 0, result.stdout
+    assert "Channel ID" in result.stdout
     assert "Name" in result.stdout
     assert "general" not in result.stdout
 


### PR DESCRIPTION
**Originally stacked on #434.** #434 has merged, so this PR now targets `main`.

## Summary
- Add a `Channel ID` column to `zulip channel list` table output so users can look up the IDs needed by `channel update`, `archive`, `unarchive`, `subscribe`, `unsubscribe`, `list-subscribers`, and `topic-policy`.
- Note in the `channel list` help text that the Channel ID value is passed to `--channel-id` on other channel commands.

## Audit results
- `zulip channel list`: was missing Channel ID; now shows normalized `stream_id`.
- `zulip user list`: already shows User ID.
- `zulip group list`: already shows Group ID.
- `zulip channel subscribers`: already shows User ID.

## Validation
- `uv run pytest tests/ -x -q`
- `uv run ruff check .`
- `SKIP=basedpyright pre-commit run --all-files`