### PR TITLE
Fix(deps): Add GitPython >=3.1.54 security floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,11 @@ dependencies = [
     "docker",
     "email-validator",
     "filelock",
-    "GitPython",
+    # Security floor covering four high severity advisories: argument
+    # injection and unsafe git option guard bypasses, fixed across 3.1.53
+    # (GHSA-3rp5-jjmw-4wv2) and 3.1.54 (GHSA-6p8h-3wgx-97gf,
+    # GHSA-fjr4-x663-mwxc, GHSA-r9mr-m37c-5fr3).
+    "GitPython>=3.1.54",
     "identify",
     "idna",
     "jinja2",

--- a/uv.lock
+++ b/uv.lock
@@ -1100,7 +1100,7 @@ requires-dist = [
     { name = "email-validator" },
     { name = "filelock" },
     { name = "furo", marker = "extra == 'docs'" },
-    { name = "gitpython" },
+    { name = "gitpython", specifier = ">=3.1.54" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "identify" },


### PR DESCRIPTION
## Summary

Adds a `GitPython>=3.1.54` security floor to the direct requirement in `pyproject.toml`.

Dependabot has already bumped the locked `gitpython` to 3.1.54 in #569, which closed all four high severity alerts. This PR is the durable follow-up: the direct requirement carried no lower bound, so nothing recorded why that version matters, nor stopped a future resolution regressing below it. Consumers who install `lftools-uv` without the lock file were also still free to resolve a vulnerable release.

## Advisories

| Alert | Advisory | Summary | First fixed in |
| ----- | -------- | ------- | -------------- |
| #34 | GHSA-3rp5-jjmw-4wv2 | git-config section-name injection enables arbitrary config directives (core.sshCommand RCE) | 3.1.53 |
| #35 | GHSA-6p8h-3wgx-97gf | Incomplete `unsafe_git_clone_options` denylist omits `--template`, enabling code execution via clone hooks | 3.1.54 |
| #36 | GHSA-fjr4-x663-mwxc | Arbitrary file overwrite via `git diff --output` argument injection in `Diffable.diff` | 3.1.54 |
| #37 | GHSA-r9mr-m37c-5fr3 | Unsafe git option guard bypass via single-character kwarg value token smuggling | 3.1.54 |

3.1.54 is the lowest release clearing all four. The floor follows the convention already used for `requests` and `urllib3`.

## Changes

- `pyproject.toml`: `GitPython` -> `GitPython>=3.1.54`, with the advisories recorded inline.
- `uv.lock`: one line, recording the requirement specifier.

The lock **stays on gitpython 3.1.54** rather than moving to the newer 3.1.57, so this respects the seven day cooldown configured for the `uv` ecosystem in `.github/dependabot.yml`. No resolved package versions change.

## Compatibility

3.1.53 and 3.1.54 tightened the guards around unsafe git options. No call site in `lftools_uv/git/gerrit.py` uses the affected APIs:

- `Repo.clone_from(remote, working_dir)` — no clone options passed
- `repo.git.rev_parse("origin/HEAD", abbrev_ref=True)`
- `repo.git.add(...)`, `repo.git.status()`, `repo.git.commit(...)`, `repo.git.push(...)`

No code changes were required.

## Validation

- `uv run pytest` — 758 passed
- `uvx pre-commit run --from-ref upstream/main --to-ref HEAD` — all hooks passed
- `gitlint` — clean

Rebased onto `dd22596` to pick up #568 and #569.