### PR TITLE
Chore: Bump sonarqube-cloud-scan-action to v1.2.1

### DIFF
--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -112,7 +112,7 @@ jobs:
 
       - name: 'SonarQube Cloud scan'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2  # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b  # v1.2.1
         with:
           sonar_token: ${{ secrets.SONAR_TOKEN }}
           # Workspace already populated by the steps above (checkout +


### PR DESCRIPTION
## Summary

Advance the pinned `sonarqube-cloud-scan-action` from **v1.1.1** to **v1.2.1** in `.github/workflows/security-scans.yaml`.

## Why

`sonarqube-cloud-scan-action` **v1.2.1** embeds `repository-metadata-action` v0.2.4, which moved its sub-actions (`actions/setup-python`, `astral-sh/setup-uv`) to **node24** runtimes. The prior pin (v1.1.1) embedded node20 sub-actions, surfacing Node 20 deprecation warnings during scans. v1.2.1 also carries the null-inputs Gerrit extractor fix.

Single-line SHA pin bump (`b8d74f0…` = commit for tag `v1.2.1`) with a matching `# v1.2.1` comment.