### PR TITLE
Fix: Set browser User-Agent for Jenkins requests

### DIFF
--- a/lftools_uv/jenkins/__init__.py
+++ b/lftools_uv/jenkins/__init__.py
@@ -52,6 +52,12 @@ def jjb_ini() -> str | None:
 
 JJB_INI: str | None = jjb_ini()
 
+# Some Jenkins servers sit behind a WAF/CDN (e.g. Cloudflare) that blocks the
+# default python-requests/python-jenkins User-Agent as suspected bot traffic.
+# Sending a browser-like User-Agent avoids these bot-detection challenges.
+# The value can be overridden via the LFTOOLS_JENKINS_USER_AGENT env variable.
+DEFAULT_USER_AGENT: str = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
+
 
 class Jenkins:
     """lftools Jenkins object."""
@@ -80,5 +86,18 @@ class Jenkins:
                 server = "https://localhost:8080"
 
         self.server: jenkins.Jenkins = jenkins.Jenkins(server, username=user, password=password)
+
+        # Override the default User-Agent so requests are not flagged as bot
+        # traffic by WAF/CDN layers (e.g. Cloudflare) in front of Jenkins.
+        # Use `or DEFAULT_USER_AGENT` so an empty env value still applies a
+        # browser-like UA rather than falling back to the requests default.
+        user_agent: str = os.environ.get("LFTOOLS_JENKINS_USER_AGENT") or DEFAULT_USER_AGENT
+        # `_session` is a python-jenkins internal; guard against it being
+        # renamed/removed in a future release so init never hard-fails.
+        session = getattr(self.server, "_session", None)
+        if session is not None:
+            session.headers["User-Agent"] = user_agent
+        else:
+            log.debug("python-jenkins session unavailable; skipping User-Agent override.")
 
         self.url: str = server


### PR DESCRIPTION
## Problem

Jenkins servers behind a WAF/CDN such as Cloudflare reject the default `python-requests`/`python-jenkins` User-Agent as suspected bot traffic. This causes commands like `lftools jenkins get-credentials` against `jenkins.opendaylight.org` to fail with a Cloudflare bot-detection challenge instead of returning data.

## Fix

Set a browser-like User-Agent on the underlying `requests` session right after the `python-jenkins` client is created in `lftools_uv/jenkins/__init__.py`:

- Defaults to a Firefox UA: `Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0`
- Overridable via the `LFTOOLS_JENKINS_USER_AGENT` environment variable.

This is cleaner than monkey-patching `requests.Session` or editing the installed `python-jenkins` package — it lives in lftools-uv and applies to every Jenkins command.

## Notes

The equivalent fix was also applied to the legacy `lftools` (Gerrit) repo. The long-term correct fix is a WAF bypass rule for authenticated API traffic, but this makes lftools-uv work today regardless.