### PR TITLE
Docs(spec): Add Zulip channel folders specification

### DIFF
--- a/specs/002-zulip-channel-folders/contracts/cli-commands.md
+++ b/specs/002-zulip-channel-folders/contracts/cli-commands.md
@@ -1,0 +1,263 @@
+<!--
+SPDX-License-Identifier: EPL-1.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+
+# CLI Command Contracts: Zulip Channel Folders
+
+This document defines the public CLI interface contracts for Zulip channel
+folder commands and the updated channel create/update folder flags.
+
+## Optional Dependency
+
+The `zulip` command group requires the `zulip` optional extra. Install with
+`pip install "lftools-uv[zulip]"` or `uv pip install "lftools-uv[zulip]"`.
+When the extra is not installed, the command group still appears in CLI help
+but running any subcommand produces a user-friendly error:
+
+```text
+Zulip support requires the zulip extra. Install with:
+  pip install "lftools-uv[zulip]"
+```
+
+## Global Options (all zulip commands)
+
+Subcommand option tables omit these globals; every subcommand accepts them.
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `--zuliprc` | PATH | No | Path to zuliprc configuration file |
+| `--json` | flag | No | Output in JSON format |
+
+---
+
+## `lftools-uv zulip folder list`
+
+**Description**: List channel folders visible to the authenticated user.
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `--include-archived` | flag | No | Include archived folders in output |
+| `--limit` | int | No | Limit number of folders displayed |
+
+**Human Output**: Table with columns: Folder ID, Name, Order, Description.
+Status appears only when `--include-archived` is specified and displays Active
+or Archived.
+
+**JSON Output**:
+
+```json
+{
+  "folders": [
+    {
+      "id": 10,
+      "name": "Projects",
+      "order": 1,
+      "description": "Project channels",
+      "rendered_description": "<p>Project channels</p>",
+      "is_archived": false,
+      "date_created": 1761955200,
+      "creator_id": 42
+    }
+  ]
+}
+```
+
+On servers below FL 414, `order` is `null` if Zulip omits the field.
+
+**Exit Codes**: 0 = success, 1 = error (config/connection/feature-level)
+
+---
+
+## `lftools-uv zulip folder create`
+
+**Description**: Create a new channel folder. Admin-only on the Zulip server.
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `--name` | str | Yes | Folder name, non-empty |
+| `--description` | str | No | Folder description; defaults to empty |
+
+**Constraints**:
+
+- Requires Zulip feature level 389.
+- `--name` must be non-empty.
+- `description` is always sent to Zulip; omitted CLI value becomes `""`.
+- Known `/register` length limits are enforced client-side.
+- Permission errors are surfaced from Zulip.
+
+**JSON Output** (success):
+
+```json
+{
+  "status": "success",
+  "folder_id": 10,
+  "folder_name": "Projects",
+  "operation": "create"
+}
+```
+
+**Human Output**: Prints the created folder ID.
+
+**Exit Codes**: 0 = success, 1 = error
+
+---
+
+## `lftools-uv zulip folder update`
+
+**Description**: Update a channel folder name and/or description. Admin-only on
+the Zulip server.
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `--folder-id` | int | Yes | Target folder ID |
+| `--name` | str | No | New folder name |
+| `--description` | str | No | New folder description |
+
+**Constraints**:
+
+- Requires Zulip feature level 389.
+- At least one of `--name` or `--description` is required.
+- Known `/register` length limits are enforced client-side.
+- Permission errors are surfaced from Zulip.
+
+**JSON Output** (success):
+
+```json
+{
+  "status": "success",
+  "folder_id": 10,
+  "folder_name": "Engineering",
+  "operation": "update"
+}
+```
+
+**Exit Codes**: 0 = success (including no-op), 1 = error
+
+---
+
+## `lftools-uv zulip folder archive`
+
+**Description**: Archive a channel folder. Admin-only on the Zulip server.
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `--folder-id` | int | Yes | Target folder ID |
+
+**Constraints**:
+
+- Requires Zulip feature level 389.
+- Calls `PATCH /api/v1/channel_folders/{id}` with `is_archived=true`.
+- There is no hard-delete command.
+
+**JSON Output** (success):
+
+```json
+{
+  "status": "success",
+  "folder_id": 10,
+  "folder_name": "Old Projects",
+  "operation": "archive"
+}
+```
+
+**Exit Codes**: 0 = success (including no-op), 1 = error
+
+---
+
+## `lftools-uv zulip folder unarchive`
+
+**Description**: Reactivate an archived channel folder. Admin-only on the Zulip
+server.
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `--folder-id` | int | Yes | Target folder ID |
+
+**Constraints**:
+
+- Requires Zulip feature level 389.
+- Calls `PATCH /api/v1/channel_folders/{id}` with `is_archived=false`.
+
+**JSON Output** (success):
+
+```json
+{
+  "status": "success",
+  "folder_id": 10,
+  "folder_name": "Projects",
+  "operation": "unarchive"
+}
+```
+
+**Exit Codes**: 0 = success (including no-op), 1 = error
+
+---
+
+## Updated `lftools-uv zulip channel create <name>`
+
+**Description**: Create a new channel, optionally assigned to a folder.
+
+| Argument/Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | positional | Yes | Channel name |
+| `--folder` | str | No | Folder name, `id:N`, or `none` |
+
+All existing channel create options from the channel management contract remain
+valid.
+
+**`--folder` syntax**:
+
+- `--folder Projects` resolves a folder by case-insensitive name.
+- `--folder id:10` resolves folder ID 10 explicitly.
+- `--folder none` sends `folder_id: null`.
+
+A numeric-looking token without `id:` is treated as a folder name. If it is not
+found, the CLI errors with a hint to use `--folder id:N` for numeric IDs.
+
+**JSON Output** (success addition): Existing `channel create` JSON remains the
+same and may include `folder_id` when a folder was requested.
+
+**Exit Codes**: 0 = success, 1 = error
+
+---
+
+## Updated `lftools-uv zulip channel update [channel]`
+
+**Description**: Update channel settings, including folder assignment.
+
+| Argument/Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `channel` | positional | No | Channel name (optional if --channel-id) |
+| `--folder` | str | No | Folder name, `id:N`, or `none` |
+| `--folder-id` | int | No | Clear-only compatibility form; only `0` |
+
+All existing channel update options from the channel management contract remain
+valid.
+
+**Constraints**:
+
+- Requires Zulip feature level 389 when `--folder` or `--folder-id 0` is used.
+- `--folder none` and `--folder-id 0` both send `folder_id: null`.
+- Non-zero folder IDs use `--folder id:N`; non-zero `--folder-id` values are
+  rejected with a message directing the user to `--folder id:N`.
+- Permission errors are surfaced from Zulip.
+
+**JSON Output** (success addition): Existing `channel update` JSON remains the
+same and may include `folder_id` when a folder change was requested.
+
+**Exit Codes**: 0 = success (including no-op), 1 = error
+
+---
+
+## Feature-Level Error Contract
+
+Folder commands and folder assignment fail before mutation on unsupported
+servers:
+
+```text
+Error: This operation requires Zulip feature level 389 (server has 388)
+```
+
+Folder list keeps a stable `Order` column even when `order` is absent before FL
+414. Missing order values are rendered blank in tables and `null` in JSON.

--- a/specs/002-zulip-channel-folders/data-model.md
+++ b/specs/002-zulip-channel-folders/data-model.md
@@ -1,0 +1,95 @@
+<!--
+SPDX-License-Identifier: EPL-1.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+<!-- markdownlint-disable MD013 -- table rows mirror existing spec style -->
+
+# Data Model: Zulip Channel Folders
+
+## Entities
+
+### ChannelFolder
+
+Represents a Zulip channel folder returned by the channel folders API.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `int` | Server-assigned channel folder ID |
+| `name` | `str` | Non-empty folder name |
+| `description` | `str` | Plain-text description; may be empty |
+| `order` | `int \| None` | Server-assigned order; present at FL 414+ |
+| `is_archived` | `bool` | Folder is archived when true |
+| `date_created` | `int \| None` | UNIX timestamp in UTC seconds |
+| `creator_id` | `int \| None` | User ID that created the folder |
+| `rendered_description` | `str` | HTML rendering; pass-through from Zulip |
+
+**Validation Rules**:
+
+- `name` MUST NOT be empty.
+- `name` length MUST be less than or equal to
+  `max_channel_folder_name_length` when that `/register` value is available.
+- `description` may be empty but MUST be supplied to the create API.
+- `description` length MUST be less than or equal to
+  `max_channel_folder_description_length` when that `/register` value is
+  available.
+- `order` may be `None` when connected to servers at FL 389 through FL 413.
+- Folder mutation commands require Zulip feature level 389 and admin
+  permissions enforced by the server.
+
+**State Transitions**:
+
+```text
+┌──────────┐   archive    ┌──────────┐
+│  Active  │─────────────▶│ Archived │
+│          │◀─────────────│          │
+└──────────┘  unarchive   └──────────┘
+      (PATCH is_archived=true/false)
+```
+
+There is no hard-delete transition. Zulip only exposes archival.
+
+---
+
+### Channel (Stream) Extension
+
+Feature 001 defines the `Channel` entity. This feature extends it with the
+folder relationship.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `folder_id` | `int \| None` | References `ChannelFolder.id`; None means no folder |
+
+**Validation Rules**:
+
+- `folder_id` is assigned on channel create/update through existing Zulip
+  stream endpoints.
+- A non-null `folder_id` MUST reference an existing folder visible through
+  `GET /api/v1/channel_folders` or be provided explicitly with `id:N`.
+- `folder_id: null` clears the relationship.
+- Channel assignment requires Zulip feature level 389; server permissions are
+  enforced by Zulip and surfaced by the CLI.
+
+---
+
+### FolderMutationResult
+
+Standard response schema for folder mutation operations.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status` | `str (enum)` | Outcome: success or error |
+| `folder_id` | `int \| None` | Folder ID, if known |
+| `folder_name` | `str \| None` | Folder name, if known |
+| `operation` | `str` | create/update/archive/unarchive |
+
+## Relationships
+
+```text
+ChannelFolder 1──────* Channel (via folder_id)
+ZulipConfig 1──────── Client Session
+```
+
+- A ChannelFolder may contain zero or more channels.
+- A Channel may reference zero or one ChannelFolder.
+- Folder list and folder assignment use the same authenticated Zulip client
+  session as existing channel management commands.

--- a/specs/002-zulip-channel-folders/plan.md
+++ b/specs/002-zulip-channel-folders/plan.md
@@ -1,0 +1,154 @@
+<!--
+SPDX-License-Identifier: EPL-1.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+
+# Implementation Plan: Zulip Channel Folders
+
+**Branch**: `002-zulip-channel-folders` | **Date**: 2026-06-04 |
+**Spec**: `specs/002-zulip-channel-folders/spec.md`
+**Input**: Feature specification from `/specs/002-zulip-channel-folders/spec.md`
+
+## Summary
+
+Add Zulip channel folder management commands to lftools-uv, providing CLI
+commands for listing, creating, updating, archiving, and unarchiving channel
+folders, plus folder assignment on existing channel create/update workflows.
+The implementation extends the existing Zulip API layer
+(`lftools_uv/api/endpoints/zulip.py`) and Typer presentation layer
+(`lftools_uv/typer_apps/zulip.py`). Runtime feature-level detection gates all
+folder behavior at Zulip feature level 389, while folder ordering is treated as
+optional until feature level 414. The CLI uses one `--folder` assignment flag
+accepting names, `id:N`, or `none`; `--folder-id 0` is accepted only for the
+explicit clear behavior locked by the spec.
+
+## Technical Context
+
+**Language/Version**: Python >=3.11, <3.15
+**Primary Dependencies**: `zulip` (official client), `typer` (CLI), `tabulate`
+(output formatting)
+**Storage**: N/A (stateless CLI — all data from Zulip API)
+**Testing**: pytest with `responses` for HTTP mocking, `typer.testing.CliRunner`
+for CLI tests
+**Target Platform**: Linux (POSIX)
+**Project Type**: CLI tool (extending existing multi-command CLI)
+**Performance Goals**: List operations <5s for 100 folders (SC-009)
+**Constraints**: Feature-level gate at FL 389; folder `order` optional before
+FL 414; no hard-delete endpoint
+**Scale/Scope**: Single Zulip server per invocation; channel folder lifecycle
+and channel assignment only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle            | Status | Notes                         |
+| -------------------- | ------ | ----------------------------- |
+| I: Quality & Testing | PASS   | pytest; type hints; ruff      |
+| II: Atomic Commits   | PASS   | Tasks are commit-sized        |
+| III: Licensing       | PASS   | EPL-1.0 per REUSE.toml        |
+| IV: Pre-Commit       | PASS   | Hooks pass before commit      |
+| V: Co-Author & DCO   | PASS   | Co-authored-by + `-s`         |
+| VI: CLI Consistency  | PASS   | Typer; existing Zulip patterns|
+| VII: Security & Deps | PASS   | No new dependency or secrets  |
+
+**Post-Design Re-Check**: ✅ All principles satisfied. No violations requiring
+justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-zulip-channel-folders/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── cli-commands.md  # CLI interface contract
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+lftools_uv/
+├── api/
+│   └── endpoints/
+│       └── zulip.py           # Folder API helpers and resolution
+├── typer_apps/
+│   └── zulip.py               # `zulip folder` commands and flags
+
+tests/
+└── unit/
+    ├── test_zulip_api.py      # Existing API layer tests
+    ├── test_zulip_cli.py      # Existing CLI layer tests
+    └── test_zulip_folders.py  # Folder-specific unit/CLI tests
+```
+
+**Structure Decision**: Reuse the existing Zulip modules from feature 001. No
+new top-level directories are needed. Folder-specific tests may live in a new
+`tests/unit/test_zulip_folders.py` file to keep the larger Zulip test files
+manageable.
+
+## Complexity Tracking
+
+> No constitution violations. No complexity justifications needed.
+
+## Phase 0: Research
+
+Research confirms Zulip channel folders are exposed by the
+`/api/v1/channel_folders` resource family, new in Zulip 11.0 at feature level
+389. Folder order is available starting at feature level 414. There is no
+hard-delete endpoint; archive and unarchive use the update endpoint. Channel
+assignment uses existing stream create/update endpoints with `folder_id`.
+
+See `research.md` for details and API references.
+
+## Phase 1: Design & Contracts
+
+Design artifacts:
+
+- `data-model.md`: Defines `ChannelFolder` and the `Channel.folder_id`
+  relationship.
+- `contracts/cli-commands.md`: Defines `zulip folder` commands and updated
+  channel create/update flags.
+- `quickstart.md`: Documents common folder workflows.
+
+## Phase 2: Implementation Planning
+
+Tasks map FRs to implementation phases:
+
+| Phase | Focus | Requirements |
+| ----- | ----- | ------------ |
+| F1 | API helpers | FR-024 through FR-027 |
+| F2 | Feature gates and validation | FR-030, FR-031, FR-033, FR-034 |
+| F3 | `zulip folder` Typer commands | FR-023 through FR-027 |
+| F4 | Folder resolution helper | FR-032 |
+| F5 | Channel `--folder` integration | FR-028, FR-029 |
+| F6 | Tests | FR-023 through FR-036 |
+| F7 | Spec sync and help text | FR-037 |
+
+## Testing Approach
+
+- Add mock-based API tests for list/create/update/archive/unarchive helpers in
+  `tests/unit/test_zulip_folders.py` or `tests/unit/test_zulip_api.py`.
+- Add CLI tests with `typer.testing.CliRunner` for folder list table/JSON
+  output, mutation output, feature-level errors, validation failures, and
+  permission error propagation.
+- Add channel create/update tests covering `--folder` by name, `id:N`, numeric
+  not-found hint, `none`, and `--folder-id 0` clearing.
+- Add feature-level tests for FL 388 rejection, FL 389 success without order,
+  and FL 414 order display.
+- Run `uv run pytest tests/`, `uv run ruff check .`, `uv run mypy lftools_uv`,
+  and `uv run basedpyright` before implementation PRs. For this spec-only PR,
+  run pre-commit with the repository's accepted `SKIP=basedpyright` setting.
+
+## Out of Scope
+
+- Implementation code in this PR.
+- Per-user folder ordering changes; no API exists as of FL 389.
+- Bulk folder reorder.
+- Hard-delete of channel folders; Zulip exposes archive only.
+- Client-side role pre-flight checks for admin-only folder mutations.

--- a/specs/002-zulip-channel-folders/quickstart.md
+++ b/specs/002-zulip-channel-folders/quickstart.md
@@ -1,0 +1,133 @@
+<!--
+SPDX-License-Identifier: EPL-1.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+
+# Quickstart: Zulip Channel Folders
+
+## Prerequisites
+
+- Python >=3.11, <3.15
+- `lftools-uv` installed with the `zulip` extra:
+
+  ```bash
+  pip install "lftools-uv[zulip]"
+  # or
+  uv pip install "lftools-uv[zulip]"
+  ```
+
+- A Zulip server at feature level 389 or newer for channel folders
+- Organization admin permissions for folder create/update/archive/unarchive
+- A zuliprc file or equivalent configuration
+
+## Configuration
+
+Use the same Zulip configuration as channel management:
+
+```ini
+[api]
+email=your-bot@your-org.zulipchat.com
+key=your-api-key-here
+site=https://your-org.zulipchat.com
+```
+
+Or specify a path explicitly:
+
+```bash
+lftools-uv zulip --zuliprc /path/to/zuliprc folder list
+```
+
+**Precedence**: `--zuliprc` > `./zuliprc` > lftools.ini `[zulip]` > `~/.zuliprc`
+
+## Common Workflows
+
+### Discover folders
+
+```bash
+# List active folders
+lftools-uv zulip folder list
+
+# Include archived folders and show Status
+lftools-uv zulip folder list --include-archived
+
+# JSON output for scripts
+lftools-uv zulip folder list --json
+```
+
+### Create and update folders
+
+```bash
+# Create a folder
+lftools-uv zulip folder create \
+  --name "Projects" \
+  --description "Project discussion channels"
+
+# Rename or redescribe a folder
+lftools-uv zulip folder update \
+  --folder-id 10 \
+  --name "Engineering Projects"
+```
+
+### Archive and unarchive folders
+
+```bash
+# Archive a folder; Zulip has no hard-delete endpoint
+lftools-uv zulip folder archive --folder-id 10
+
+# Restore an archived folder
+lftools-uv zulip folder unarchive --folder-id 10
+```
+
+### Create a channel in a folder
+
+```bash
+# Resolve by folder name
+lftools-uv zulip channel create "project-alpha" \
+  --description "Project Alpha" \
+  --type public \
+  --folder "Projects"
+
+# Resolve by folder ID
+lftools-uv zulip channel create "project-beta" \
+  --description "Project Beta" \
+  --type public \
+  --folder id:10
+```
+
+### Change or clear a channel folder
+
+```bash
+# Move channel to another folder
+lftools-uv zulip channel update project-alpha --folder "Engineering"
+
+# Clear folder assignment explicitly
+lftools-uv zulip channel update project-alpha --folder none
+
+# Compatibility clear form
+lftools-uv zulip channel update project-alpha --folder-id 0
+```
+
+## Error Handling
+
+All errors go to stderr with non-zero exit codes. Feature-level errors use the
+existing Zulip command pattern:
+
+```text
+Error: This operation requires Zulip feature level 389 (server has 388)
+```
+
+Folder mutation permission errors are returned by Zulip and displayed by the
+CLI. The CLI does not pre-flight admin role checks.
+
+## Development
+
+> **Note**: The paths below are planned locations; implementation happens in a
+> later PR.
+
+```bash
+# Run folder-focused tests once implementation exists
+uv run pytest tests/unit/test_zulip_folders.py
+
+# Run broader Zulip unit tests
+uv run pytest tests/unit/test_zulip_api.py tests/unit/test_zulip_cli.py
+```

--- a/specs/002-zulip-channel-folders/research.md
+++ b/specs/002-zulip-channel-folders/research.md
@@ -1,0 +1,133 @@
+<!--
+SPDX-License-Identifier: EPL-1.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+
+# Research: Zulip Channel Folders
+
+## Decision 1: Zulip Channel Folder API Family
+
+**Decision**: Use the Zulip channel folders resource family introduced in
+Zulip 11.0 at feature level 389.
+
+| Operation | Endpoint | Notes |
+| --- | --- | --- |
+| List folders | `GET /api/v1/channel_folders` | Optional `include_archived` |
+| Create folder | `POST /api/v1/channel_folders/create` | Admin-only |
+| Update folder | `PATCH /api/v1/channel_folders/{id}` | Admin-only |
+
+API references:
+
+- <https://zulip.com/api/get-channel-folders>
+- <https://zulip.com/api/create-channel-folder>
+- <https://zulip.com/api/update-channel-folder>
+
+**Rationale**: These endpoints are the canonical API surface for channel
+folders. The CLI should not emulate folders client-side.
+
+**Alternatives Considered**:
+
+- Store folder metadata locally: Rejected — would diverge from Zulip server
+  state and fail for other clients.
+- Use undocumented endpoints: Rejected — the documented API supports the
+  required lifecycle operations.
+
+## Decision 2: Feature-Level Gates
+
+**Decision**: Add hardcoded feature-level constants:
+
+| Feature | Required Feature Level |
+| --- | --- |
+| `channel-folders` | 389 |
+| `channel-folders-order` | 414 |
+
+All folder commands and `--folder` assignment require FL 389. The folder
+`order` field is optional unless the server is at FL 414 or newer.
+
+**Rationale**: Feature-level checks match the existing FR-019 pattern from the
+channel management spec and provide clear errors on older servers.
+
+**Alternatives Considered**:
+
+- Minimum Zulip version string checks: Rejected — feature levels are the
+  existing runtime compatibility mechanism.
+- Try the API and report Zulip's error: Rejected — produces less actionable
+  errors and can attempt mutations on unsupported servers.
+
+## Decision 3: Archive Instead of Delete
+
+**Decision**: Provide `folder archive` and `folder unarchive`; do not provide a
+folder delete command.
+
+**Rationale**: Zulip does not expose a hard-delete endpoint for channel folders.
+The update endpoint changes `is_archived` to hide or restore folders.
+
+**Alternatives Considered**:
+
+- `folder delete` alias for archive: Rejected — misleading because the folder
+  remains recoverable.
+- `--archive` flag on update: Rejected — inconsistent with the existing channel
+  UX, which uses standalone archive/unarchive commands.
+
+## Decision 4: Channel Assignment Through `folder_id`
+
+**Decision**: Use existing channel create/update API surfaces with a
+`folder_id` integer parameter. Passing an integer assigns a folder; passing
+`null` clears it.
+
+**Rationale**: Zulip documents `folder_id` on `PATCH /api/v1/streams/{stream_id}`
+and `POST /api/v1/users/me/subscriptions`, so channel folder assignment belongs
+in the existing channel workflows.
+
+**Alternatives Considered**:
+
+- Separate `folder add-channel` command: Rejected — duplicates channel update
+  semantics and creates another targeting model.
+
+## Decision 5: Single `--folder` Flag
+
+**Decision**: Add one `--folder` flag to channel create/update. It accepts a
+folder name by default, `id:N` for explicit numeric lookup, or `none` to clear.
+`--folder-id 0` is accepted for the locked explicit-clear UX and maps to
+`folder_id: null`; non-zero IDs should use `--folder id:N`.
+
+**Rationale**: This mirrors the inline `--allow-group` resolution UX after the
+recent group-resolution fix and avoids duplicating `--folder-name` and
+`--folder-id` flags for normal assignment.
+
+**Alternatives Considered**:
+
+- Split `--folder-id` and `--folder-name`: Rejected — duplicates concepts and
+  makes scripts more verbose.
+- Separate `--clear-folder` boolean: Rejected — the locked decision chose
+  explicit-none (`--folder none`) instead.
+
+## Decision 6: Length Limits From `/register`
+
+**Decision**: Validate folder name and description lengths against
+`max_channel_folder_name_length` and
+`max_channel_folder_description_length` when those `/register` values are
+available.
+
+**Rationale**: Zulip exposes server-specific limits. Client-side validation
+provides faster feedback while preserving server authority when limits are not
+available.
+
+**Alternatives Considered**:
+
+- Hardcode limits: Rejected — limits are server-provided and may change.
+- Rely only on server errors: Rejected — worse UX when limits are known.
+
+## Decision 7: Permission Handling
+
+**Decision**: Do not pre-flight role checks. Surface Zulip permission errors
+from folder mutations and channel assignment as-is.
+
+**Rationale**: Folder create/update/archive/unarchive are admin-only, while
+channel assignment permissions vary by server policy and channel type. Zulip is
+the source of truth.
+
+**Alternatives Considered**:
+
+- Fetch user role and reject locally: Rejected — duplicates server policy and
+  risks false negatives.

--- a/specs/002-zulip-channel-folders/spec.md
+++ b/specs/002-zulip-channel-folders/spec.md
@@ -1,0 +1,241 @@
+<!--
+SPDX-License-Identifier: EPL-1.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+
+# Feature Specification: Zulip Channel Folders
+
+**Feature Branch**: `002-zulip-channel-folders`
+**Created**: 2026-06-04
+**Status**: Draft
+**Input**: User description: "Add specification artifacts for Zulip channel
+folders, including folder lifecycle commands and channel folder assignment."
+
+## Clarifications
+
+### Session 2026-06-04
+
+- Q: What command group should expose folder lifecycle operations? → A:
+  Add `lftools-uv zulip folder ...` with `list`, `create`, `update`,
+  `archive`, and `unarchive` subcommands.
+- Q: Should folder deletion be supported? → A: No. Zulip exposes archive and
+  unarchive through `PATCH /api/v1/channel_folders/{id}`. There is no
+  hard-delete endpoint.
+- Q: How should channels reference folders? → A: `channel create` and
+  `channel update` gain a single `--folder` flag accepting a folder name,
+  `id:N`, or `none`. The value `none` clears the folder on update. The
+  `--folder-id 0` clear form is accepted on `channel update` for
+  compatibility with the locked CLI decision and maps to `folder_id: null`;
+  non-zero folder IDs use `--folder id:N`.
+- Q: How should folder names and IDs be resolved? → A: Names resolve through
+  `GET /api/v1/channel_folders`. The `id:N` prefix forces numeric ID lookup.
+  A numeric-looking token without `id:` is treated as a name; if no folder is
+  found, the error hints to use `id:N`.
+- Q: Which feature levels gate this work? → A: Channel folders require Zulip
+  feature level 389. The folder `order` field requires feature level 414. All
+  folder commands and use of `--folder` short-circuit below FL 389.
+- Q: Should the CLI pre-flight admin permissions? → A: No. Folder create,
+  update, archive, and unarchive are admin-only per Zulip. The CLI propagates
+  server-side permission errors. Folder list is available to all users.
+- Q: Should archive/unarchive be flags on update? → A: No. Use separate
+  `archive` and `unarchive` commands to match the existing channel UX.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discover channel folders (Priority: P1)
+
+A Zulip user can list channel folders visible on the server, optionally
+including archived folders, and can consume the result as either a table or
+JSON for automation.
+
+**Why this priority**: Discovery is the safe MVP and is required before users
+can assign channels to existing folders by name.
+
+**Independent Test**: Run `lftools-uv zulip folder list` against mocked folder
+API responses and verify active-only output, archived inclusion, table columns,
+`--limit`, and JSON shape.
+
+**Acceptance Scenarios**:
+
+1. **Given** a server at FL 389 or newer with active folders, **When** the user
+   runs `zulip folder list`, **Then** only active folders appear.
+2. **Given** active and archived folders, **When** the user runs
+   `zulip folder list --include-archived`, **Then** both active and archived
+   folders appear and table output includes a Status column.
+3. **Given** a server below FL 414, **When** folder list output is rendered,
+   **Then** the Order column is still present but shows an empty value or
+   `null` because the server does not provide order data.
+
+---
+
+### User Story 2 - Manage folder lifecycle (Priority: P1)
+
+A Zulip organization administrator can create, rename, describe, archive, and
+unarchive channel folders without using the Zulip web UI.
+
+**Why this priority**: Folder lifecycle management is the core administrative
+capability for organizing channels.
+
+**Independent Test**: Mock create/update/archive/unarchive API calls and verify
+payloads, success output, validation, feature-level gating, and permission error
+propagation.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin on a FL 389 server, **When** the admin runs
+   `zulip folder create --name Projects --description "Project channels"`,
+   **Then** the CLI calls the create endpoint and prints the created folder ID.
+2. **Given** an existing folder, **When** the admin runs
+   `zulip folder update --folder-id 10 --name Engineering`, **Then** the CLI
+   patches only the requested field.
+3. **Given** an existing active folder, **When** the admin runs
+   `zulip folder archive --folder-id 10`, **Then** the CLI sets
+   `is_archived=true`.
+4. **Given** an archived folder, **When** the admin runs
+   `zulip folder unarchive --folder-id 10`, **Then** the CLI sets
+   `is_archived=false`.
+
+---
+
+### User Story 3 - Assign channels to folders (Priority: P2)
+
+An administrator or channel owner can assign a folder during channel creation
+or update and can clear a channel's folder assignment explicitly.
+
+**Why this priority**: The feature is only useful when channels can be placed
+into folders through existing channel workflows.
+
+**Independent Test**: Mock channel create/update calls with `--folder` values
+and verify name resolution, `id:N` resolution, `none`/`--folder-id 0` clearing,
+feature-level errors, and propagated API permission failures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a folder named Projects, **When** the user creates a channel with
+   `--folder Projects`, **Then** the create payload includes that folder ID.
+2. **Given** a folder ID 10, **When** the user updates a channel with
+   `--folder id:10`, **Then** the update payload includes `folder_id: 10`.
+3. **Given** a channel currently assigned to a folder, **When** the user updates
+   it with `--folder none` or `--folder-id 0`, **Then** the update payload
+   includes `folder_id: null`.
+
+### Edge Cases
+
+- Servers below FL 389 reject all folder commands and `--folder` usage before
+  making folder API calls.
+- Servers at FL 389 through FL 413 may omit the folder `order` field; output
+  remains stable with a blank table value or JSON `null`.
+- Folder create requires a non-empty name. Description is a required API field
+  but may be an empty string; the CLI defaults omitted descriptions to `""`.
+- `folder update` requires at least one of `--name` or `--description`.
+- A numeric-looking `--folder` token without `id:` is treated as a name; if not
+  found, the CLI suggests `--folder id:N` for numeric IDs.
+- Permission errors from admin-only folder mutations are displayed as returned
+  by Zulip and are not pre-flight checked by the CLI.
+- Folder length limits come from `/register` fields
+  `max_channel_folder_name_length` and
+  `max_channel_folder_description_length`; the CLI validates when those limits
+  are available and otherwise lets the server enforce them.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-023**: System MUST provide a `lftools-uv zulip folder list` command that
+  returns active channel folders visible to the authenticated user. It MUST
+  support `--include-archived`, `--json`, and `--limit`. Human-readable output
+  MUST use columns `Folder ID`, `Name`, `Order`, and `Description`; it MUST add
+  a `Status` column only when `--include-archived` is used. JSON output MUST be
+  `{"folders": [...]}` with folder entity fields.
+- **FR-024**: System MUST provide a `lftools-uv zulip folder create` command
+  with required `--name` and optional `--description` defaulting to `""`. The
+  command MUST call `POST /api/v1/channel_folders/create` and print the created
+  `channel_folder_id` in human output. JSON output MUST include
+  `status`, `folder_id`, `folder_name`, and `operation`.
+- **FR-025**: System MUST provide a `lftools-uv zulip folder update` command
+  with required `--folder-id` and optional `--name` and `--description`. At
+  least one mutable field MUST be provided. The command MUST call
+  `PATCH /api/v1/channel_folders/{id}` with only requested fields.
+- **FR-026**: System MUST provide a `lftools-uv zulip folder archive` command
+  with required `--folder-id`. It MUST call the folder PATCH endpoint with
+  `is_archived=true`. No hard-delete command is in scope.
+- **FR-027**: System MUST provide a `lftools-uv zulip folder unarchive` command
+  with required `--folder-id`. It MUST call the folder PATCH endpoint with
+  `is_archived=false`.
+- **FR-028**: `lftools-uv zulip channel create` MUST accept `--folder` to assign
+  the new channel to a channel folder. The flag MUST accept a folder name,
+  `id:N`, or `none`; `none` maps to `folder_id: null`.
+- **FR-029**: `lftools-uv zulip channel update` MUST accept `--folder` to assign
+  or change a channel folder. The command MUST also accept `--folder none` and
+  `--folder-id 0` to clear the channel folder by sending `folder_id: null`.
+- **FR-030**: Folder operations and `--folder` usage MUST require Zulip feature
+  level 389. Unsupported servers MUST fail before mutation with the canonical
+  feature-level error: `This operation requires Zulip feature level 389 (server
+  has Y)`.
+- **FR-031**: System MUST define `FEATURE_LEVELS["channel-folders"] = 389` and
+  `FEATURE_LEVELS["channel-folders-order"] = 414` in
+  `lftools_uv/api/endpoints/zulip.py` during implementation.
+- **FR-032**: Folder resolution MUST use `GET /api/v1/channel_folders` for
+  case-insensitive name lookup and `id:N` lookup. Numeric-looking names without
+  `id:` MUST be treated as names; if not found, errors MUST hint to pass
+  `id:N` for numeric folder IDs, matching the group resolution UX. The
+  `none` token and update-only `--folder-id 0` clear form MUST short-circuit
+  lookup and yield `folder_id: null`.
+- **FR-033**: The CLI MUST respect `max_channel_folder_name_length` and
+  `max_channel_folder_description_length` from `/register` when available.
+  Values exceeding known limits MUST fail client-side with a clear validation
+  error; otherwise the server response is authoritative.
+- **FR-034**: Folder list MUST tolerate missing `order` on servers below FL
+  414. The table still includes `Order`, and JSON uses `null` when the API
+  omits the field. The `channel-folders-order` constant documents this
+  threshold for output handling and future order-specific behavior; it does not
+  block folder list on FL 389 through FL 413.
+- **FR-035**: Folder create/update/archive/unarchive MUST surface Zulip
+  permission errors as-is. The CLI MUST NOT perform client-side role checks.
+- **FR-036**: Folder mutations MUST be idempotent for no-op archive state
+  changes when the server reports success or already-current state; JSON no-ops
+  MUST return `"status": "success"`. Folder update sends requested fields and
+  treats the server response as authoritative for same-value updates.
+- **FR-037**: Contracts and quickstart documentation MUST describe the new
+  folder commands, updated channel flags, feature-level gates, and API facts
+  from the Zulip channel folders documentation.
+
+### Key Entities
+
+- **ChannelFolder**: A Zulip channel folder with server-assigned ID, name,
+  description, optional order, archived status, creation metadata, and rendered
+  HTML description.
+- **Channel (Stream)**: Existing channel entity gains `folder_id: int | None`,
+  referencing `ChannelFolder.id` when assigned.
+- **Zulip Configuration**: Existing Zulip configuration resolution applies to
+  all folder commands.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-009**: Users can list 100 channel folders in under 5 seconds with table
+  or JSON output.
+- **SC-010**: Administrators can create, update, archive, and unarchive a
+  channel folder with one CLI invocation per operation.
+- **SC-011**: Users can assign or clear a channel folder during channel create
+  or update without using the Zulip web UI.
+- **SC-012**: Servers below FL 389 produce a clear feature-level error for all
+  folder commands and `--folder` usage.
+- **SC-013**: JSON output from folder commands is valid parseable JSON and uses
+  stable field names for scripting.
+
+## Assumptions
+
+- The existing Zulip optional dependency, configuration resolution, API layer,
+  and Typer command group from `001-zulip-channel-mgmt` are present.
+- Folder commands use Zulip REST API v1 endpoints documented at
+  <https://zulip.com/api/get-channel-folders>,
+  <https://zulip.com/api/create-channel-folder>, and
+  <https://zulip.com/api/update-channel-folder>.
+- Channel folder APIs are new in Zulip 11.0 at feature level 389. Folder order
+  data is available starting at feature level 414.
+- Folder list is available to all authenticated users. Folder mutations are
+  admin-only, and channel folder assignment permissions are enforced by Zulip.
+- Per-user folder ordering and bulk folder reorder are out of scope because no
+  API exists for those operations as of the cited channel folder API docs.

--- a/specs/002-zulip-channel-folders/tasks.md
+++ b/specs/002-zulip-channel-folders/tasks.md
@@ -1,0 +1,173 @@
+<!--
+SPDX-License-Identifier: EPL-1.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+<!-- markdownlint-disable MD013 -- task checklist lines are intentionally long -->
+
+# Tasks: Zulip Channel Folders
+
+**Input**: Design documents from `/specs/002-zulip-channel-folders/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/cli-commands.md
+
+**Tests**: Included — the plan specifies pytest with `responses` for HTTP mocking and `typer.testing.CliRunner` for CLI tests.
+
+**Organization**: Tasks are grouped by implementation phase so each phase can be
+completed in atomic commits while preserving feature traceability.
+
+## Format: `[ID] [P?] [Phase] Description`
+
+- **[P]**: Can run in parallel (different files or independent tests)
+- **[Phase]**: Which implementation phase this task belongs to (F1–F7)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **API layer**: `lftools_uv/api/endpoints/zulip.py`
+- **CLI layer**: `lftools_uv/typer_apps/zulip.py`
+- **Tests**: `tests/unit/test_zulip_api.py`, `tests/unit/test_zulip_cli.py`, `tests/unit/test_zulip_folders.py`
+
+---
+
+## Phase F1: API Helpers
+
+**Purpose**: Add reusable API functions for the channel folder endpoints.
+
+- [ ] T001 [F1] Add `ChannelFolder` parsing helpers in `lftools_uv/api/endpoints/zulip.py` for id, name, order, description, rendered_description, is_archived, date_created, and creator_id (FR-023, FR-034)
+- [ ] T002 [F1] Implement `list_channel_folders(client, include_archived=False, limit=None)` using `GET /api/v1/channel_folders` (FR-023)
+- [ ] T003 [F1] Implement `create_channel_folder(client, name, description="")` using `POST /api/v1/channel_folders/create` and returning `channel_folder_id` (FR-024)
+- [ ] T004 [F1] Implement `update_channel_folder(client, folder_id, *, name=None, description=None, is_archived=None)` using `PATCH /api/v1/channel_folders/{id}` (FR-025, FR-026, FR-027)
+- [ ] T005 [F1] Add thin `archive_channel_folder()` and `unarchive_channel_folder()` wrappers that call `update_channel_folder()` with `is_archived` true or false (FR-026, FR-027)
+
+**Checkpoint**: API layer can call all documented channel folder endpoints.
+
+---
+
+## Phase F2: Feature-Level Gating and Validation
+
+**Purpose**: Enforce server compatibility and server-provided folder limits.
+
+- [ ] T006 [F2] Add `FEATURE_LEVELS["channel-folders"] = 389` and `FEATURE_LEVELS["channel-folders-order"] = 414` in `lftools_uv/api/endpoints/zulip.py` (FR-031)
+- [ ] T007 [F2] Gate all folder API helpers and channel folder assignment paths with `check_feature_level(..., 389, "channel-folders")` (FR-030)
+- [ ] T008 [P] [F2] Add `/register` limit lookup helpers for `max_channel_folder_name_length` and `max_channel_folder_description_length` with per-client caching (FR-033)
+- [ ] T009 [F2] Validate folder create/update names and descriptions against known limits and produce clear validation errors before API calls (FR-024, FR-025, FR-033)
+- [ ] T010 [P] [F2] Ensure missing `order` on servers below FL 414 renders as `None` instead of raising parsing errors (FR-034)
+
+**Checkpoint**: Unsupported servers and invalid folder values fail safely.
+
+---
+
+## Phase F3: `zulip folder` Typer Subcommands
+
+**Purpose**: Expose folder lifecycle operations in the CLI.
+
+- [ ] T011 [F3] Create `folder` Typer sub-app in `lftools_uv/typer_apps/zulip.py` and register it under the existing `zulip` app (FR-023)
+- [ ] T012 [F3] Implement `folder list` with `--include-archived`, `--limit`, `--json`, stable table columns, and conditional Status column (FR-023, FR-034)
+- [ ] T013 [F3] Implement `folder create` with required `--name`, optional `--description`, human ID output, and JSON mutation output (FR-024)
+- [ ] T014 [F3] Implement `folder update` with required `--folder-id`, optional `--name`/`--description`, and at-least-one-field validation (FR-025)
+- [ ] T015 [F3] Implement `folder archive` and `folder unarchive` commands using required `--folder-id` and JSON mutation output (FR-026, FR-027, FR-036)
+- [ ] T016 [P] [F3] Add help text and error messages documenting admin-only mutations and server-side permission handling (FR-035, FR-037)
+
+**Checkpoint**: `lftools-uv zulip folder ...` commands work independently.
+
+---
+
+## Phase F4: Folder Resolution Helper
+
+**Purpose**: Resolve folder names and explicit IDs consistently for channel
+assignment.
+
+- [ ] T017 [F4] Implement `resolve_channel_folder_token(client, token)` in `lftools_uv/api/endpoints/zulip.py` accepting names, `id:N`, and `none` (FR-028, FR-029, FR-032)
+- [ ] T018 [F4] Add numeric-looking-name not-found errors that hint to use `id:N` for numeric folder IDs (FR-032)
+- [ ] T019 [P] [F4] Add ambiguity and archived-folder behavior tests for folder resolution if Zulip responses can include duplicate or archived names (FR-032)
+
+**Checkpoint**: Channel workflows can convert user folder input to `folder_id`.
+
+---
+
+## Phase F5: Channel Create/Update `--folder` Integration
+
+**Purpose**: Add folder assignment to existing channel workflows.
+
+- [ ] T020 [F5] Add `--folder` option to `channel create` in `lftools_uv/typer_apps/zulip.py` and pass resolved `folder_id` to the create API payload (FR-028)
+- [ ] T021 [F5] Add `--folder` option to `channel update` and pass resolved `folder_id` to the stream PATCH payload (FR-029)
+- [ ] T022 [F5] Add `channel update` clear handling for `--folder none` and `--folder-id 0`, both mapping to `folder_id: null`; reject non-zero `--folder-id` with guidance to use `--folder id:N` (FR-029)
+- [ ] T023 [F5] Ensure channel create/update with folder assignment short-circuits below FL 389 before mutation (FR-030)
+- [ ] T024 [F5] Preserve existing channel create/update behavior when no folder flag is supplied (FR-028, FR-029)
+
+**Checkpoint**: Existing channel workflows support folder assignment safely.
+
+---
+
+## Phase F6: Tests
+
+**Purpose**: Cover API helpers, CLI commands, feature gates, and channel
+integration.
+
+- [ ] T025 [P] [F6] Add API tests for folder list/create/update/archive/unarchive in `tests/unit/test_zulip_folders.py` or `tests/unit/test_zulip_api.py` (FR-023 through FR-027)
+- [ ] T026 [P] [F6] Add CLI tests for `folder list` table output, JSON output, `--include-archived`, `--limit`, FL 388 rejection, and missing-order behavior below FL 414 (FR-023, FR-030, FR-034)
+- [ ] T027 [P] [F6] Add CLI tests for folder create/update/archive/unarchive success, validation failures, feature-level errors, no-op archive/unarchive JSON success, and permission error propagation (FR-024 through FR-027, FR-030, FR-035, FR-036)
+- [ ] T028 [P] [F6] Add folder resolution tests for name, `id:N`, `none`, numeric not-found hints, and missing folder errors (FR-032)
+- [ ] T029 [P] [F6] Add channel create/update tests for `--folder` name, `id:N`, `none`, `--folder-id 0`, FL 389 gate, and unchanged behavior without folder flags (FR-028 through FR-030)
+- [ ] T030 [F6] Run `uv run pytest tests/unit/test_zulip_folders.py tests/unit/test_zulip_api.py tests/unit/test_zulip_cli.py` and fix failures (FR-023 through FR-036)
+
+**Checkpoint**: Folder feature behavior is covered by unit and CLI tests.
+
+---
+
+## Phase F7: Spec Sync and Docstring Polish
+
+**Purpose**: Keep user-facing docs and implementation comments aligned.
+
+- [ ] T031 [P] [F7] Update command docstrings and `--help` text for folder commands and channel `--folder` flags in `lftools_uv/typer_apps/zulip.py` (FR-037)
+- [ ] T032 [P] [F7] Ensure API helper docstrings cite FL 389, FL 414, and no hard-delete behavior in `lftools_uv/api/endpoints/zulip.py` (FR-030, FR-034, FR-037)
+- [ ] T033 [F7] Reconcile `specs/002-zulip-channel-folders/` with implemented behavior before final implementation PR review (FR-037)
+- [ ] T034 [F7] Run `SKIP=basedpyright pre-commit run --all-files` and fix all reported issues without bypassing hooks (FR-037)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **F1 API Helpers**: No implementation dependencies beyond existing Zulip API
+  layer from feature 001.
+- **F2 Feature-Level Gating and Validation**: Depends on F1 helper shapes.
+- **F3 `zulip folder` Commands**: Depends on F1 and F2.
+- **F4 Folder Resolution Helper**: Depends on F1 list helper and F2 gate.
+- **F5 Channel Integration**: Depends on F4.
+- **F6 Tests**: Test tasks can be written before implementation and completed
+  alongside each phase.
+- **F7 Polish**: Depends on all selected implementation phases.
+
+### Parallel Opportunities
+
+- T008 and T010 can run in parallel after T006.
+- T025 through T029 can be split across API, CLI, resolution, and channel
+  integration test files.
+- F3 folder commands can be implemented in parallel with F4 resolution after
+  the shared API helpers exist, as long as final integration waits for F4.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete F1 and F2.
+2. Complete `folder list` from F3.
+3. Validate active/archived listing, JSON output, and FL 389/414 behavior.
+
+### Incremental Delivery
+
+1. Add folder lifecycle helpers and commands.
+2. Add folder resolution.
+3. Integrate `--folder` into channel create/update.
+4. Complete tests and polish.
+
+## Notes
+
+- Each task should be small enough to review as a single commit.
+- Tasks that update `tasks.md` remain separate commits per project rules.
+- Do not add implementation code in the spec-only PR.
+- Use Zulip docs for source facts:
+  <https://zulip.com/api/get-channel-folders>,
+  <https://zulip.com/api/create-channel-folder>, and
+  <https://zulip.com/api/update-channel-folder>.


### PR DESCRIPTION
## Summary

- Add Spec Kit artifacts for the Zulip channel folders feature.
- Document folder lifecycle commands and channel folder assignment.
- Keep this as a SPEC-ONLY PR; implementation follows separately.

## Scope

This PR contains spec/plan/tasks/data-model/research/contracts/quickstart ONLY. Implementation will follow in separate PRs after this is merged.

## Locked design decisions

- Use a single `--folder` flag accepting folder name, `id:N`, or `none`.
- `--folder none` clears a channel folder; `--folder-id 0` is an update-only compatibility clear form.
- Use separate `folder archive` and `folder unarchive` commands.

## Zulip API facts

- Channel folder APIs are new in Zulip 11.0, feature level 389.
- Folder order is available starting at feature level 414.
- There is no hard-delete endpoint; archive is the destructive operation.
- Folder create/update/archive/unarchive are admin-only; list is available to all users.

## References

- https://zulip.com/api/get-channel-folders
- https://zulip.com/api/create-channel-folder
- https://zulip.com/api/update-channel-folder

## Validation

- `SKIP=basedpyright pre-commit run --all-files`