### PR TITLE
Fix: resolve Zizmor cache-poisoning finding

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -192,9 +192,12 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-          cache-suffix: "documentation"
+          # Caching is intentionally disabled on this publish path. The
+          # workflow deploys to GitHub Pages and only runs on tag pushes
+          # and manual dispatch, so a restored dependency cache (which a
+          # lower-privileged PR/branch run could populate) would be an
+          # avoidable cache-poisoning vector for negligible speed-up.
+          enable-cache: false
 
       - name: 'Set up Python'
         run: uv python install 3.13


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported a `cache-poisoning` finding
in `.github/workflows/documentation.yaml`. This change resolves it,
bringing the repository to zero medium-or-higher findings.

### Changes

- **cache-poisoning:** the "Build Documentation" job restored an
  `astral-sh/setup-uv` dependency cache (`enable-cache: true`) while the
  workflow publishes to GitHub Pages. A publish workflow must not trust
  a restored cache, since a lower-privileged run sharing the cache-key
  namespace could populate it and influence the deployed output.
  Caching is disabled on this path (`enable-cache: false`); the now-inert
  `cache-dependency-glob`/`cache-suffix` inputs are removed.

### Impact

The documentation build runs only on tag pushes and manual dispatch, so
losing the dependency cache is a negligible speed-up cost. No change to
the published documentation.

### Validation

- `zizmor --persona regular --min-severity medium` now reports **no
  findings**.
- `yamllint` passes on the changed workflow.