### PR TITLE
Feat(zulip): Implement channel folders

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -41,14 +41,18 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal
 
 from lftools_uv import config as lf_config
 
+_zulip_module: ModuleType | None
 try:  # pragma: no cover - import guard exercised by integration tests
-    import zulip as _zulip_module
+    import zulip as _imported_zulip
 except ImportError:  # pragma: no cover - exercised when extra not installed
     _zulip_module = None
+else:
+    _zulip_module = _imported_zulip
 
 if TYPE_CHECKING:  # pragma: no cover
     import zulip as _zulip_module_type  # noqa: F401
@@ -307,12 +311,16 @@ def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None
 #: * Feature level 161 — ``can_remove_subscribers_group`` permission.
 #: * Feature level 334 — ``topic_policy`` per-channel field.
 #: * Feature level 59 — stream reactivation via stream update API.
+#: * Feature level 389 — channel folders.
+#: * Feature level 414 — channel folder ordering.
 FEATURE_LEVELS: dict[str, int] = {
     "web-public": 12,
     "can-subscribe-group": 357,
     "can-remove-subscribers-group": 161,
     "topic-policy": 334,
     "unarchive": 59,
+    "channel-folders": 389,
+    "channel-folders-order": 414,
 }
 
 
@@ -730,6 +738,291 @@ def list_channels(client: Any, *, include_archived: bool = False) -> list[dict[s
 
 
 # ---------------------------------------------------------------------------
+# Channel folders
+# ---------------------------------------------------------------------------
+
+
+def _normalize_channel_folder(raw: dict[str, Any]) -> dict[str, Any]:
+    """Project a raw Zulip channel-folder object to a stable shape.
+
+    Channel folders require Zulip feature level 389. The ``order`` field
+    was added at feature level 414, so missing values are represented as
+    ``None`` rather than treated as malformed.
+    """
+    folder_id = raw.get("id")
+    if not isinstance(folder_id, int) or isinstance(folder_id, bool):
+        raise ZulipAPIError(f"Channel folder missing numeric id: {raw!r}")
+    name = raw.get("name")
+    if not isinstance(name, str) or not name:
+        raise ZulipAPIError(f"Channel folder missing non-empty name: {raw!r}")
+    order_raw = raw.get("order")
+    if order_raw is None:
+        order: int | None = None
+    elif isinstance(order_raw, int) and not isinstance(order_raw, bool):
+        order = order_raw
+    else:
+        raise ZulipAPIError(f"Channel folder has malformed order: {raw!r}")
+    description = raw.get("description")
+    rendered = raw.get("rendered_description")
+    date_created = raw.get("date_created")
+    creator_id = raw.get("creator_id")
+    return {
+        "id": folder_id,
+        "name": name,
+        "order": order,
+        "description": "" if description is None else str(description),
+        "rendered_description": "" if rendered is None else str(rendered),
+        "is_archived": bool(raw.get("is_archived", False)),
+        "date_created": date_created if isinstance(date_created, int) and not isinstance(date_created, bool) else None,
+        "creator_id": creator_id if isinstance(creator_id, int) and not isinstance(creator_id, bool) else None,
+    }
+
+
+def _fetch_channel_folders(client: Any, *, include_archived: bool = False) -> list[dict[str, Any]]:
+    """Return raw channel folders from ``GET /api/v1/channel_folders``."""
+    request: dict[str, Any] = {}
+    if include_archived:
+        request["include_archived"] = True
+    try:
+        response = client.call_endpoint(
+            url="channel_folders",
+            method="GET",
+            request=request or None,
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to list channel folders: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = response.get("msg") if isinstance(response, dict) else None
+        raise ZulipAPIError(f"Failed to list channel folders: {msg or response!r}")
+    folders = response.get("channel_folders", [])
+    if not isinstance(folders, list):
+        raise ZulipAPIError(f"Malformed channel_folders payload: {response!r}")
+    return folders
+
+
+def list_channel_folders(
+    client: Any,
+    *,
+    include_archived: bool = False,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """List normalized channel folders, gated at feature level 389.
+
+    ``order`` is optional before feature level 414; omitted values are
+    returned as ``None`` in JSON and render as a blank table cell.
+    """
+    check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
+    if limit is not None:
+        if isinstance(limit, bool) or limit < 0:
+            raise ZulipValidationError("--limit must be a non-negative integer")
+    raw_folders = _fetch_channel_folders(client, include_archived=include_archived)
+    folders = [_normalize_channel_folder(folder) for folder in raw_folders]
+    if not include_archived:
+        folders = [folder for folder in folders if not folder["is_archived"]]
+    if limit is not None:
+        folders = folders[:limit]
+    return folders
+
+
+def _get_channel_folder_limits(client: Any) -> dict[str, int]:
+    """Return cached `/register` channel-folder length limits when available."""
+    cached = getattr(client, "_lftools_channel_folder_limits", None)
+    if isinstance(cached, dict):
+        return {str(k): v for k, v in cached.items() if isinstance(v, int) and not isinstance(v, bool)}
+    limits: dict[str, int] = {}
+    try:
+        response = client.call_endpoint(url="register", method="GET")
+    except Exception:
+        response = None
+    if isinstance(response, dict) and response.get("result") == "success":
+        for key in ("max_channel_folder_name_length", "max_channel_folder_description_length"):
+            value = response.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                limits[key] = value
+    try:
+        client._lftools_channel_folder_limits = limits
+    except AttributeError:  # pragma: no cover - defensive
+        pass
+    return limits
+
+
+def _validate_channel_folder_values(
+    client: Any,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> None:
+    """Validate folder names/descriptions against known server limits."""
+    if name is not None and not name.strip():
+        raise ZulipValidationError("Folder name must not be empty")
+    limits = _get_channel_folder_limits(client)
+    name_limit = limits.get("max_channel_folder_name_length")
+    if name is not None and name_limit is not None and len(name) > name_limit:
+        raise ZulipValidationError(f"Folder name exceeds server limit of {name_limit} characters")
+    description_limit = limits.get("max_channel_folder_description_length")
+    if description is not None and description_limit is not None and len(description) > description_limit:
+        raise ZulipValidationError(f"Folder description exceeds server limit of {description_limit} characters")
+
+
+def _folder_mutation_result(
+    response: dict[str, Any],
+    *,
+    operation: str,
+    fallback_id: int | None,
+    fallback_name: str | None,
+) -> dict[str, Any]:
+    """Build the folder mutation result contract from a Zulip response."""
+    raw_id = response.get("channel_folder_id", response.get("folder_id", response.get("id", fallback_id)))
+    folder_id = raw_id if isinstance(raw_id, int) and not isinstance(raw_id, bool) else fallback_id
+    folder_name: str | None = fallback_name
+    raw_folder = response.get("channel_folder")
+    if isinstance(raw_folder, dict):
+        raw_name = raw_folder.get("name")
+        if isinstance(raw_name, str):
+            folder_name = raw_name
+        raw_folder_id = raw_folder.get("id")
+        if isinstance(raw_folder_id, int) and not isinstance(raw_folder_id, bool):
+            folder_id = raw_folder_id
+    raw_name = response.get("folder_name")
+    if isinstance(raw_name, str):
+        folder_name = raw_name
+    return {
+        "status": "success",
+        "folder_id": folder_id,
+        "folder_name": folder_name,
+        "operation": operation,
+    }
+
+
+def create_channel_folder(client: Any, name: str, description: str = "") -> dict[str, Any]:
+    """Create a channel folder via ``POST /channel_folders/create``.
+
+    Channel folders require Zulip feature level 389. The server enforces
+    admin-only permissions; this helper intentionally surfaces those
+    API errors without client-side role checks.
+    """
+    check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
+    _validate_channel_folder_values(client, name=name, description=description)
+    request = {"name": name, "description": description}
+    try:
+        response = client.call_endpoint(
+            url="channel_folders/create",
+            method="POST",
+            request=request,
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to create channel folder: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = response.get("msg") if isinstance(response, dict) else None
+        raise ZulipAPIError(f"Failed to create channel folder: {msg or response!r}")
+    return _folder_mutation_result(response, operation="create", fallback_id=None, fallback_name=name)
+
+
+def update_channel_folder(
+    client: Any,
+    folder_id: int,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    is_archived: bool | None = None,
+) -> dict[str, Any]:
+    """Update a channel folder via ``PATCH /channel_folders/{id}``.
+
+    The same endpoint implements rename, description updates, archive,
+    and unarchive. Zulip exposes no hard-delete endpoint for folders.
+    """
+    if isinstance(folder_id, bool) or folder_id <= 0:
+        raise ZulipValidationError(f"folder_id must be a positive integer (got {folder_id})")
+    if name is None and description is None and is_archived is None:
+        raise ZulipValidationError("folder update requires at least one of --name, --description, or archive state")
+    check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
+    _validate_channel_folder_values(client, name=name, description=description)
+    request: dict[str, Any] = {}
+    if name is not None:
+        request["name"] = name
+    if description is not None:
+        request["description"] = description
+    if is_archived is not None:
+        request["is_archived"] = is_archived
+    try:
+        response = client.call_endpoint(
+            url=f"channel_folders/{folder_id}",
+            method="PATCH",
+            request=request,
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to update channel folder {folder_id}: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = response.get("msg") if isinstance(response, dict) else None
+        raise ZulipAPIError(f"Failed to update channel folder {folder_id}: {msg or response!r}")
+    operation = "update"
+    if is_archived is True and name is None and description is None:
+        operation = "archive"
+    elif is_archived is False and name is None and description is None:
+        operation = "unarchive"
+    return _folder_mutation_result(response, operation=operation, fallback_id=folder_id, fallback_name=name)
+
+
+def archive_channel_folder(client: Any, folder_id: int) -> dict[str, Any]:
+    """Archive a channel folder; there is no hard-delete endpoint."""
+    return update_channel_folder(client, folder_id, is_archived=True)
+
+
+def unarchive_channel_folder(client: Any, folder_id: int) -> dict[str, Any]:
+    """Unarchive a channel folder via the feature-level-389 PATCH API."""
+    return update_channel_folder(client, folder_id, is_archived=False)
+
+
+def resolve_channel_folder_token(client: Any, token: str) -> int | None:
+    """Resolve a folder token for channel assignment.
+
+    Accepts a case-insensitive folder name, ``id:N`` for explicit ID
+    lookup, or ``none`` to clear the assignment. Numeric-looking names
+    are treated as names; if absent, the error hints to use ``id:N``.
+    """
+    check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
+    token = token.strip()
+    if not token:
+        raise ZulipValidationError("--folder must not be empty")
+    if token.casefold() == "none":
+        return None
+
+    folders = list_channel_folders(client, include_archived=True)
+    if token.casefold().startswith("id:"):
+        suffix = token[3:].strip()
+        try:
+            wanted = int(suffix)
+        except ValueError as exc:
+            raise ZulipValidationError(f"id: prefix requires a numeric folder ID, got {suffix!r}") from exc
+        if wanted <= 0:
+            raise ZulipValidationError(f"id: prefix requires a positive folder ID, got {wanted}")
+        for folder in folders:
+            if folder["id"] == wanted:
+                return wanted
+        raise ZulipNotFoundError(f"No channel folder with id {wanted}")
+
+    target = token.casefold()
+    matches = [folder for folder in folders if str(folder.get("name", "")).casefold() == target]
+    if not matches:
+        if token.isdigit():
+            raise ZulipNotFoundError(
+                f"No channel folder named {token!r}. If you meant a numeric folder ID, use 'id:{token}'."
+            )
+        raise ZulipNotFoundError(f"No channel folder named {token!r}")
+    if len(matches) > 1:
+        raise ZulipAmbiguityError(
+            f"Channel folder name {token!r} matched {len(matches)} folders; use the id:NUM prefix to disambiguate",
+            matches=[
+                {"id": folder["id"], "name": folder["name"], "is_archived": folder["is_archived"]} for folder in matches
+            ],
+        )
+    folder_id = matches[0]["id"]
+    if not isinstance(folder_id, int):
+        raise ZulipAPIError(f"Resolved folder missing numeric id: {matches[0]!r}")
+    return folder_id
+
+
+# ---------------------------------------------------------------------------
 # Channel subscribers (US7)
 # ---------------------------------------------------------------------------
 
@@ -1002,6 +1295,8 @@ def create_channel(
     can_remove_subscribers_group_value: GroupSettingValue | None = None,
     announce: bool | None = None,
     topic_policy: str | None = None,
+    folder_id: int | None = None,
+    folder_id_specified: bool = False,
 ) -> dict[str, Any]:
     """Create a new Zulip channel (stream).
 
@@ -1027,6 +1322,9 @@ def create_channel(
         ``True`` to announce, ``False`` to suppress, ``None`` for API default.
     topic_policy
         One of ``allow``, ``deny``, ``follow-default``, or ``None``.
+    folder_id
+        Channel folder ID to assign, or ``None`` to clear when
+        ``folder_id_specified`` is true.
 
     Returns
     -------
@@ -1067,6 +1365,9 @@ def create_channel(
     if can_remove_subscribers_group_value is not None:
         check_feature_level(client, FEATURE_LEVELS["can-remove-subscribers-group"], "can-remove-subscribers-group")
 
+    if folder_id is not None or folder_id_specified:
+        check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
+
     # Lockout prevention for private channels:
     # Require at least one subscriber OR a non-None allow_group_value.
     # Callers must validate that allow_group_value is not the Nobody group
@@ -1083,6 +1384,8 @@ def create_channel(
     subscription: dict[str, Any] = {"name": name}
     if description:
         subscription["description"] = description
+    if folder_id is not None or folder_id_specified:
+        subscription["folder_id"] = folder_id
 
     principals: list[int] = list(subscribe_user_ids) if subscribe_user_ids else []
 
@@ -1167,6 +1470,8 @@ def create_channel(
     }
     if topic_policy is not None:
         result["topic_policy_applied"] = topic_policy_applied
+    if folder_id is not None or folder_id_specified:
+        result["folder_id"] = folder_id
     if warnings:
         result["warnings"] = warnings
 
@@ -1586,6 +1891,8 @@ def update_channel(
     user_id_mode: IdMode | None = None,
     allow_group: str | None = None,
     can_remove_subscribers_group: str | None = None,
+    folder_id: int | None = None,
+    folder_id_specified: bool = False,
     include_archived: bool = False,
 ) -> dict[str, Any]:
     """Update channel settings via ``PATCH /api/v1/streams/{stream_id}``.
@@ -1593,8 +1900,8 @@ def update_channel(
     Implements FR-004 (channel update) end-to-end:
 
     * Validates that at least one setting flag is supplied (rename,
-      description, type, topic-policy, allow-group, or
-      can-remove-subscribers-group).
+      description, type, topic-policy, allow-group, folder assignment,
+      or can-remove-subscribers-group).
     * Applies the FR-019 feature-level checks for web-public,
       topic-policy, can-subscribe-group (``--allow-group``) and
       can-remove-subscribers-group.
@@ -1618,22 +1925,27 @@ def update_channel(
     # Argument validation
     # ------------------------------------------------------------------
     subscribe_list: list[str] = list(subscribe_user_specs or [])
-    settings_specified = any(
-        v is not None
-        for v in (
-            new_name,
-            description,
-            channel_type,
-            topic_policy,
-            allow_group,
-            can_remove_subscribers_group,
+    settings_specified = (
+        any(
+            v is not None
+            for v in (
+                new_name,
+                description,
+                channel_type,
+                topic_policy,
+                allow_group,
+                can_remove_subscribers_group,
+            )
         )
-    ) or bool(subscribe_list)
+        or bool(subscribe_list)
+        or folder_id_specified
+        or folder_id is not None
+    )
     if not settings_specified:
         raise ZulipValidationError(
             "channel update requires at least one setting to change "
             "(--name, --description, --type, --topic-policy, --allow-group, "
-            "--subscribe, or --can-remove-subscribers-group)"
+            "--folder, --subscribe, or --can-remove-subscribers-group)"
         )
 
     valid_channel_types = {"public", "private", "web-public"}
@@ -1695,6 +2007,8 @@ def update_channel(
             FEATURE_LEVELS["can-remove-subscribers-group"],
             feature_name="can-remove-subscribers-group",
         )
+    if folder_id is not None or folder_id_specified:
+        check_feature_level(client, FEATURE_LEVELS["channel-folders"], feature_name="channel-folders")
 
     # ------------------------------------------------------------------
     # Resolve target channel
@@ -1822,6 +2136,8 @@ def update_channel(
         request["can_subscribe_group"] = {"new": allow_group_value}
     if can_remove_value is not None:
         request["can_remove_subscribers_group"] = {"new": can_remove_value}
+    if folder_id is not None or folder_id_specified:
+        request["folder_id"] = folder_id
 
     # ------------------------------------------------------------------
     # PATCH /api/v1/streams/{stream_id}
@@ -1842,12 +2158,15 @@ def update_channel(
 
     # Reflect rename in the returned channel_name.
     effective_name = new_name if new_name is not None else resolved_name
-    return {
+    result = {
         "status": "success",
         "channel_id": stream_id,
         "channel_name": effective_name,
         "operation": "update",
     }
+    if folder_id is not None or folder_id_specified:
+        result["folder_id"] = folder_id
+    return result
 
 
 # Topic policy convenience helpers (FR-021)

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -864,6 +864,12 @@ def _validate_channel_folder_values(
         raise ZulipValidationError(f"Folder description exceeds server limit of {description_limit} characters")
 
 
+def _validate_channel_folder_assignment_id(folder_id: Any) -> None:
+    """Validate a non-null channel folder assignment ID."""
+    if not isinstance(folder_id, int) or isinstance(folder_id, bool) or folder_id <= 0:
+        raise ZulipValidationError(f"folder_id must be a positive integer (got {folder_id})")
+
+
 def _folder_mutation_result(
     response: dict[str, Any],
     *,
@@ -1365,6 +1371,8 @@ def create_channel(
     if can_remove_subscribers_group_value is not None:
         check_feature_level(client, FEATURE_LEVELS["can-remove-subscribers-group"], "can-remove-subscribers-group")
 
+    if folder_id is not None:
+        _validate_channel_folder_assignment_id(folder_id)
     if folder_id is not None or folder_id_specified:
         check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
 
@@ -1958,6 +1966,8 @@ def update_channel(
         raise ZulipValidationError(
             f"Invalid topic_policy {topic_policy!r}; expected one of {', '.join(sorted(valid_topic_policies))}"
         )
+    if folder_id is not None:
+        _validate_channel_folder_assignment_id(folder_id)
 
     # ------------------------------------------------------------------
     # Feature-level gating (FR-019)

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -813,7 +813,7 @@ def list_channel_folders(
     """
     check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
     if limit is not None:
-        if isinstance(limit, bool) or limit < 0:
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 0:
             raise ZulipValidationError("--limit must be a non-negative integer")
     raw_folders = _fetch_channel_folders(client, include_archived=include_archived)
     folders = [_normalize_channel_folder(folder) for folder in raw_folders]
@@ -937,8 +937,7 @@ def update_channel_folder(
     The same endpoint implements rename, description updates, archive,
     and unarchive. Zulip exposes no hard-delete endpoint for folders.
     """
-    if isinstance(folder_id, bool) or folder_id <= 0:
-        raise ZulipValidationError(f"folder_id must be a positive integer (got {folder_id})")
+    _validate_channel_folder_assignment_id(folder_id)
     if name is None and description is None and is_archived is None:
         raise ZulipValidationError("folder update requires at least one of --name, --description, or archive state")
     check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")

--- a/lftools_uv/cli/errors.py
+++ b/lftools_uv/cli/errors.py
@@ -74,13 +74,17 @@ import logging
 import traceback
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from functools import wraps
+from types import ModuleType
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 # Optional import guarded to avoid hard dependency on Click
+click: ModuleType | None
 try:
-    import click
+    import click as _click_module
 except Exception:  # pragma: no cover - defensive
     click = None
+else:
+    click = _click_module
 
 if TYPE_CHECKING:
     import click as _click_type

--- a/lftools_uv/openstack/stack.py
+++ b/lftools_uv/openstack/stack.py
@@ -113,8 +113,10 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
 
     def get_server_info(server_id: str) -> tuple[str, float]:
         server = cloud.compute.find_server(server_id)  # pyright: ignore[reportAttributeAccessIssue]
-        diff = datetime.now(UTC) - parse_iso8601_time(server.launched_at)  # pyright: ignore[reportOptionalMemberAccess]
-        return server.flavor["original_name"], diff.total_seconds()  # pyright: ignore[reportOptionalMemberAccess]
+        if server is None:
+            raise RuntimeError(f"Server {server_id} not found")
+        diff = datetime.now(UTC) - parse_iso8601_time(server.launched_at)
+        return server.flavor["original_name"], diff.total_seconds()
 
     def get_server_ids(stack_name: str) -> list[str]:
         servers = get_resources_by_type(stack_name, "OS::Nova::Server")

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -261,22 +261,6 @@ folder_app = typer.Typer(
 zulip_app.add_typer(folder_app, name="folder")
 
 
-def folder_mutation_result(
-    *,
-    status: str,
-    operation: str,
-    folder_id: int | None,
-    folder_name: str | None,
-) -> dict[str, Any]:
-    """Build the standard folder mutation-result JSON payload."""
-    return {
-        "status": status,
-        "folder_id": folder_id,
-        "folder_name": folder_name,
-        "operation": operation,
-    }
-
-
 @channel_app.command("list")
 def channel_list(
     ctx: typer.Context,

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -39,17 +39,23 @@ from lftools_uv.api.endpoints.zulip import (
     ZulipAmbiguityError,
     ZulipError,
     archive_channel,
+    archive_channel_folder,
+    create_channel_folder,
     get_client,
     get_topic_policy,
+    list_channel_folders,
     list_channels,
     list_groups,
     list_subscribers,
     list_users,
     resolve_channel,
+    resolve_channel_folder_token,
     set_topic_policy,
     subscribe_users,
     unarchive_channel,
+    unarchive_channel_folder,
     update_channel,
+    update_channel_folder,
     zulip_available,
 )
 
@@ -247,6 +253,29 @@ channel_app = typer.Typer(
 )
 zulip_app.add_typer(channel_app, name="channel")
 
+folder_app = typer.Typer(
+    name="folder",
+    help="Manage Zulip channel folders.",
+    no_args_is_help=True,
+)
+zulip_app.add_typer(folder_app, name="folder")
+
+
+def folder_mutation_result(
+    *,
+    status: str,
+    operation: str,
+    folder_id: int | None,
+    folder_name: str | None,
+) -> dict[str, Any]:
+    """Build the standard folder mutation-result JSON payload."""
+    return {
+        "status": status,
+        "folder_id": folder_id,
+        "folder_name": folder_name,
+        "operation": operation,
+    }
+
 
 @channel_app.command("list")
 def channel_list(
@@ -297,6 +326,175 @@ def channel_list(
             row.append("archived" if c.get("is_archived") else "active")
         rows.append(row)
     emit_table(rows, headers)
+
+
+@folder_app.command("list")
+def folder_list(
+    ctx: typer.Context,
+    include_archived: bool = typer.Option(
+        False,
+        "--include-archived",
+        help="Include archived folders and show their status.",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        help="Limit the number of folders displayed.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of a table.",
+        hidden=True,
+    ),
+) -> None:
+    """List channel folders visible to the authenticated user."""
+    options = {**(ctx.obj or {})}
+    if json_output:
+        options["json_output"] = True
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        folders = list_channel_folders(client, include_archived=include_archived, limit=limit)
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json({"folders": folders})
+        return
+
+    headers = ["Folder ID", "Name", "Order", "Description"]
+    if include_archived:
+        headers.append("Status")
+    rows: list[list[Any]] = []
+    for folder in folders:
+        row: list[Any] = [
+            folder.get("id", ""),
+            folder.get("name", ""),
+            folder.get("order"),
+            folder.get("description", ""),
+        ]
+        if include_archived:
+            row.append("Archived" if folder.get("is_archived") else "Active")
+        rows.append(row)
+    emit_table(rows, headers)
+
+
+@folder_app.command("create")
+def folder_create(
+    ctx: typer.Context,
+    name: str = typer.Option(..., "--name", help="Folder name."),
+    description: str = typer.Option(
+        "",
+        "--description",
+        help="Folder description; defaults to empty.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of text.",
+        hidden=True,
+    ),
+) -> None:
+    """Create a channel folder; Zulip enforces admin permissions."""
+    options = {**(ctx.obj or {})}
+    if json_output:
+        options["json_output"] = True
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        result = create_channel_folder(client, name=name, description=description)
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json(result)
+    else:
+        typer.echo(f"Created folder '{result.get('folder_name') or name}' (ID: {result.get('folder_id')})")
+
+
+@folder_app.command("update")
+def folder_update(
+    ctx: typer.Context,
+    folder_id: int = typer.Option(..., "--folder-id", help="Target folder ID."),
+    name: str | None = typer.Option(None, "--name", help="New folder name."),
+    description: str | None = typer.Option(None, "--description", help="New folder description."),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of text.",
+        hidden=True,
+    ),
+) -> None:
+    """Update a channel folder name and/or description."""
+    if name is None and description is None:
+        emit_error("folder update requires at least one of --name or --description")
+        raise typer.Exit(code=1)
+    options = {**(ctx.obj or {})}
+    if json_output:
+        options["json_output"] = True
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        result = update_channel_folder(client, folder_id=folder_id, name=name, description=description)
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json(result)
+    else:
+        typer.echo(f"Updated folder {result.get('folder_id') or folder_id}")
+
+
+def _folder_archive_common(
+    ctx: typer.Context,
+    *,
+    folder_id: int,
+    json_output: bool,
+    archive: bool,
+) -> None:
+    """Shared implementation for folder archive/unarchive commands."""
+    options = {**(ctx.obj or {})}
+    if json_output:
+        options["json_output"] = True
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        result = archive_channel_folder(client, folder_id) if archive else unarchive_channel_folder(client, folder_id)
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json(result)
+    else:
+        verb = "Archived" if archive else "Unarchived"
+        typer.echo(f"{verb} folder {result.get('folder_id') or folder_id}")
+
+
+@folder_app.command("archive")
+def folder_archive(
+    ctx: typer.Context,
+    folder_id: int = typer.Option(..., "--folder-id", help="Target folder ID."),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of text.",
+        hidden=True,
+    ),
+) -> None:
+    """Archive a channel folder; Zulip exposes no hard delete."""
+    _folder_archive_common(ctx, folder_id=folder_id, json_output=json_output, archive=True)
+
+
+@folder_app.command("unarchive")
+def folder_unarchive(
+    ctx: typer.Context,
+    folder_id: int = typer.Option(..., "--folder-id", help="Target folder ID."),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of text.",
+        hidden=True,
+    ),
+) -> None:
+    """Reactivate an archived channel folder."""
+    _folder_archive_common(ctx, folder_id=folder_id, json_output=json_output, archive=False)
 
 
 def _resolve_channel_target(channel: str | None, channel_id: str | None) -> None:
@@ -455,6 +653,11 @@ def channel_create(
         "--can-remove-subscribers-group",
         help="Comma-separated groups that can remove subscribers; use 'id:NUM' for ID lookup.",
     ),
+    folder: str | None = typer.Option(
+        None,
+        "--folder",
+        help="Folder name, 'id:NUM', or 'none' for no folder.",
+    ),
     announce: bool = typer.Option(
         False,
         "--announce",
@@ -533,6 +736,11 @@ def channel_create(
         if can_remove_subscribers_group:
             _, can_remove_value = resolve_groups(client, can_remove_subscribers_group)
 
+        folder_id: int | None = None
+        folder_id_specified = folder is not None
+        if folder is not None:
+            folder_id = resolve_channel_folder_token(client, folder)
+
         result = create_channel(
             client,
             name=name,
@@ -543,6 +751,8 @@ def channel_create(
             can_remove_subscribers_group_value=can_remove_value,
             announce=announce_value,
             topic_policy=topic_policy,
+            folder_id=folder_id,
+            folder_id_specified=folder_id_specified,
         )
     except ZulipAmbiguityError as exc:
         emit_error(str(exc))
@@ -1169,6 +1379,16 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
         "--can-remove-subscribers-group",
         help="Group(s) permitted to remove subscribers (group-setting syntax).",
     ),
+    folder: str | None = typer.Option(
+        None,
+        "--folder",
+        help="Folder name, 'id:NUM', or 'none' to clear the assignment.",
+    ),
+    folder_id: str | None = typer.Option(
+        None,
+        "--folder-id",
+        help="Clear-only compatibility form; only 0 is accepted.",
+    ),
     include_archived: bool = typer.Option(
         False,
         "--include-archived",
@@ -1207,15 +1427,34 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
             topic_policy,
             allow_group,
             can_remove_subscribers_group,
+            folder,
+            folder_id,
         )
     ) or bool(subscribe)
     if not any_setting:
         emit_error(
             "channel update requires at least one setting to change "
             "(--name, --description, --type, --topic-policy, --allow-group, "
-            "--subscribe, or --can-remove-subscribers-group)"
+            "--folder, --subscribe, or --can-remove-subscribers-group)"
         )
         raise typer.Exit(code=1)
+
+    if folder is not None and folder_id is not None:
+        emit_error("Specify only one of --folder or --folder-id")
+        raise typer.Exit(code=1)
+
+    parsed_folder_id: int | None = None
+    folder_id_specified = False
+    if folder_id is not None:
+        try:
+            parsed_clear_id = int(folder_id)
+        except ValueError:
+            emit_error("--folder-id must be 0 to clear the folder assignment; use --folder id:N to assign by ID")
+            raise typer.Exit(code=1) from None
+        if parsed_clear_id != 0:
+            emit_error("--folder-id only accepts 0 to clear; use --folder id:N to assign a folder")
+            raise typer.Exit(code=1)
+        folder_id_specified = True
 
     # Validate --type choice locally so the error is presented before
     # any network calls are made.
@@ -1252,6 +1491,9 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
     options = ctx.obj or {}
     try:
         client = get_client(zuliprc=options.get("zuliprc"))
+        if folder is not None:
+            parsed_folder_id = resolve_channel_folder_token(client, folder)
+            folder_id_specified = True
         result = update_channel(
             client,
             name=channel,
@@ -1264,6 +1506,8 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
             user_id_mode=cast(IdMode | None, user_id_mode),
             allow_group=allow_group,
             can_remove_subscribers_group=can_remove_subscribers_group,
+            folder_id=parsed_folder_id,
+            folder_id_specified=folder_id_specified,
             include_archived=include_archived,
         )
     except ZulipError as exc:

--- a/specs/002-zulip-channel-folders/quickstart.md
+++ b/specs/002-zulip-channel-folders/quickstart.md
@@ -121,9 +121,6 @@ CLI. The CLI does not pre-flight admin role checks.
 
 ## Development
 
-> **Note**: The paths below are planned locations; implementation happens in a
-> later PR.
-
 ```bash
 # Run folder-focused tests once implementation exists
 uv run pytest tests/unit/test_zulip_folders.py

--- a/specs/002-zulip-channel-folders/spec.md
+++ b/specs/002-zulip-channel-folders/spec.md
@@ -7,7 +7,7 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 **Feature Branch**: `002-zulip-channel-folders`
 **Created**: 2026-06-04
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Add specification artifacts for Zulip channel
 folders, including folder lifecycle commands and channel folder assignment."
 

--- a/specs/002-zulip-channel-folders/tasks.md
+++ b/specs/002-zulip-channel-folders/tasks.md
@@ -32,11 +32,11 @@ completed in atomic commits while preserving feature traceability.
 
 **Purpose**: Add reusable API functions for the channel folder endpoints.
 
-- [ ] T001 [F1] Add `ChannelFolder` parsing helpers in `lftools_uv/api/endpoints/zulip.py` for id, name, order, description, rendered_description, is_archived, date_created, and creator_id (FR-023, FR-034)
-- [ ] T002 [F1] Implement `list_channel_folders(client, include_archived=False, limit=None)` using `GET /api/v1/channel_folders` (FR-023)
-- [ ] T003 [F1] Implement `create_channel_folder(client, name, description="")` using `POST /api/v1/channel_folders/create` and returning `channel_folder_id` (FR-024)
-- [ ] T004 [F1] Implement `update_channel_folder(client, folder_id, *, name=None, description=None, is_archived=None)` using `PATCH /api/v1/channel_folders/{id}` (FR-025, FR-026, FR-027)
-- [ ] T005 [F1] Add thin `archive_channel_folder()` and `unarchive_channel_folder()` wrappers that call `update_channel_folder()` with `is_archived` true or false (FR-026, FR-027)
+- [x] T001 [F1] Add `ChannelFolder` parsing helpers in `lftools_uv/api/endpoints/zulip.py` for id, name, order, description, rendered_description, is_archived, date_created, and creator_id (FR-023, FR-034)
+- [x] T002 [F1] Implement `list_channel_folders(client, include_archived=False, limit=None)` using `GET /api/v1/channel_folders` (FR-023)
+- [x] T003 [F1] Implement `create_channel_folder(client, name, description="")` using `POST /api/v1/channel_folders/create` and returning `channel_folder_id` (FR-024)
+- [x] T004 [F1] Implement `update_channel_folder(client, folder_id, *, name=None, description=None, is_archived=None)` using `PATCH /api/v1/channel_folders/{id}` (FR-025, FR-026, FR-027)
+- [x] T005 [F1] Add thin `archive_channel_folder()` and `unarchive_channel_folder()` wrappers that call `update_channel_folder()` with `is_archived` true or false (FR-026, FR-027)
 
 **Checkpoint**: API layer can call all documented channel folder endpoints.
 
@@ -46,11 +46,11 @@ completed in atomic commits while preserving feature traceability.
 
 **Purpose**: Enforce server compatibility and server-provided folder limits.
 
-- [ ] T006 [F2] Add `FEATURE_LEVELS["channel-folders"] = 389` and `FEATURE_LEVELS["channel-folders-order"] = 414` in `lftools_uv/api/endpoints/zulip.py` (FR-031)
-- [ ] T007 [F2] Gate all folder API helpers and channel folder assignment paths with `check_feature_level(..., 389, "channel-folders")` (FR-030)
-- [ ] T008 [P] [F2] Add `/register` limit lookup helpers for `max_channel_folder_name_length` and `max_channel_folder_description_length` with per-client caching (FR-033)
-- [ ] T009 [F2] Validate folder create/update names and descriptions against known limits and produce clear validation errors before API calls (FR-024, FR-025, FR-033)
-- [ ] T010 [P] [F2] Ensure missing `order` on servers below FL 414 renders as `None` instead of raising parsing errors (FR-034)
+- [x] T006 [F2] Add `FEATURE_LEVELS["channel-folders"] = 389` and `FEATURE_LEVELS["channel-folders-order"] = 414` in `lftools_uv/api/endpoints/zulip.py` (FR-031)
+- [x] T007 [F2] Gate all folder API helpers and channel folder assignment paths with `check_feature_level(..., 389, "channel-folders")` (FR-030)
+- [x] T008 [P] [F2] Add `/register` limit lookup helpers for `max_channel_folder_name_length` and `max_channel_folder_description_length` with per-client caching (FR-033)
+- [x] T009 [F2] Validate folder create/update names and descriptions against known limits and produce clear validation errors before API calls (FR-024, FR-025, FR-033)
+- [x] T010 [P] [F2] Ensure missing `order` on servers below FL 414 renders as `None` instead of raising parsing errors (FR-034)
 
 **Checkpoint**: Unsupported servers and invalid folder values fail safely.
 
@@ -60,12 +60,12 @@ completed in atomic commits while preserving feature traceability.
 
 **Purpose**: Expose folder lifecycle operations in the CLI.
 
-- [ ] T011 [F3] Create `folder` Typer sub-app in `lftools_uv/typer_apps/zulip.py` and register it under the existing `zulip` app (FR-023)
-- [ ] T012 [F3] Implement `folder list` with `--include-archived`, `--limit`, `--json`, stable table columns, and conditional Status column (FR-023, FR-034)
-- [ ] T013 [F3] Implement `folder create` with required `--name`, optional `--description`, human ID output, and JSON mutation output (FR-024)
-- [ ] T014 [F3] Implement `folder update` with required `--folder-id`, optional `--name`/`--description`, and at-least-one-field validation (FR-025)
-- [ ] T015 [F3] Implement `folder archive` and `folder unarchive` commands using required `--folder-id` and JSON mutation output (FR-026, FR-027, FR-036)
-- [ ] T016 [P] [F3] Add help text and error messages documenting admin-only mutations and server-side permission handling (FR-035, FR-037)
+- [x] T011 [F3] Create `folder` Typer sub-app in `lftools_uv/typer_apps/zulip.py` and register it under the existing `zulip` app (FR-023)
+- [x] T012 [F3] Implement `folder list` with `--include-archived`, `--limit`, `--json`, stable table columns, and conditional Status column (FR-023, FR-034)
+- [x] T013 [F3] Implement `folder create` with required `--name`, optional `--description`, human ID output, and JSON mutation output (FR-024)
+- [x] T014 [F3] Implement `folder update` with required `--folder-id`, optional `--name`/`--description`, and at-least-one-field validation (FR-025)
+- [x] T015 [F3] Implement `folder archive` and `folder unarchive` commands using required `--folder-id` and JSON mutation output (FR-026, FR-027, FR-036)
+- [x] T016 [P] [F3] Add help text and error messages documenting admin-only mutations and server-side permission handling (FR-035, FR-037)
 
 **Checkpoint**: `lftools-uv zulip folder ...` commands work independently.
 
@@ -76,9 +76,9 @@ completed in atomic commits while preserving feature traceability.
 **Purpose**: Resolve folder names and explicit IDs consistently for channel
 assignment.
 
-- [ ] T017 [F4] Implement `resolve_channel_folder_token(client, token)` in `lftools_uv/api/endpoints/zulip.py` accepting names, `id:N`, and `none` (FR-028, FR-029, FR-032)
-- [ ] T018 [F4] Add numeric-looking-name not-found errors that hint to use `id:N` for numeric folder IDs (FR-032)
-- [ ] T019 [P] [F4] Add ambiguity and archived-folder behavior tests for folder resolution if Zulip responses can include duplicate or archived names (FR-032)
+- [x] T017 [F4] Implement `resolve_channel_folder_token(client, token)` in `lftools_uv/api/endpoints/zulip.py` accepting names, `id:N`, and `none` (FR-028, FR-029, FR-032)
+- [x] T018 [F4] Add numeric-looking-name not-found errors that hint to use `id:N` for numeric folder IDs (FR-032)
+- [x] T019 [P] [F4] Add ambiguity and archived-folder behavior tests for folder resolution if Zulip responses can include duplicate or archived names (FR-032)
 
 **Checkpoint**: Channel workflows can convert user folder input to `folder_id`.
 
@@ -88,11 +88,11 @@ assignment.
 
 **Purpose**: Add folder assignment to existing channel workflows.
 
-- [ ] T020 [F5] Add `--folder` option to `channel create` in `lftools_uv/typer_apps/zulip.py` and pass resolved `folder_id` to the create API payload (FR-028)
-- [ ] T021 [F5] Add `--folder` option to `channel update` and pass resolved `folder_id` to the stream PATCH payload (FR-029)
-- [ ] T022 [F5] Add `channel update` clear handling for `--folder none` and `--folder-id 0`, both mapping to `folder_id: null`; reject non-zero `--folder-id` with guidance to use `--folder id:N` (FR-029)
-- [ ] T023 [F5] Ensure channel create/update with folder assignment short-circuits below FL 389 before mutation (FR-030)
-- [ ] T024 [F5] Preserve existing channel create/update behavior when no folder flag is supplied (FR-028, FR-029)
+- [x] T020 [F5] Add `--folder` option to `channel create` in `lftools_uv/typer_apps/zulip.py` and pass resolved `folder_id` to the create API payload (FR-028)
+- [x] T021 [F5] Add `--folder` option to `channel update` and pass resolved `folder_id` to the stream PATCH payload (FR-029)
+- [x] T022 [F5] Add `channel update` clear handling for `--folder none` and `--folder-id 0`, both mapping to `folder_id: null`; reject non-zero `--folder-id` with guidance to use `--folder id:N` (FR-029)
+- [x] T023 [F5] Ensure channel create/update with folder assignment short-circuits below FL 389 before mutation (FR-030)
+- [x] T024 [F5] Preserve existing channel create/update behavior when no folder flag is supplied (FR-028, FR-029)
 
 **Checkpoint**: Existing channel workflows support folder assignment safely.
 
@@ -103,12 +103,12 @@ assignment.
 **Purpose**: Cover API helpers, CLI commands, feature gates, and channel
 integration.
 
-- [ ] T025 [P] [F6] Add API tests for folder list/create/update/archive/unarchive in `tests/unit/test_zulip_folders.py` or `tests/unit/test_zulip_api.py` (FR-023 through FR-027)
-- [ ] T026 [P] [F6] Add CLI tests for `folder list` table output, JSON output, `--include-archived`, `--limit`, FL 388 rejection, and missing-order behavior below FL 414 (FR-023, FR-030, FR-034)
-- [ ] T027 [P] [F6] Add CLI tests for folder create/update/archive/unarchive success, validation failures, feature-level errors, no-op archive/unarchive JSON success, and permission error propagation (FR-024 through FR-027, FR-030, FR-035, FR-036)
-- [ ] T028 [P] [F6] Add folder resolution tests for name, `id:N`, `none`, numeric not-found hints, and missing folder errors (FR-032)
-- [ ] T029 [P] [F6] Add channel create/update tests for `--folder` name, `id:N`, `none`, `--folder-id 0`, FL 389 gate, and unchanged behavior without folder flags (FR-028 through FR-030)
-- [ ] T030 [F6] Run `uv run pytest tests/unit/test_zulip_folders.py tests/unit/test_zulip_api.py tests/unit/test_zulip_cli.py` and fix failures (FR-023 through FR-036)
+- [x] T025 [P] [F6] Add API tests for folder list/create/update/archive/unarchive in `tests/unit/test_zulip_folders.py` or `tests/unit/test_zulip_api.py` (FR-023 through FR-027)
+- [x] T026 [P] [F6] Add CLI tests for `folder list` table output, JSON output, `--include-archived`, `--limit`, FL 388 rejection, and missing-order behavior below FL 414 (FR-023, FR-030, FR-034)
+- [x] T027 [P] [F6] Add CLI tests for folder create/update/archive/unarchive success, validation failures, feature-level errors, no-op archive/unarchive JSON success, and permission error propagation (FR-024 through FR-027, FR-030, FR-035, FR-036)
+- [x] T028 [P] [F6] Add folder resolution tests for name, `id:N`, `none`, numeric not-found hints, and missing folder errors (FR-032)
+- [x] T029 [P] [F6] Add channel create/update tests for `--folder` name, `id:N`, `none`, `--folder-id 0`, FL 389 gate, and unchanged behavior without folder flags (FR-028 through FR-030)
+- [x] T030 [F6] Run `uv run pytest tests/unit/test_zulip_folders.py tests/unit/test_zulip_api.py tests/unit/test_zulip_cli.py` and fix failures (FR-023 through FR-036)
 
 **Checkpoint**: Folder feature behavior is covered by unit and CLI tests.
 
@@ -118,10 +118,10 @@ integration.
 
 **Purpose**: Keep user-facing docs and implementation comments aligned.
 
-- [ ] T031 [P] [F7] Update command docstrings and `--help` text for folder commands and channel `--folder` flags in `lftools_uv/typer_apps/zulip.py` (FR-037)
-- [ ] T032 [P] [F7] Ensure API helper docstrings cite FL 389, FL 414, and no hard-delete behavior in `lftools_uv/api/endpoints/zulip.py` (FR-030, FR-034, FR-037)
-- [ ] T033 [F7] Reconcile `specs/002-zulip-channel-folders/` with implemented behavior before final implementation PR review (FR-037)
-- [ ] T034 [F7] Run `SKIP=basedpyright pre-commit run --all-files` and fix all reported issues without bypassing hooks (FR-037)
+- [x] T031 [P] [F7] Update command docstrings and `--help` text for folder commands and channel `--folder` flags in `lftools_uv/typer_apps/zulip.py` (FR-037)
+- [x] T032 [P] [F7] Ensure API helper docstrings cite FL 389, FL 414, and no hard-delete behavior in `lftools_uv/api/endpoints/zulip.py` (FR-030, FR-034, FR-037)
+- [x] T033 [F7] Reconcile `specs/002-zulip-channel-folders/` with implemented behavior before final implementation PR review (FR-037)
+- [x] T034 [F7] Run `SKIP=basedpyright pre-commit run --all-files` and fix all reported issues without bypassing hooks (FR-037)
 
 ---
 

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -1868,6 +1868,7 @@ def test_channel_unsubscribe_json_error_client_init_failure(
         raise ZulipError("config missing")
 
     monkeypatch.setattr(zulip_mod, "get_client", _boom)
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
     runner = CliRunner()
     result = runner.invoke(
         zulip_app,

--- a/tests/unit/test_zulip_folders.py
+++ b/tests/unit/test_zulip_folders.py
@@ -207,6 +207,15 @@ def test_create_channel_with_folder_id_in_subscription() -> None:
     assert client.last_create["request"]["subscriptions"] == [{"name": "general", "folder_id": 10}]
 
 
+@pytest.mark.parametrize("bad_folder_id", [0, -1, True, False])
+def test_create_channel_rejects_invalid_folder_id(bad_folder_id: int) -> None:
+    """Channel create validates folder assignments before API calls."""
+    client = _folder_client()
+    with pytest.raises(ZulipValidationError, match="positive integer"):
+        create_channel(client, name="general", folder_id=bad_folder_id, folder_id_specified=True)
+    assert not any(call["url"] == "users/me/subscriptions" for call in client.last_requests)
+
+
 def test_update_channel_folder_id_and_clear() -> None:
     """Channel update sends folder_id for assignment and clearing."""
     client = _folder_client()
@@ -218,6 +227,15 @@ def test_update_channel_folder_id_and_clear() -> None:
     result = update_channel(client, name="general", folder_id=None, folder_id_specified=True)
     assert result["folder_id"] is None
     assert client.last_patch["request"] == {"folder_id": None}
+
+
+@pytest.mark.parametrize("bad_folder_id", [0, -1, True, False])
+def test_update_channel_rejects_invalid_folder_id(bad_folder_id: int) -> None:
+    """Channel update validates folder assignments before API calls."""
+    client = _folder_client()
+    with pytest.raises(ZulipValidationError, match="positive integer"):
+        update_channel(client, name="general", folder_id=bad_folder_id, folder_id_specified=True)
+    assert not any(call["url"].startswith("streams/") for call in client.last_requests)
 
 
 def test_channel_folder_assignment_feature_gate() -> None:

--- a/tests/unit/test_zulip_folders.py
+++ b/tests/unit/test_zulip_folders.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Tests for Zulip channel folder API and CLI support."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+import lftools_uv.typer_apps.zulip as zulip_cli
+from lftools_uv.api.endpoints.zulip import (
+    FEATURE_LEVELS,
+    ZulipAmbiguityError,
+    ZulipAPIError,
+    ZulipFeatureLevelError,
+    ZulipNotFoundError,
+    ZulipValidationError,
+    archive_channel_folder,
+    create_channel,
+    create_channel_folder,
+    list_channel_folders,
+    resolve_channel_folder_token,
+    unarchive_channel_folder,
+    update_channel,
+    update_channel_folder,
+)
+from lftools_uv.typer_apps.zulip import zulip_app
+from tests.test_utils import clean_cli_output
+
+FOLDERS = [
+    {
+        "id": 10,
+        "name": "Projects",
+        "description": "Project channels",
+        "rendered_description": "<p>Project channels</p>",
+        "order": 1,
+        "is_archived": False,
+        "date_created": 1761955200,
+        "creator_id": 42,
+    },
+    {
+        "id": 11,
+        "name": "Old Projects",
+        "description": "Archived projects",
+        "rendered_description": "<p>Archived projects</p>",
+        "is_archived": True,
+        "date_created": 1761955300,
+        "creator_id": 43,
+    },
+]
+
+
+def _folder_client(
+    *,
+    feature_level: int = 500,
+    folders: list[dict[str, Any]] | None = None,
+    folder_response: dict[str, Any] | None = None,
+    limits: dict[str, int] | None = None,
+    streams: list[dict[str, Any]] | None = None,
+) -> mock.MagicMock:
+    """Return a mock Zulip client wired for folder operations."""
+    client = mock.MagicMock()
+    client.get_server_settings.return_value = {
+        "result": "success",
+        "zulip_feature_level": feature_level,
+    }
+    folder_list = FOLDERS if folders is None else folders
+    streams_list = streams if streams is not None else [{"stream_id": 1, "name": "general", "is_archived": False}]
+    client.last_requests = []
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> dict[str, Any]:
+        client.last_requests.append({"url": url, "method": method, "request": request})
+        if url == "register" and method == "GET":
+            return {"result": "success", **(limits or {})}
+        if url == "channel_folders" and method == "GET":
+            include_archived = bool((request or {}).get("include_archived"))
+            visible = (
+                folder_list if include_archived else [folder for folder in folder_list if not folder.get("is_archived")]
+            )
+            return {"result": "success", "channel_folders": visible}
+        if url == "channel_folders/create" and method == "POST":
+            return folder_response or {"result": "success", "channel_folder_id": 99}
+        if url.startswith("channel_folders/") and method == "PATCH":
+            return folder_response or {"result": "success"}
+        if url == "streams" and method == "GET":
+            return {"result": "success", "streams": streams_list}
+        if url.startswith("streams/") and method == "PATCH":
+            client.last_patch = {"url": url, "request": request}
+            return {"result": "success"}
+        if url == "users/me/subscriptions" and method == "POST":
+            client.last_create = {"url": url, "request": request}
+            return {"result": "success", "subscribed": {}}
+        return {"result": "error", "msg": f"unexpected endpoint {method} {url}"}
+
+    client.call_endpoint.side_effect = call_endpoint
+    return client
+
+
+# API helpers
+
+
+def test_feature_level_table_contains_folder_keys() -> None:
+    """Feature level constants document folder support thresholds."""
+    assert FEATURE_LEVELS["channel-folders"] == 389
+    assert FEATURE_LEVELS["channel-folders-order"] == 414
+
+
+def test_list_channel_folders_active_only_and_missing_order() -> None:
+    """Default folder listing filters archived folders and tolerates no order."""
+    client = _folder_client()
+    folders = list_channel_folders(client)
+    assert [folder["id"] for folder in folders] == [10]
+    assert folders[0]["order"] == 1
+
+    all_folders = list_channel_folders(client, include_archived=True)
+    assert [folder["id"] for folder in all_folders] == [10, 11]
+    assert all_folders[1]["order"] is None
+
+
+def test_list_channel_folders_limit_and_feature_gate() -> None:
+    """Folder list supports --limit and fails before API calls below FL 389."""
+    client = _folder_client(folders=[{**FOLDERS[0], "id": idx, "name": f"f{idx}"} for idx in range(5)])
+    assert [folder["id"] for folder in list_channel_folders(client, limit=2)] == [0, 1]
+
+    old_client = _folder_client(feature_level=388)
+    with pytest.raises(ZulipFeatureLevelError):
+        list_channel_folders(old_client)
+    assert not any(call["url"] == "channel_folders" for call in old_client.last_requests)
+
+
+def test_create_channel_folder_payload_and_limits() -> None:
+    """Create sends name/description and validates known length limits."""
+    client = _folder_client(limits={"max_channel_folder_name_length": 20, "max_channel_folder_description_length": 30})
+    result = create_channel_folder(client, "Projects", "Project channels")
+    assert result == {"status": "success", "folder_id": 99, "folder_name": "Projects", "operation": "create"}
+    create_call = next(call for call in client.last_requests if call["url"] == "channel_folders/create")
+    assert create_call["request"] == {"name": "Projects", "description": "Project channels"}
+
+    with pytest.raises(ZulipValidationError, match="Folder name"):
+        create_channel_folder(client, "", "")
+    with pytest.raises(ZulipValidationError, match="description"):
+        create_channel_folder(client, "Projects", "x" * 31)
+
+
+def test_update_archive_unarchive_channel_folder_payloads() -> None:
+    """Update and archive wrappers PATCH only requested fields."""
+    client = _folder_client()
+    result = update_channel_folder(client, 10, name="Engineering")
+    assert result["operation"] == "update"
+    patch_call = next(call for call in client.last_requests if call["url"] == "channel_folders/10")
+    assert patch_call["request"] == {"name": "Engineering"}
+
+    client = _folder_client()
+    archive_channel_folder(client, 10)
+    assert client.last_requests[-1]["request"] == {"is_archived": True}
+
+    client = _folder_client()
+    unarchive_channel_folder(client, 10)
+    assert client.last_requests[-1]["request"] == {"is_archived": False}
+
+
+def test_folder_mutation_permission_errors_surface_as_api_errors() -> None:
+    """Server permission errors are not preflighted client-side."""
+    client = _folder_client(folder_response={"result": "error", "msg": "Insufficient permission"})
+    with pytest.raises(ZulipAPIError, match="Insufficient permission"):
+        create_channel_folder(client, "Projects")
+
+
+def test_resolve_channel_folder_token_variants() -> None:
+    """Folder resolver accepts names, id:N, none, and numeric-name hints."""
+    client = _folder_client(folders=[*FOLDERS, {**FOLDERS[0], "id": 12, "name": "123"}])
+    assert resolve_channel_folder_token(client, "projects") == 10
+    assert resolve_channel_folder_token(client, "id:11") == 11
+    assert resolve_channel_folder_token(client, "none") is None
+    assert resolve_channel_folder_token(client, "123") == 12
+
+    with pytest.raises(ZulipNotFoundError, match="id:999"):
+        resolve_channel_folder_token(client, "999")
+    with pytest.raises(ZulipValidationError, match="positive"):
+        resolve_channel_folder_token(client, "id:0")
+
+
+def test_resolve_channel_folder_token_ambiguity() -> None:
+    """Duplicate folder names raise ambiguity with disambiguation matches."""
+    client = _folder_client(folders=[FOLDERS[0], {**FOLDERS[0], "id": 12, "name": "projects"}])
+    with pytest.raises(ZulipAmbiguityError) as exc_info:
+        resolve_channel_folder_token(client, "Projects")
+    assert {match["id"] for match in exc_info.value.matches} == {10, 12}
+
+
+def test_create_channel_with_folder_id_in_subscription() -> None:
+    """Channel create includes folder_id in the subscription payload."""
+    client = _folder_client(streams=[{"stream_id": 42, "name": "general", "is_archived": False}])
+    result = create_channel(client, name="general", folder_id=10, folder_id_specified=True)
+    assert result["folder_id"] == 10
+    assert client.last_create["request"]["subscriptions"] == [{"name": "general", "folder_id": 10}]
+
+
+def test_update_channel_folder_id_and_clear() -> None:
+    """Channel update sends folder_id for assignment and clearing."""
+    client = _folder_client()
+    result = update_channel(client, name="general", folder_id=10, folder_id_specified=True)
+    assert result["folder_id"] == 10
+    assert client.last_patch["request"] == {"folder_id": 10}
+
+    client = _folder_client()
+    result = update_channel(client, name="general", folder_id=None, folder_id_specified=True)
+    assert result["folder_id"] is None
+    assert client.last_patch["request"] == {"folder_id": None}
+
+
+def test_channel_folder_assignment_feature_gate() -> None:
+    """Channel folder assignment fails before mutation below FL 389."""
+    client = _folder_client(feature_level=388)
+    with pytest.raises(ZulipFeatureLevelError):
+        create_channel(client, name="general", folder_id=10, folder_id_specified=True)
+    assert not any(call["url"] == "users/me/subscriptions" for call in client.last_requests)
+
+
+# CLI commands
+
+
+def _patch_cli_client(monkeypatch: pytest.MonkeyPatch, client: mock.MagicMock) -> None:
+    monkeypatch.setattr(zulip_cli, "get_client", lambda **_kw: client)
+    monkeypatch.setattr(zulip_cli, "zulip_available", lambda: True)
+
+
+def test_folder_list_cli_table_json_and_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Folder list renders table and JSON contracts."""
+    client = _folder_client()
+    _patch_cli_client(monkeypatch, client)
+    runner = CliRunner()
+
+    result = runner.invoke(zulip_app, ["folder", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Folder ID" in result.stdout
+    assert "Projects" in result.stdout
+    assert "Old Projects" not in result.stdout
+    assert "Status" not in result.stdout
+
+    result = runner.invoke(zulip_app, ["folder", "list", "--include-archived"])
+    assert result.exit_code == 0, result.output
+    assert "Status" in result.stdout
+    assert "Archived" in result.stdout
+
+    result = runner.invoke(zulip_app, ["--json", "folder", "list", "--include-archived", "--limit", "1"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert list(payload) == ["folders"]
+    assert len(payload["folders"]) == 1
+
+
+def test_folder_mutation_cli_success_and_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Folder create/update/archive/unarchive CLI paths emit mutation JSON."""
+    client = _folder_client()
+    _patch_cli_client(monkeypatch, client)
+    runner = CliRunner()
+
+    result = runner.invoke(zulip_app, ["--json", "folder", "create", "--name", "Projects"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["operation"] == "create"
+
+    result = runner.invoke(zulip_app, ["folder", "update", "--folder-id", "10"])
+    assert result.exit_code == 1
+    assert "at least one" in (result.stdout + result.stderr)
+
+    result = runner.invoke(zulip_app, ["--json", "folder", "update", "--folder-id", "10", "--name", "Engineering"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["operation"] == "update"
+
+    result = runner.invoke(zulip_app, ["--json", "folder", "archive", "--folder-id", "10"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["operation"] == "archive"
+
+    result = runner.invoke(zulip_app, ["--json", "folder", "unarchive", "--folder-id", "10"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["operation"] == "unarchive"
+
+
+def test_folder_cli_feature_level_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Folder commands surface canonical feature-level errors."""
+    client = _folder_client(feature_level=388)
+    _patch_cli_client(monkeypatch, client)
+    result = CliRunner().invoke(zulip_app, ["folder", "list"])
+    assert result.exit_code == 1
+    assert "feature level 389" in (result.stdout + result.stderr)
+
+
+def test_channel_create_cli_folder_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Channel create --folder resolves names and sends folder_id."""
+    client = _folder_client(streams=[{"stream_id": 42, "name": "new-project", "is_archived": False}])
+    _patch_cli_client(monkeypatch, client)
+    result = CliRunner().invoke(zulip_app, ["--json", "channel", "create", "new-project", "--folder", "Projects"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["folder_id"] == 10
+    assert client.last_create["request"]["subscriptions"][0]["folder_id"] == 10
+
+
+def test_channel_update_cli_folder_variants(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Channel update supports --folder id:N, none, and --folder-id 0."""
+    client = _folder_client()
+    _patch_cli_client(monkeypatch, client)
+    runner = CliRunner()
+
+    result = runner.invoke(zulip_app, ["--json", "channel", "update", "general", "--folder", "id:10"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["folder_id"] == 10
+    assert client.last_patch["request"] == {"folder_id": 10}
+
+    result = runner.invoke(zulip_app, ["--json", "channel", "update", "general", "--folder", "none"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["folder_id"] is None
+    assert client.last_patch["request"] == {"folder_id": None}
+
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--folder-id", "0"])
+    assert result.exit_code == 0, result.output
+    assert client.last_patch["request"] == {"folder_id": None}
+
+    result = runner.invoke(zulip_app, ["channel", "update", "general", "--folder-id", "10"])
+    assert result.exit_code == 1
+    assert "--folder id:N" in (result.stdout + result.stderr)
+
+
+def test_channel_update_cli_no_folder_preserves_behavior(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing channel update flags still work without folder options."""
+    client = _folder_client()
+    _patch_cli_client(monkeypatch, client)
+    result = CliRunner().invoke(zulip_app, ["channel", "update", "general", "--description", "new"])
+    assert result.exit_code == 0, result.output
+    assert client.last_patch["request"] == {"description": "new"}
+
+
+def test_folder_help_output_has_no_spec_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    """New folder help text avoids leaking internal spec identifiers."""
+    monkeypatch.setattr(zulip_cli, "zulip_available", lambda: True)
+    runner = CliRunner()
+    for args in (
+        ["folder", "--help"],
+        ["folder", "list", "--help"],
+        ["folder", "create", "--help"],
+        ["channel", "create", "--help"],
+        ["channel", "update", "--help"],
+    ):
+        result = runner.invoke(zulip_app, args, env={"COLUMNS": "200", "NO_COLOR": "1", "TERM": "dumb"})
+        assert result.exit_code == 0, result.output
+        cleaned = clean_cli_output(result.output)
+        assert "--folder" in cleaned or args[0] == "folder"
+        assert "US#" not in cleaned
+        assert "T###" not in cleaned
+        assert "FR-###" not in cleaned

--- a/tests/unit/test_zulip_folders.py
+++ b/tests/unit/test_zulip_folders.py
@@ -138,6 +138,9 @@ def test_list_channel_folders_limit_and_feature_gate() -> None:
         list_channel_folders(old_client)
     assert not any(call["url"] == "channel_folders" for call in old_client.last_requests)
 
+    with pytest.raises(ZulipValidationError, match="non-negative integer"):
+        list_channel_folders(client, limit=1.5)  # type: ignore[arg-type]
+
 
 def test_create_channel_folder_payload_and_limits() -> None:
     """Create sends name/description and validates known length limits."""
@@ -160,6 +163,9 @@ def test_update_archive_unarchive_channel_folder_payloads() -> None:
     assert result["operation"] == "update"
     patch_call = next(call for call in client.last_requests if call["url"] == "channel_folders/10")
     assert patch_call["request"] == {"name": "Engineering"}
+
+    with pytest.raises(ZulipValidationError, match="positive integer"):
+        update_channel_folder(client, 1.5, name="Engineering")  # type: ignore[arg-type]
 
     client = _folder_client()
     archive_channel_folder(client, 10)


### PR DESCRIPTION
## Summary

- Add Zulip channel-folder API helpers and feature-level gating.
- Add `lftools zulip folder list/create/update/archive/unarchive`.
- Add `--folder` to channel create/update, including clearing with `--folder none` and `--folder-id 0`.
- Add unit and CLI coverage for folder helpers, resolver behavior, mutations, and help output.

## Spec

Implements feature spec merged in #436: `specs/002-zulip-channel-folders/`

## Locked design decisions

- Single `--folder` flag accepts NAME or `id:N`.
- `--folder none` and `--folder-id 0` clear assignment.
- Folder feature levels are 389 and order support is 414.
- Numeric-not-found hints mirror group-token resolver behavior.
- Folder mutations remain server-side admin-enforced.

## Testing

- `uv run pytest tests/unit/test_zulip_folders.py tests/unit/test_zulip_api.py tests/unit/test_zulip_cli.py -x -q` — 345 passed.
- `uv run pytest tests/ -x -q` — 727 passed.
- `uv run ruff check .` — passed.
- `uv run mypy lftools_uv` — passed.
- `SKIP=basedpyright pre-commit run --all-files` — passed.
- Spot-checked new folder help and updated channel create/update help.