### PR TITLE
Feat(zulip): Add folder move command

### DIFF
--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1012,6 +1012,8 @@ def plan_folder_move(
     """Return the folder order produced by moving a folder."""
     if position not in ("before", "after"):
         raise ZulipValidationError(f"Invalid folder move position: {position!r}")
+    _validate_channel_folder_assignment_id(target_id)
+    _validate_channel_folder_assignment_id(reference_id)
     if target_id == reference_id:
         raise ZulipValidationError("Cannot move folder relative to itself")
     if target_id not in current_order:

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1011,13 +1011,13 @@ def plan_folder_move(
 ) -> list[int]:
     """Return the folder order produced by moving a folder."""
     if position not in ("before", "after"):
-        raise ValueError(f"Invalid folder move position: {position!r}")
+        raise ZulipValidationError(f"Invalid folder move position: {position!r}")
     if target_id == reference_id:
-        raise ValueError("Cannot move folder relative to itself")
+        raise ZulipValidationError("Cannot move folder relative to itself")
     if target_id not in current_order:
-        raise ValueError(f"Target folder id {target_id} not found")
+        raise ZulipNotFoundError(f"Target folder id {target_id} not found")
     if reference_id not in current_order:
-        raise ValueError(f"Reference folder id {reference_id} not found")
+        raise ZulipNotFoundError(f"Reference folder id {reference_id} not found")
 
     new_order = [folder_id for folder_id in current_order if folder_id != target_id]
     insert_at = new_order.index(reference_id)

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -978,23 +978,81 @@ def unarchive_channel_folder(client: Any, folder_id: int) -> dict[str, Any]:
     return update_channel_folder(client, folder_id, is_archived=False)
 
 
-def resolve_channel_folder_token(client: Any, token: str) -> int | None:
-    """Resolve a folder token for channel assignment.
+def reorder_channel_folders(client: Any, order: list[int]) -> dict[str, Any]:
+    """Reorder all channel folders via ``PATCH /channel_folders``.
 
-    Accepts a case-insensitive folder name, ``id:N`` for explicit ID
-    lookup, or ``none`` to clear the assignment. Numeric-looking names
-    are treated as names; if absent, the error hints to use ``id:N``.
+    Zulip requires feature level 414 and expects ``order`` as a
+    JSON-encoded array containing every channel folder ID exactly once.
+    The server enforces admin-only permissions and validates completeness.
     """
-    check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
+    check_feature_level(client, FEATURE_LEVELS["channel-folders-order"], "channel-folders-order")
+    for folder_id in order:
+        _validate_channel_folder_assignment_id(folder_id)
+    request = {"order": json.dumps(order)}
+    try:
+        response = client.call_endpoint(
+            url="channel_folders",
+            method="PATCH",
+            request=request,
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ZulipAPIError(f"Failed to reorder channel folders: {exc}") from exc
+    if not isinstance(response, dict) or response.get("result") != "success":
+        msg = response.get("msg") if isinstance(response, dict) else None
+        raise ZulipAPIError(f"Failed to reorder channel folders: {msg or response!r}")
+    return response
+
+
+def plan_folder_move(
+    current_order: list[int],
+    target_id: int,
+    reference_id: int,
+    position: Literal["before", "after"],
+) -> list[int]:
+    """Return the folder order produced by moving a folder."""
+    if position not in ("before", "after"):
+        raise ValueError(f"Invalid folder move position: {position!r}")
+    if target_id == reference_id:
+        raise ValueError("Cannot move folder relative to itself")
+    if target_id not in current_order:
+        raise ValueError(f"Target folder id {target_id} not found")
+    if reference_id not in current_order:
+        raise ValueError(f"Reference folder id {reference_id} not found")
+
+    new_order = [folder_id for folder_id in current_order if folder_id != target_id]
+    insert_at = new_order.index(reference_id)
+    if position == "after":
+        insert_at += 1
+    new_order.insert(insert_at, target_id)
+    return new_order
+
+
+def _resolve_single_channel_folder_token(
+    token: str,
+    folders: list[dict[str, Any]],
+    *,
+    allow_none: bool,
+    bare_int_is_id: bool,
+    option_name: str,
+) -> int | None:
+    """Resolve one folder token against an already-fetched folder list."""
     token = token.strip()
     if not token:
-        raise ZulipValidationError("--folder must not be empty")
-    if token.casefold() == "none":
+        raise ZulipValidationError(f"{option_name} must not be empty")
+    if allow_none and token.casefold() == "none":
         return None
 
-    folders = list_channel_folders(client, include_archived=True)
+    id_lookup = False
     if token.casefold().startswith("id:"):
         suffix = token[3:].strip()
+        id_lookup = True
+    elif bare_int_is_id and token.isdigit():
+        suffix = token
+        id_lookup = True
+    else:
+        suffix = ""
+
+    if id_lookup:
         try:
             wanted = int(suffix)
         except ValueError as exc:
@@ -1004,6 +1062,10 @@ def resolve_channel_folder_token(client: Any, token: str) -> int | None:
         for folder in folders:
             if folder["id"] == wanted:
                 return wanted
+        if bare_int_is_id and token.isdigit():
+            raise ZulipNotFoundError(
+                f"No channel folder with id {wanted}. If you meant a numeric folder ID, use 'id:{wanted}'."
+            )
         raise ZulipNotFoundError(f"No channel folder with id {wanted}")
 
     target = token.casefold()
@@ -1025,6 +1087,38 @@ def resolve_channel_folder_token(client: Any, token: str) -> int | None:
     if not isinstance(folder_id, int):
         raise ZulipAPIError(f"Resolved folder missing numeric id: {matches[0]!r}")
     return folder_id
+
+
+def resolve_channel_folder_reference(token: str, folders: list[dict[str, Any]]) -> int:
+    """Resolve a folder move reference from name, ``id:N``, or bare ID."""
+    folder_id = _resolve_single_channel_folder_token(
+        token,
+        folders,
+        allow_none=False,
+        bare_int_is_id=True,
+        option_name="folder reference",
+    )
+    if folder_id is None:  # pragma: no cover - allow_none=False
+        raise ZulipValidationError("folder reference must identify a folder")
+    return folder_id
+
+
+def resolve_channel_folder_token(client: Any, token: str) -> int | None:
+    """Resolve a folder token for channel assignment.
+
+    Accepts a case-insensitive folder name, ``id:N`` for explicit ID
+    lookup, or ``none`` to clear the assignment. Numeric-looking names
+    are treated as names; if absent, the error hints to use ``id:N``.
+    """
+    check_feature_level(client, FEATURE_LEVELS["channel-folders"], "channel-folders")
+    folders = list_channel_folders(client, include_archived=True)
+    return _resolve_single_channel_folder_token(
+        token,
+        folders,
+        allow_none=True,
+        bare_int_is_id=False,
+        option_name="--folder",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -48,7 +48,10 @@ from lftools_uv.api.endpoints.zulip import (
     list_groups,
     list_subscribers,
     list_users,
+    plan_folder_move,
+    reorder_channel_folders,
     resolve_channel,
+    resolve_channel_folder_reference,
     resolve_channel_folder_token,
     set_topic_policy,
     subscribe_users,
@@ -479,6 +482,74 @@ def folder_unarchive(
 ) -> None:
     """Reactivate an archived channel folder."""
     _folder_archive_common(ctx, folder_id=folder_id, json_output=json_output, archive=False)
+
+
+def _current_folder_order(folders: list[dict[str, Any]]) -> list[int]:
+    """Return folder IDs in the server's current order."""
+    indexed: list[tuple[bool, int, int, int]] = []
+    for index, folder in enumerate(folders):
+        folder_id = folder.get("id")
+        if not isinstance(folder_id, int) or isinstance(folder_id, bool):
+            raise ValueError(f"Channel folder missing numeric id: {folder!r}")
+        order = folder.get("order")
+        if isinstance(order, int) and not isinstance(order, bool):
+            indexed.append((False, order, index, folder_id))
+        else:
+            indexed.append((True, index, index, folder_id))
+    return [folder_id for _missing, _order, _index, folder_id in sorted(indexed)]
+
+
+@folder_app.command("move")
+def folder_move(
+    ctx: typer.Context,
+    folder_id: int = typer.Option(..., "--folder-id", help="Folder ID to move."),
+    before: str | None = typer.Option(None, "--before", help="Move before this folder name, id:NUM, or ID."),
+    after: str | None = typer.Option(None, "--after", help="Move after this folder name, id:NUM, or ID."),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of text.",
+        hidden=True,
+    ),
+) -> None:
+    """Move a channel folder before or after another folder."""
+    if (before is None) == (after is None):
+        emit_error("Exactly one of --before or --after is required")
+        raise typer.Exit(code=1)
+
+    options = {**(ctx.obj or {})}
+    if json_output:
+        options["json_output"] = True
+    position: Literal["before", "after"] = "before" if before is not None else "after"
+    reference_token = before if before is not None else after
+    assert reference_token is not None
+
+    try:
+        client = get_client(zuliprc=options.get("zuliprc"))
+        folders = list_channel_folders(client, include_archived=True)
+        reference_id = resolve_channel_folder_reference(reference_token, folders)
+        current_order = _current_folder_order(folders)
+        new_order = plan_folder_move(current_order, folder_id, reference_id, position)
+        reorder_channel_folders(client, new_order)
+    except ValueError as exc:
+        emit_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    except ZulipError as exc:
+        raise handle_zulip_error(exc) from exc
+
+    if options.get("json_output"):
+        emit_json(
+            {
+                "status": "success",
+                "operation": "move",
+                "folder_id": folder_id,
+                "reference_folder_id": reference_id,
+                "position": position,
+                "order": new_order,
+            }
+        )
+    else:
+        typer.echo(f"Moved folder {folder_id} {position} folder {reference_id}", err=True)
 
 
 def _resolve_channel_target(channel: str | None, channel_id: str | None) -> None:

--- a/specs/002-zulip-channel-folders/contracts/cli-commands.md
+++ b/specs/002-zulip-channel-folders/contracts/cli-commands.md
@@ -194,6 +194,64 @@ server.
 
 ---
 
+## `lftools-uv zulip folder move`
+
+**Description**: Move a channel folder before or after another folder.
+Admin-only on the Zulip server.
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `--folder-id` | int | Yes | Folder ID to move |
+| `--before` | str | One of before/after | Reference folder to move before |
+| `--after` | str | One of before/after | Reference folder to move after |
+
+**Reference syntax**:
+
+- `--before Projects` resolves a folder by case-insensitive name.
+- `--after id:10` resolves folder ID 10 explicitly.
+- `--before 10` treats bare numeric references as folder ID 10.
+
+**Constraints**:
+
+- Requires Zulip feature level 414 (`channel-folders-order`).
+- Exactly one of `--before` or `--after` is required.
+- The target folder ID must exist in the complete folder list.
+- The reference folder must resolve to an existing folder.
+- The target and reference folders must differ.
+- The CLI lists folders with `include_archived=true` so the order sent to Zulip
+  includes every channel folder ID exactly once.
+- Calls `PATCH /api/v1/channel_folders` with `order` set to a JSON-encoded
+  array, for example `order=[12,10,11]`.
+- Permission and invalid-order errors are surfaced from Zulip.
+
+**Human Output**: Prints a short move confirmation to stderr.
+
+**JSON Output** (success):
+
+```json
+{
+  "status": "success",
+  "operation": "move",
+  "folder_id": 12,
+  "reference_folder_id": 10,
+  "position": "before",
+  "order": [12, 10, 11]
+}
+```
+
+**Errors**:
+
+```text
+Error: Exactly one of --before or --after is required
+Error: Cannot move folder relative to itself
+Error: Target folder id 99 not found
+Error: No channel folder with id 999. If you meant a numeric folder ID, use 'id:999'.
+```
+
+**Exit Codes**: 0 = success, 1 = error
+
+---
+
 ## Updated `lftools-uv zulip channel create <name>`
 
 **Description**: Create a new channel, optionally assigned to a folder.
@@ -261,3 +319,5 @@ Error: This operation requires Zulip feature level 389 (server has 388)
 
 Folder list keeps a stable `Order` column even when `order` is absent before FL
 414. Missing order values are rendered blank in tables and `null` in JSON.
+`folder move` is the exception: it requires FL 414 before attempting the bulk
+reorder mutation.

--- a/specs/002-zulip-channel-folders/data-model.md
+++ b/specs/002-zulip-channel-folders/data-model.md
@@ -33,8 +33,12 @@ Represents a Zulip channel folder returned by the channel folders API.
   `max_channel_folder_description_length` when that `/register` value is
   available.
 - `order` may be `None` when connected to servers at FL 389 through FL 413.
+- `order` is mutable at FL 414 and newer through the bulk reorder endpoint.
+  Reorder requests must include every channel folder ID exactly once.
 - Folder mutation commands require Zulip feature level 389 and admin
   permissions enforced by the server.
+- Folder move requires Zulip feature level 414 and admin permissions enforced
+  by the server.
 
 **State Transitions**:
 
@@ -47,6 +51,8 @@ Represents a Zulip channel folder returned by the channel folders API.
 ```
 
 There is no hard-delete transition. Zulip only exposes archival.
+Moving a folder changes its relative `order` value through
+`PATCH /api/v1/channel_folders`; it does not change the active/archive state.
 
 ---
 
@@ -80,7 +86,7 @@ Standard response schema for folder mutation operations.
 | `status` | `str (enum)` | Outcome: success or error |
 | `folder_id` | `int \| None` | Folder ID, if known |
 | `folder_name` | `str \| None` | Folder name, if known |
-| `operation` | `str` | create/update/archive/unarchive |
+| `operation` | `str` | create/update/archive/unarchive/move |
 
 ## Relationships
 

--- a/specs/002-zulip-channel-folders/plan.md
+++ b/specs/002-zulip-channel-folders/plan.md
@@ -12,15 +12,17 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
 ## Summary
 
 Add Zulip channel folder management commands to lftools-uv, providing CLI
-commands for listing, creating, updating, archiving, and unarchiving channel
-folders, plus folder assignment on existing channel create/update workflows.
-The implementation extends the existing Zulip API layer
+commands for listing, creating, updating, archiving, unarchiving, and moving
+channel folders, plus folder assignment on existing channel create/update
+workflows. The implementation extends the existing Zulip API layer
 (`lftools_uv/api/endpoints/zulip.py`) and Typer presentation layer
 (`lftools_uv/typer_apps/zulip.py`). Runtime feature-level detection gates all
 folder behavior at Zulip feature level 389, while folder ordering is treated as
-optional until feature level 414. The CLI uses one `--folder` assignment flag
-accepting names, `id:N`, or `none`; `--folder-id 0` is accepted only for the
-explicit clear behavior locked by the spec.
+optional until feature level 414. The `folder move` command uses Zulip's bulk
+`PATCH /api/v1/channel_folders` reorder API at FL 414 and exposes semantic
+`--before`/`--after` placement instead of a raw order array. The CLI uses one
+`--folder` assignment flag accepting names, `id:N`, or `none`; `--folder-id 0`
+is accepted only for the explicit clear behavior locked by the spec.
 
 ## Technical Context
 
@@ -34,9 +36,9 @@ for CLI tests
 **Project Type**: CLI tool (extending existing multi-command CLI)
 **Performance Goals**: List operations <5s for 100 folders (SC-009)
 **Constraints**: Feature-level gate at FL 389; folder `order` optional before
-FL 414; no hard-delete endpoint
-**Scale/Scope**: Single Zulip server per invocation; channel folder lifecycle
-and channel assignment only
+FL 414; folder move requires FL 414; no hard-delete endpoint
+**Scale/Scope**: Single Zulip server per invocation; channel folder lifecycle,
+ordering, and channel assignment only
 
 ## Constitution Check
 
@@ -100,9 +102,11 @@ manageable.
 
 Research confirms Zulip channel folders are exposed by the
 `/api/v1/channel_folders` resource family, new in Zulip 11.0 at feature level
-389. Folder order is available starting at feature level 414. There is no
-hard-delete endpoint; archive and unarchive use the update endpoint. Channel
-assignment uses existing stream create/update endpoints with `folder_id`.
+389. Folder order is available starting at feature level 414, and bulk reorder
+uses `PATCH /api/v1/channel_folders` with a complete JSON-encoded `order`
+array. There is no hard-delete endpoint; archive and unarchive use the update
+endpoint. Channel assignment uses existing stream create/update endpoints with
+`folder_id`.
 
 See `research.md` for details and API references.
 
@@ -129,6 +133,7 @@ Tasks map FRs to implementation phases:
 | F5 | Channel `--folder` integration | FR-028, FR-029 |
 | F6 | Tests | FR-023 through FR-036 |
 | F7 | Spec sync and help text | FR-037 |
+| F8 | Folder move and reorder | FR-038 |
 
 ## Testing Approach
 
@@ -139,16 +144,18 @@ Tasks map FRs to implementation phases:
   permission error propagation.
 - Add channel create/update tests covering `--folder` by name, `id:N`, numeric
   not-found hint, `none`, and `--folder-id 0` clearing.
+- Add folder move tests covering reorder payloads, FL 414 gating, before/after
+  planning, name/`id:N`/bare-ID references, self-move rejection, missing target
+  and reference errors, and server error propagation.
 - Add feature-level tests for FL 388 rejection, FL 389 success without order,
   and FL 414 order display.
 - Run `uv run pytest tests/`, `uv run ruff check .`, `uv run mypy lftools_uv`,
-  and `uv run basedpyright` before implementation PRs. For this spec-only PR,
-  run pre-commit with the repository's accepted `SKIP=basedpyright` setting.
+  and pre-commit with the repository's accepted `SKIP=basedpyright` setting
+  before implementation PRs.
 
 ## Out of Scope
 
-- Implementation code in this PR.
 - Per-user folder ordering changes; no API exists as of FL 389.
-- Bulk folder reorder.
+- A raw `folder reorder --order ID,ID,ID` command.
 - Hard-delete of channel folders; Zulip exposes archive only.
 - Client-side role pre-flight checks for admin-only folder mutations.

--- a/specs/002-zulip-channel-folders/quickstart.md
+++ b/specs/002-zulip-channel-folders/quickstart.md
@@ -17,7 +17,8 @@ SPDX-FileCopyrightText: 2026 The Linux Foundation
   ```
 
 - A Zulip server at feature level 389 or newer for channel folders
-- Organization admin permissions for folder create/update/archive/unarchive
+- A Zulip server at feature level 414 or newer for folder move
+- Organization admin permissions for folder create/update/archive/unarchive/move
 - A zuliprc file or equivalent configuration
 
 ## Configuration
@@ -76,6 +77,20 @@ lftools-uv zulip folder archive --folder-id 10
 
 # Restore an archived folder
 lftools-uv zulip folder unarchive --folder-id 10
+```
+
+### Move folders
+
+```bash
+# Move a folder before another folder by name
+lftools-uv zulip folder move \
+  --folder-id 12 \
+  --before "Projects"
+
+# Move a folder after another folder by ID
+lftools-uv zulip folder move \
+  --folder-id 10 \
+  --after id:12
 ```
 
 ### Create a channel in a folder

--- a/specs/002-zulip-channel-folders/research.md
+++ b/specs/002-zulip-channel-folders/research.md
@@ -131,3 +131,24 @@ the source of truth.
 
 - Fetch user role and reject locally: Rejected — duplicates server policy and
   risks false negatives.
+
+## Decision 8: Folder Move Uses Bulk Reorder API
+
+**Decision**: Implement folder reordering with
+`PATCH /api/v1/channel_folders`, sending `order` as a JSON-encoded form value
+containing every channel folder ID exactly once. Expose this through
+`zulip folder move --folder-id N --before REF` and
+`zulip folder move --folder-id N --after REF`, where `REF` accepts a folder
+name, `id:N`, or a bare numeric folder ID.
+
+**Rationale**: Zulip's API only accepts complete bulk order mappings; it does
+not provide a single-folder move endpoint. The CLI can safely derive the
+complete order from the current folder list while presenting a semantic UX that
+matches how administrators think about moving one folder relative to another.
+
+**Alternatives Considered**:
+
+- Raw `folder reorder --order ID,ID,ID`: Rejected — it exposes the low-level API
+  shape and makes it easy for users to omit or duplicate IDs.
+- Per-user folder ordering: Rejected — the API updates organization-wide folder
+  order, and per-user ordering is outside this command's scope.

--- a/specs/002-zulip-channel-folders/spec.md
+++ b/specs/002-zulip-channel-folders/spec.md
@@ -40,6 +40,16 @@ folders, including folder lifecycle commands and channel folder assignment."
 - Q: Should archive/unarchive be flags on update? → A: No. Use separate
   `archive` and `unarchive` commands to match the existing channel UX.
 
+### Session 2026-06-09
+
+- Q: How should administrators reorder folders? → A: Add
+  `zulip folder move --folder-id N --before REF` and
+  `zulip folder move --folder-id N --after REF`, where `REF` is a folder
+  name, `id:N`, or bare numeric ID.
+- Q: Should the CLI expose a raw order array? → A: No. Use semantic
+  before/after placement and compute the complete order required by Zulip's
+  bulk reorder API.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Discover channel folders (Priority: P1)
@@ -119,6 +129,33 @@ feature-level errors, and propagated API permission failures.
    it with `--folder none` or `--folder-id 0`, **Then** the update payload
    includes `folder_id: null`.
 
+---
+
+### User Story 4 - Reorder channel folders (Priority: P2)
+
+An organization administrator can move one channel folder before or after
+another folder without manually constructing the complete folder order.
+
+**Why this priority**: Folder order controls the navigation and organization
+experience after folders exist. A semantic move command avoids error-prone raw
+bulk order arrays.
+
+**Independent Test**: Mock `GET /api/v1/channel_folders` and
+`PATCH /api/v1/channel_folders`, then verify `folder move` resolves references,
+plans the complete order, gates at feature level 414, and propagates Zulip
+validation or permission errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** folders Projects, Engineering, and Archive, **When** the admin runs
+   `zulip folder move --folder-id 12 --before Projects`, **Then** the CLI sends
+   an order placing folder 12 before Projects.
+2. **Given** folder IDs 10 and 12, **When** the admin runs
+   `zulip folder move --folder-id 10 --after id:12`, **Then** the CLI sends an
+   order placing folder 10 after folder 12.
+3. **Given** a numeric reference `12`, **When** the admin uses it with
+   `--before` or `--after`, **Then** the CLI treats it as folder ID 12.
+
 ### Edge Cases
 
 - Servers below FL 389 reject all folder commands and `--folder` usage before
@@ -132,6 +169,12 @@ feature-level errors, and propagated API permission failures.
   found, the CLI suggests `--folder id:N` for numeric IDs.
 - Permission errors from admin-only folder mutations are displayed as returned
   by Zulip and are not pre-flight checked by the CLI.
+- `folder move` requires FL 414 because it uses the bulk folder reorder API.
+- `folder move` requires exactly one of `--before` or `--after`.
+- `folder move` rejects moves where the target folder equals the reference
+  folder.
+- `folder move` lists folders with archived entries included so the complete
+  order sent to Zulip preserves every folder ID exactly once.
 - Folder length limits come from `/register` fields
   `max_channel_folder_name_length` and
   `max_channel_folder_description_length`; the CLI validates when those limits
@@ -199,6 +242,16 @@ feature-level errors, and propagated API permission failures.
 - **FR-037**: Contracts and quickstart documentation MUST describe the new
   folder commands, updated channel flags, feature-level gates, and API facts
   from the Zulip channel folders documentation.
+- **FR-038**: System MUST provide a `lftools-uv zulip folder move` command with
+  required `--folder-id` and exactly one of `--before REF` or `--after REF`.
+  `REF` MUST accept a folder name, `id:N`, or bare numeric folder ID. The
+  command MUST fetch the complete folder list including archived folders,
+  compute a complete ID order containing every folder exactly once, and call
+  `PATCH /api/v1/channel_folders` with `order` as a JSON-encoded form value.
+  The command MUST require feature level 414 using the existing
+  `channel-folders-order` gate, reject missing targets or references, reject
+  self-relative moves, and surface server permission or validation errors
+  as-is.
 
 ### Key Entities
 
@@ -224,6 +277,8 @@ feature-level errors, and propagated API permission failures.
   folder commands and `--folder` usage.
 - **SC-013**: JSON output from folder commands is valid parseable JSON and uses
   stable field names for scripting.
+- **SC-014**: Administrators can move a folder before or after another folder
+  with one command, and the server receives a complete valid order array.
 
 ## Assumptions
 
@@ -231,11 +286,12 @@ feature-level errors, and propagated API permission failures.
   and Typer command group from `001-zulip-channel-mgmt` are present.
 - Folder commands use Zulip REST API v1 endpoints documented at
   <https://zulip.com/api/get-channel-folders>,
-  <https://zulip.com/api/create-channel-folder>, and
-  <https://zulip.com/api/update-channel-folder>.
+  <https://zulip.com/api/create-channel-folder>,
+  <https://zulip.com/api/update-channel-folder>, and the bulk reorder
+  `PATCH /api/v1/channel_folders` endpoint.
 - Channel folder APIs are new in Zulip 11.0 at feature level 389. Folder order
   data is available starting at feature level 414.
 - Folder list is available to all authenticated users. Folder mutations are
   admin-only, and channel folder assignment permissions are enforced by Zulip.
-- Per-user folder ordering and bulk folder reorder are out of scope because no
-  API exists for those operations as of the cited channel folder API docs.
+- Per-user folder ordering is out of scope; the bulk reorder endpoint updates
+  the organization-wide folder order.

--- a/specs/002-zulip-channel-folders/tasks.md
+++ b/specs/002-zulip-channel-folders/tasks.md
@@ -125,6 +125,21 @@ integration.
 
 ---
 
+## Phase F8: Folder Move and Bulk Reorder
+
+**Purpose**: Expose Zulip's bulk channel-folder reordering API through a
+semantic move command.
+
+- [x] T035 [F8] Implement `reorder_channel_folders(client, order)` in `lftools_uv/api/endpoints/zulip.py` using `PATCH /api/v1/channel_folders` with JSON-encoded `order` and the existing `channel-folders-order` FL 414 gate (FR-038)
+- [x] T036 [F8] Add pure `plan_folder_move(current_order, target_id, reference_id, position)` helper in `lftools_uv/api/endpoints/zulip.py` for before/after move planning (FR-038)
+- [x] T037 [F8] Extract shared folder token resolution in `lftools_uv/api/endpoints/zulip.py` and add move-reference support for name, `id:N`, and bare integer IDs (FR-038)
+- [x] T038 [F8] Add `zulip folder move --folder-id N --before REF|--after REF` in `lftools_uv/typer_apps/zulip.py`, including mutual exclusion, target/reference validation, archived-folder-inclusive ordering, and success output (FR-038)
+- [x] T039 [P] [F8] Add API tests in `tests/unit/test_zulip_api.py` for reorder payloads, FL 414 gating, API error propagation, and direct move-planner cases (FR-038)
+- [x] T040 [P] [F8] Add CLI tests in `tests/unit/test_zulip_cli.py` for move before/after, reference resolution by name/`id:N`/bare ID, self-move, missing target, missing numeric reference, and before/after mutex errors (FR-038)
+- [x] T041 [F8] Update `specs/002-zulip-channel-folders/` design artifacts to document `folder move`, the bulk reorder API, FL 414 behavior, and quickstart examples (FR-038)
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies
@@ -138,6 +153,8 @@ integration.
 - **F6 Tests**: Test tasks can be written before implementation and completed
   alongside each phase.
 - **F7 Polish**: Depends on all selected implementation phases.
+- **F8 Folder Move**: Depends on F1 list helpers and F4 folder resolution
+  patterns; tests and spec sync complete alongside implementation.
 
 ### Parallel Opportunities
 
@@ -146,6 +163,8 @@ integration.
   integration test files.
 - F3 folder commands can be implemented in parallel with F4 resolution after
   the shared API helpers exist, as long as final integration waits for F4.
+- T039 and T040 can be implemented in parallel after T035 through T038 define
+  the helper and CLI surfaces.
 
 ## Implementation Strategy
 
@@ -160,14 +179,16 @@ integration.
 1. Add folder lifecycle helpers and commands.
 2. Add folder resolution.
 3. Integrate `--folder` into channel create/update.
-4. Complete tests and polish.
+4. Add `folder move` on top of the existing folder list and resolver helpers.
+5. Complete tests and polish.
 
 ## Notes
 
 - Each task should be small enough to review as a single commit.
 - Tasks that update `tasks.md` remain separate commits per project rules.
-- Do not add implementation code in the spec-only PR.
 - Use Zulip docs for source facts:
   <https://zulip.com/api/get-channel-folders>,
   <https://zulip.com/api/create-channel-folder>, and
   <https://zulip.com/api/update-channel-folder>.
+- `folder move` follows the Zulip bulk reorder API at
+  `PATCH /api/v1/channel_folders` and deliberately avoids a raw order-array CLI.

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -133,7 +133,7 @@ def _folder_reorder_client(
 
     def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> dict[str, Any]:
         client.last_requests.append({"url": url, "method": method, "request": request})
-        return response or {"result": "success", "msg": ""}
+        return response if response is not None else {"result": "success", "msg": ""}
 
     client.call_endpoint.side_effect = call_endpoint
     return client
@@ -164,16 +164,21 @@ def test_plan_folder_move_positions(
 
 
 @pytest.mark.parametrize(
-    ("target_id", "reference_id", "message"),
+    ("target_id", "reference_id", "expected_error", "message"),
     [
-        (2, 2, "Cannot move folder relative to itself"),
-        (99, 1, "Target folder id 99 not found"),
-        (1, 99, "Reference folder id 99 not found"),
+        (2, 2, ZulipValidationError, "Cannot move folder relative to itself"),
+        (99, 1, ZulipNotFoundError, "Target folder id 99 not found"),
+        (1, 99, ZulipNotFoundError, "Reference folder id 99 not found"),
     ],
 )
-def test_plan_folder_move_rejects_invalid_ids(target_id: int, reference_id: int, message: str) -> None:
+def test_plan_folder_move_rejects_invalid_ids(
+    target_id: int,
+    reference_id: int,
+    expected_error: type[Exception],
+    message: str,
+) -> None:
     """Folder move planning validates target and reference membership."""
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(expected_error, match=message):
         plan_folder_move([1, 2, 3], target_id, reference_id, "before")
 
 

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -166,6 +166,8 @@ def test_plan_folder_move_positions(
 @pytest.mark.parametrize(
     ("target_id", "reference_id", "expected_error", "message"),
     [
+        (0, 1, ZulipValidationError, "positive integer"),
+        (1, -1, ZulipValidationError, "positive integer"),
         (2, 2, ZulipValidationError, "Cannot move folder relative to itself"),
         (99, 1, ZulipNotFoundError, "Target folder id 99 not found"),
         (1, 99, ZulipNotFoundError, "Reference folder id 99 not found"),

--- a/tests/unit/test_zulip_api.py
+++ b/tests/unit/test_zulip_api.py
@@ -20,7 +20,7 @@ Covers the foundational tasks T016–T019:
 from __future__ import annotations
 
 import json as _json
-from typing import Any, cast
+from typing import Any, Literal, cast
 from unittest import mock
 
 import pytest
@@ -44,6 +44,8 @@ from lftools_uv.api.endpoints.zulip import (
     list_channels,
     list_groups,
     list_users,
+    plan_folder_move,
+    reorder_channel_folders,
     resolve_channel,
     resolve_groups,
     resolve_users,
@@ -114,6 +116,94 @@ def test_feature_level_table_contains_expected_keys() -> None:
         assert key in FEATURE_LEVELS
         assert isinstance(FEATURE_LEVELS[key], int)
         assert FEATURE_LEVELS[key] >= 0
+
+
+def _folder_reorder_client(
+    *,
+    feature_level: int = 500,
+    response: dict[str, Any] | None = None,
+) -> Any:
+    """Return a mock client for channel-folder reorder API tests."""
+    client = mock.MagicMock()
+    client.get_server_settings.return_value = {
+        "result": "success",
+        "zulip_feature_level": feature_level,
+    }
+    client.last_requests = []
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> dict[str, Any]:
+        client.last_requests.append({"url": url, "method": method, "request": request})
+        return response or {"result": "success", "msg": ""}
+
+    client.call_endpoint.side_effect = call_endpoint
+    return client
+
+
+@pytest.mark.parametrize(
+    ("current_order", "target_id", "reference_id", "position", "expected"),
+    [
+        ([1, 2, 3], 3, 1, "before", [3, 1, 2]),
+        ([1, 2, 3], 1, 3, "after", [2, 3, 1]),
+        ([1, 2, 3, 4], 2, 4, "after", [1, 3, 4, 2]),
+        ([1, 2, 3, 4], 4, 2, "before", [1, 4, 2, 3]),
+        ([1, 2, 3], 2, 1, "before", [2, 1, 3]),
+        ([1, 2, 3], 2, 3, "after", [1, 3, 2]),
+    ],
+)
+def test_plan_folder_move_positions(
+    current_order: list[int],
+    target_id: int,
+    reference_id: int,
+    position: str,
+    expected: list[int],
+) -> None:
+    """Folder move planning covers start, end, forward, and backward moves."""
+    assert (
+        plan_folder_move(current_order, target_id, reference_id, cast(Literal["before", "after"], position)) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("target_id", "reference_id", "message"),
+    [
+        (2, 2, "Cannot move folder relative to itself"),
+        (99, 1, "Target folder id 99 not found"),
+        (1, 99, "Reference folder id 99 not found"),
+    ],
+)
+def test_plan_folder_move_rejects_invalid_ids(target_id: int, reference_id: int, message: str) -> None:
+    """Folder move planning validates target and reference membership."""
+    with pytest.raises(ValueError, match=message):
+        plan_folder_move([1, 2, 3], target_id, reference_id, "before")
+
+
+def test_reorder_channel_folders_payload() -> None:
+    """Bulk folder reorder sends a JSON-encoded order array to the API."""
+    client = _folder_reorder_client()
+    response = reorder_channel_folders(client, [2, 1, 3])
+    assert response == {"result": "success", "msg": ""}
+    assert client.last_requests == [
+        {
+            "url": "channel_folders",
+            "method": "PATCH",
+            "request": {"order": _json.dumps([2, 1, 3])},
+        }
+    ]
+
+
+def test_reorder_channel_folders_feature_gate() -> None:
+    """Bulk folder reorder requires Zulip feature level 414."""
+    client = _folder_reorder_client(feature_level=413)
+    with pytest.raises(ZulipFeatureLevelError):
+        reorder_channel_folders(client, [1, 2, 3])
+    assert client.last_requests == []
+
+
+def test_reorder_channel_folders_api_error() -> None:
+    """Bulk folder reorder surfaces Zulip API validation failures."""
+    client = _folder_reorder_client(response={"result": "error", "msg": "Invalid order mapping"})
+    with pytest.raises(ZulipAPIError, match="Invalid order mapping"):
+        reorder_channel_folders(client, [1, 1, 2])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -314,6 +314,15 @@ def test_folder_move_rejects_missing_target(monkeypatch: pytest.MonkeyPatch) -> 
     assert not any(call["method"] == "PATCH" for call in client.last_requests)
 
 
+def test_folder_move_rejects_invalid_target_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The moved folder ID must be a positive integer."""
+    client = _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["folder", "move", "--folder-id", "0", "--before", "Projects"])
+    assert result.exit_code == 1
+    assert "positive integer" in (result.stdout + result.stderr)
+    assert not any(call["method"] == "PATCH" for call in client.last_requests)
+
+
 def test_folder_move_rejects_missing_bare_id_reference(monkeypatch: pytest.MonkeyPatch) -> None:
     """Missing bare integer references include the numeric-ID hint."""
     client = _patched_folder_move_client(monkeypatch)

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -204,7 +204,7 @@ def _patched_folder_move_client(
         fake.last_requests.append({"url": url, "method": method, "request": request})
         if url == "channel_folders" and method == "GET":
             assert request == {"include_archived": True}
-            return {"result": "success", "channel_folders": folders or MOVE_FOLDERS}
+            return {"result": "success", "channel_folders": folders if folders is not None else MOVE_FOLDERS}
         if url == "channel_folders" and method == "PATCH":
             fake.last_order = json.loads(cast(str, (request or {})["order"]))
             return {"result": "success", "msg": ""}

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -183,6 +183,39 @@ def _patched_channel_client(monkeypatch: pytest.MonkeyPatch, response: dict[str,
     return fake
 
 
+MOVE_FOLDERS = [
+    {"id": 10, "name": "Projects", "description": "", "order": 1, "is_archived": False},
+    {"id": 11, "name": "Engineering", "description": "", "order": 2, "is_archived": False},
+    {"id": 12, "name": "Old", "description": "", "order": 3, "is_archived": True},
+]
+
+
+def _patched_folder_move_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    folders: list[dict[str, Any]] | None = None,
+) -> mock.MagicMock:
+    """Patch ``get_client`` with a fake client for folder move tests."""
+    fake = mock.MagicMock()
+    fake.get_server_settings.return_value = {"result": "success", "zulip_feature_level": 500}
+    fake.last_requests = []
+
+    def call_endpoint(*, url: str, method: str, request: dict[str, Any] | None = None) -> dict[str, Any]:
+        fake.last_requests.append({"url": url, "method": method, "request": request})
+        if url == "channel_folders" and method == "GET":
+            assert request == {"include_archived": True}
+            return {"result": "success", "channel_folders": folders or MOVE_FOLDERS}
+        if url == "channel_folders" and method == "PATCH":
+            fake.last_order = json.loads(cast(str, (request or {})["order"]))
+            return {"result": "success", "msg": ""}
+        return {"result": "error", "msg": f"unexpected endpoint {method} {url}"}
+
+    fake.call_endpoint.side_effect = call_endpoint
+    monkeypatch.setattr(zulip_mod, "get_client", lambda **_kw: fake)
+    monkeypatch.setattr(zulip_mod, "zulip_available", lambda: True)
+    return fake
+
+
 def test_channel_list_table_output(monkeypatch: pytest.MonkeyPatch) -> None:
     """Default invocation prints a table with the documented columns."""
     _patched_channel_client(monkeypatch, _LIST_RESPONSE)
@@ -216,6 +249,80 @@ def test_channel_list_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
         assert by_id[2]["type"] == "private"
         assert by_id[1]["subscriber_count"] == 42
         assert by_id[1]["is_archived"] is False
+
+
+def test_folder_move_before_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``folder move --before`` resolves a folder name and patches order."""
+    client = _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["folder", "move", "--folder-id", "12", "--before", "Projects"])
+    assert result.exit_code == 0, result.output
+    assert client.last_order == [12, 10, 11]
+
+
+def test_folder_move_after_by_id_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``folder move --after`` accepts explicit ``id:N`` references."""
+    client = _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["--json", "folder", "move", "--folder-id", "10", "--after", "id:12"])
+    assert result.exit_code == 0, result.output
+    assert client.last_order == [11, 12, 10]
+    payload = json.loads(result.stdout)
+    assert payload["operation"] == "move"
+    assert payload["order"] == [11, 12, 10]
+
+
+def test_folder_move_after_by_bare_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``folder move`` treats bare integer references as folder IDs."""
+    client = _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["folder", "move", "--folder-id", "10", "--after", "12"])
+    assert result.exit_code == 0, result.output
+    assert client.last_order == [11, 12, 10]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["folder", "move", "--folder-id", "10"],
+        ["folder", "move", "--folder-id", "10", "--before", "Projects", "--after", "Engineering"],
+    ],
+)
+def test_folder_move_requires_exactly_one_position(
+    monkeypatch: pytest.MonkeyPatch,
+    args: list[str],
+) -> None:
+    """``folder move`` requires exactly one of ``--before`` or ``--after``."""
+    _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, args)
+    assert result.exit_code == 1
+    assert "Exactly one of --before or --after is required" in (result.stdout + result.stderr)
+
+
+def test_folder_move_rejects_self_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Moving a folder relative to itself is rejected before PATCH."""
+    client = _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["folder", "move", "--folder-id", "10", "--before", "id:10"])
+    assert result.exit_code == 1
+    assert "Cannot move folder relative to itself" in (result.stdout + result.stderr)
+    assert not any(call["method"] == "PATCH" for call in client.last_requests)
+
+
+def test_folder_move_rejects_missing_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The moved folder ID must exist in the complete folder order."""
+    client = _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["folder", "move", "--folder-id", "99", "--before", "Projects"])
+    assert result.exit_code == 1
+    assert "Target folder id 99 not found" in (result.stdout + result.stderr)
+    assert not any(call["method"] == "PATCH" for call in client.last_requests)
+
+
+def test_folder_move_rejects_missing_bare_id_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing bare integer references include the numeric-ID hint."""
+    client = _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["folder", "move", "--folder-id", "10", "--before", "999"])
+    assert result.exit_code == 1
+    output = result.stdout + result.stderr
+    assert "No channel folder with id 999" in output
+    assert "id:999" in output
+    assert not any(call["method"] == "PATCH" for call in client.last_requests)
 
 
 def test_channel_list_accepts_global_zuliprc(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Introduce `zulip folder move --folder-id N --before|--after REF`.
- Follow-up to PR #439 for Zulip channel folders.
- Update channel-folder spec artifacts and task tracking.

## API note
- Uses Zulip's bulk `PATCH /channel_folders` reorder API.
- Sends a complete JSON-encoded `order` array and gates on FL 414.
- The server remains authoritative for admin-only permission errors.

## UX note
- Uses semantic `--before`/`--after` placement instead of raw order input.
- `REF` accepts folder names, `id:N`, or bare numeric folder IDs.

## Tests
- `uv run pytest tests/unit/test_zulip_api.py tests/unit/test_zulip_cli.py -x -q`
- `uv run pytest tests/ -x -q`
- `uv run ruff check .`
- `uv run mypy lftools_uv`
- `SKIP=basedpyright pre-commit run --all-files`