### PR TITLE
Refactor: Call the shared cache-clearing workflow

### DIFF
--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -1,7 +1,20 @@
 ---
-# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+# Thin caller for the reusable cache housekeeping workflow in
+# generic-workflows. Cache clearing is a deliberate, occasional act, so
+# this workflow is dispatch-only: nothing here runs on push or pull
+# request. The filters appear in the "Run workflow" form and pass
+# straight through to the reusable.
+#
+# The reusable needs `actions: write` to list and delete caches. A called
+# workflow cannot hold more permission than its caller, so the calling
+# job below declares the grant.
+#
+# This workflow declares no `concurrency` block on purpose. The reusable
+# serialises itself under a literal group of its own; a caller repeating
+# that group would deadlock against it.
 name: 'Clear Action Cache 🧹'
 
 # yamllint disable-line rule:truthy
@@ -25,297 +38,21 @@ on:
         type: string
       dry_run:
         description: >-
-          When 'true', list matching entries but do not delete
-          them.
+          When true, list matching entries but do not delete them.
         required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
+        default: false
+        type: boolean
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 jobs:
-  clear-cache:
+  clear-action-cache:
     name: 'Clear Action Cache'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
-      # yamllint disable-line rule:line-length
-      actions: write  # Required to list and delete repository Actions caches
-    steps:
-      # Load the egress allow-list out-of-band from the
-      # organisation's .github repository and publish it as
-      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
-      # yamllint disable-line rule:line-length
-      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
-        with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
-
-      # Harden the runner with the just-loaded allow-list.
-      - name: 'Harden runner (block)'
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
-        with:
-          egress-policy: 'block'
-          allowed-endpoints: >
-            ${{ env.CONNECTION_ALLOW_LIST }}
-
-      - name: 'Inspect cache before deletion'
-        id: before
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          KEY_PATTERN: ${{ inputs.key_pattern }}
-          REF_FILTER: ${{ inputs.ref_filter }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          # List current cache entries (pre-deletion snapshot).
-          set -euo pipefail
-
-          echo "Repository: $REPO"
-          echo "Key filter: '${KEY_PATTERN:-<none>}'"
-          echo "Ref filter: '${REF_FILTER:-<none>}'"
-          echo ""
-
-          # Page through all caches via the REST API; gh cache list
-          # is convenient locally but the JSON response from the
-          # REST endpoint is more reliable for scripting.
-          all_caches=$(
-            gh api \
-              --paginate \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/$REPO/actions/caches?per_page=100" \
-              --jq '.actions_caches[]'
-          )
-
-          if [ -z "$all_caches" ]; then
-            echo "No cache entries found."
-            echo "before_count=0" >> "$GITHUB_OUTPUT"
-            echo "matched_count=0" >> "$GITHUB_OUTPUT"
-            : > matched_ids.txt
-            exit 0
-          fi
-
-          # Total count before any filtering.
-          before_count=$(printf '%s\n' "$all_caches" | jq -s 'length')
-          echo "Total cache entries: $before_count"
-
-          # Apply optional key/ref filters.
-          filtered=$(printf '%s\n' "$all_caches" | jq -c '.')
-          if [ -n "$KEY_PATTERN" ]; then
-            filtered=$(printf '%s\n' "$filtered" | jq -c \
-              --arg pat "$KEY_PATTERN" \
-              'select(.key | contains($pat))')
-          fi
-          if [ -n "$REF_FILTER" ]; then
-            filtered=$(printf '%s\n' "$filtered" | jq -c \
-              --arg ref "$REF_FILTER" \
-              'select(.ref == $ref)')
-          fi
-
-          if [ -z "$filtered" ]; then
-            echo "No cache entries match the supplied filters."
-            echo "before_count=$before_count" >> "$GITHUB_OUTPUT"
-            echo "matched_count=0" >> "$GITHUB_OUTPUT"
-            : > matched_ids.txt
-            exit 0
-          fi
-
-          matched_count=$(printf '%s\n' "$filtered" | jq -s 'length')
-          echo ""
-          echo "Matched $matched_count cache entr(y/ies) for processing:"
-          printf '%s\n' "$filtered" | jq -r \
-            '"  - id=\(.id)  size=\(.size_in_bytes)B  ref=\(.ref)  key=\(.key)"'
-
-          # Persist matched IDs for the deletion step.
-          printf '%s\n' "$filtered" | jq -r '.id' > matched_ids.txt
-
-          {
-            echo "## Cache snapshot (before)"
-            echo ""
-            echo "| Property | Value |"
-            echo "|----------|-------|"
-            echo "| Total entries | $before_count |"
-            echo "| Matched | $matched_count |"
-            echo "| Dry run | \`${DRY_RUN}\` |"
-            echo ""
-            # Render user-controlled filter inputs inside a fenced
-            # code block. KEY_PATTERN and REF_FILTER are free-form
-            # workflow_dispatch inputs and may contain characters
-            # (|, backticks, newlines) that would break table
-            # rendering or inject markup into the step summary.
-            # jq @json safely quotes/escapes the values.
-            echo "### Filters"
-            echo ""
-            echo '```text'
-            jq -nr \
-              --arg key "${KEY_PATTERN:-}" \
-              --arg ref "${REF_FILTER:-}" \
-              '"key_pattern=\($key|@json)\nref_filter=\($ref|@json)"'
-            echo '```'
-            echo ""
-            if [ "$matched_count" -gt 0 ]; then
-              echo "### Matched entries"
-              echo ""
-              # Emit as a fenced code block rather than a Markdown
-              # table: cache keys and refs are user-controlled and
-              # may contain characters (|, backticks, newlines) that
-              # would otherwise break table rendering or allow
-              # injection into the step summary.
-              echo '```text'
-              printf '%s\n' "$filtered" | jq -r '
-                  "id=\(.id)  size=\(.size_in_bytes)B  " +
-                  "ref=\(.ref|tojson)  key=\(.key|tojson)"
-                '
-              echo '```'
-              echo ""
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          echo "before_count=$before_count" >> "$GITHUB_OUTPUT"
-          echo "matched_count=$matched_count" >> "$GITHUB_OUTPUT"
-
-      - name: 'Delete matching cache entries'
-        if: steps.before.outputs.matched_count != '0'
-        id: delete
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          # Delete the matched cache IDs unless this is a dry run.
-          set -euo pipefail
-
-          if [ ! -s matched_ids.txt ]; then
-            echo "No matched IDs file; nothing to delete."
-            echo "deleted_count=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$DRY_RUN" = "true" ]; then
-            echo "Dry-run mode: would delete the following IDs:"
-            cat matched_ids.txt
-            echo "deleted_count=0" >> "$GITHUB_OUTPUT"
-            {
-              echo "### Dry run"
-              echo ""
-              echo "No entries were deleted."
-              echo ""
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          deleted=0
-          failed=0
-          while IFS= read -r cache_id; do
-            [ -z "$cache_id" ] && continue
-            echo "Deleting cache id=$cache_id…"
-            if gh api \
-                --method DELETE \
-                -H "Accept: application/vnd.github+json" \
-                "/repos/$REPO/actions/caches/${cache_id}";
-            then
-              deleted=$((deleted + 1))
-            else
-              echo "::warning::Failed to delete cache id=$cache_id"
-              failed=$((failed + 1))
-            fi
-          done < matched_ids.txt
-
-          echo ""
-          echo "Deleted: $deleted"
-          echo "Failed:  $failed"
-          echo "deleted_count=$deleted" >> "$GITHUB_OUTPUT"
-          echo "failed_count=$failed" >> "$GITHUB_OUTPUT"
-
-          {
-            echo "### Deletion result"
-            echo ""
-            echo "| Property | Value |"
-            echo "|----------|-------|"
-            echo "| Deleted | $deleted |"
-            echo "| Failed | $failed |"
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "$failed" -gt 0 ]; then
-            exit 1
-          fi
-
-      - name: 'Verify cache after deletion'
-        if: always() && steps.before.outputs.matched_count != '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          KEY_PATTERN: ${{ inputs.key_pattern }}
-          REF_FILTER: ${{ inputs.ref_filter }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          # Re-query the cache list and confirm matched entries are
-          # gone (or still present in dry-run mode).
-          set -euo pipefail
-
-          all_caches=$(
-            gh api \
-              --paginate \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/$REPO/actions/caches?per_page=100" \
-              --jq '.actions_caches[]'
-          )
-
-          after_count=0
-          if [ -n "$all_caches" ]; then
-            after_count=$(printf '%s\n' "$all_caches" | jq -s 'length')
-          fi
-
-          remaining_matches=0
-          if [ -n "$all_caches" ]; then
-            filtered=$(printf '%s\n' "$all_caches" | jq -c '.')
-            if [ -n "$KEY_PATTERN" ]; then
-              filtered=$(printf '%s\n' "$filtered" | jq -c \
-                --arg pat "$KEY_PATTERN" \
-                'select(.key | contains($pat))')
-            fi
-            if [ -n "$REF_FILTER" ]; then
-              filtered=$(printf '%s\n' "$filtered" | jq -c \
-                --arg ref "$REF_FILTER" \
-                'select(.ref == $ref)')
-            fi
-            if [ -n "$filtered" ]; then
-              remaining_matches=$(
-                printf '%s\n' "$filtered" | jq -s 'length'
-              )
-            fi
-          fi
-
-          echo "Total cache entries after run: $after_count"
-          echo "Remaining matches:             $remaining_matches"
-
-          {
-            echo "## Cache snapshot (after)"
-            echo ""
-            echo "| Property | Value |"
-            echo "|----------|-------|"
-            echo "| Total entries | $after_count |"
-            echo "| Remaining matches | $remaining_matches |"
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "$DRY_RUN" = "true" ]; then
-            echo "Dry run: skipping post-deletion verification."
-            exit 0
-          fi
-
-          if [ "$remaining_matches" -ne 0 ]; then
-            echo "::error::Expected zero matching cache entries " \
-              "after deletion, found $remaining_matches"
-            exit 1
-          fi
-
-          echo "✅ All matched cache entries successfully removed"
+      actions: write  # list and delete repository Actions caches
+    # yamllint disable-line rule:line-length
+    uses: lfreleng-actions/generic-workflows/.github/workflows/clear-action-cache.yaml@b80a5a8374fa54986ec542617efaa35e93515af6  # v0.0.3
+    with:
+      key_pattern: ${{ inputs.key_pattern }}
+      ref_filter: ${{ inputs.ref_filter }}
+      dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Why

This repository **does** write Actions cache entries, so cache housekeeping
earns its place here. What it did not need was a local copy of the
implementation.

## What changed

Replaces the inline shell with a thin caller delegating to the
[reusable workflow in `generic-workflows`](https://github.com/lfreleng-actions/generic-workflows#cache-housekeeping-reusable-workflow),
pinned to
[v0.0.3](https://github.com/lfreleng-actions/generic-workflows/releases/tag/v0.0.3)
(`b80a5a8374fa54986ec542617efaa35e93515af6`).

## Behaviour

The dispatch form keeps the same three filters (`key_pattern`, `ref_filter`,
`dry_run`). One deliberate difference: `dry_run` becomes a checkbox rather than
a `true`/`false` menu, because `workflow_call` accepts `boolean` inputs but not
`choice`.

The reusable also verifies more honestly than the copy replaced here. It
distinguishes `grep`'s "no match" from a genuine `grep`/`jq` failure, so it can
no longer report success without having verified anything.

## Two details worth noting for review

- **No `concurrency` block**, deliberately. The reusable serialises itself under
  a literal group of its own. Inside a called workflow `github.workflow`
  resolves to the *caller's* name, so a caller repeating that group would
  deadlock against it.
- **`actions: write` sits on the calling job.** A called workflow cannot hold
  more permission than its caller, so the grant has to be declared here.

Both the reusable and this caller pattern have been exercised end-to-end before
this rollout.
