### PR TITLE
Fix(deps): Remove uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,10 +299,6 @@ ignore = [
 known-first-party = ["lftools_uv"]
 
 [tool.uv]
-# Supply-chain cooldown: do not resolve anything published in the last
-# 7 days (rolling window; uv records it as a relative span in uv.lock).
-# Requires uv >= 0.9.17 for the relative-duration ("7 days") form.
-exclude-newer = "7 days"
 constraint-dependencies = [
     # Security: force minimum versions for transitive dependencies
     # Fixes CVE-2026-27962, CVE-2026-28490, CVE-2026-28498, CVE-2026-28802

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [manifest]
 constraints = [
     { name = "authlib", specifier = ">=1.6.9" },


### PR DESCRIPTION
## Summary

The relative `exclude-newer = "7 days"` cooldown in `[tool.uv]` is baked
into `uv.lock` as `exclude-newer-span = "P7D"`. Dependabot's `uv` updater
re-resolves against that rolling window, regenerates a byte-identical
lockfile, and fails with **"Dependency file content did not change"** —
blocking automated and priority security updates.

## Change

- Remove the `exclude-newer` supply-chain cooldown from `pyproject.toml`
  (the `[tool.uv]` table and its `constraint-dependencies` security pins
  are preserved).
- Regenerate `uv.lock` (drops the `[options]` `exclude-newer-span` block);
  deletion-only, no dependency versions moved.

The supply-chain auditing tool that originally recommended this cooldown
has updated its guidance — Dependabot cooldowns now cover the same
concern without breaking priority security fixes.

## Validation

- `uv lock` regenerates cleanly.
- `pre-commit` (including the test suite) passes.