### PR TITLE
Fix: Grant contents:read to Sonatype scan job

### DIFF
--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -35,6 +35,8 @@ concurrency:
 jobs:
   sonatype-lifecycle:
     name: 'Sonatype Lifecycle'
+    permissions:
+      contents: read  # Reusable scan job checks out the repo
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonatype-lifecycle.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267 # v0.7.2
     with:


### PR DESCRIPTION
## Problem

`Security Scans` fails at workflow-validation time:

```
The nested job 'sonatype-cli' is requesting 'contents: read',
but is only allowed 'contents: none'.
```

## Root cause

`reuse-sonatype-lifecycle.yaml` (in `lfit/releng-reusable-workflows`) was hardened in **v0.6.0** to declare a workflow-level `permissions: {}` plus a job-level `contents: read` (zizmor least-privilege / `excessive-permissions`). A reusable workflow's job can never request **more** permission than the calling job grants it.

This caller sets a top-level `permissions: {}` and the `sonatype-lifecycle` job had **no** job-level `permissions` block, so it inherited `contents: none` — less than the `contents: read` the reusable workflow now requests.

## Fix

Grant the calling job the `contents: read` it must pass through to the reusable scan job.

```yaml
  sonatype-lifecycle:
    name: 'Sonatype Lifecycle'
    permissions:
      contents: read  # Reusable scan job checks out the repo
    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonatype-lifecycle.yaml@...
```

Validated with `yamllint`. This is part of an org-wide sweep; the only other affected caller found was `http-api-tool-docker`.