### PR TITLE
Refactor: Rebuild Read the Docs command surface

### DIFF
--- a/docs/commands/rtd.rst
+++ b/docs/commands/rtd.rst
@@ -8,6 +8,47 @@ rtd
 
 .. program-output:: lftools-uv rtd --help
 
+Machine-readable output
+=======================
+
+Every command accepts ``--json`` and emits a parsable payload on
+stdout. Diagnostics go to stderr, so a caller may parse stdout without
+a warning corrupting the stream.
+
+.. code-block:: bash
+
+   lftools-uv rtd project-version-details onap-cps latest --json | jq '.active'
+
+The flag works before or after the subcommand:
+
+.. code-block:: bash
+
+   lftools-uv rtd --json project-list
+   lftools-uv rtd project-list --json
+
+Commands that return a collection always include the collection in the
+``--json`` payload, empty when nothing matches, so a parser needs no
+special case for the empty result. Table output prints a short message
+such as ``No projects found`` instead.
+
+Branch names and version slugs
+==============================
+
+Read the Docs addresses a version by its **slug**, which lowercases the
+branch name and replaces every character outside ``[a-z0-9._-]`` with a
+hyphen. Read the Docs holds a branch named ``maintenance/3.7.10`` under
+the slug ``maintenance-3.7.10``.
+
+Passing a raw branch name to the API produces a request path that does
+not resolve. Commands that accept a version offer ``--from-branch``,
+which performs the conversion:
+
+.. code-block:: bash
+
+   lftools-uv rtd project-build-trigger onap-cps maintenance/3.7.10 --from-branch
+
+Omit the flag when you already hold a slug.
+
 Commands
 ========
 
@@ -21,57 +62,68 @@ project-details
 
 .. program-output:: lftools-uv rtd project-details --help
 
+project-create
+--------------
 
+.. program-output:: lftools-uv rtd project-create --help
+
+project-update
+--------------
+
+.. program-output:: lftools-uv rtd project-update --help
 
 project-version-list
 --------------------
 
 .. program-output:: lftools-uv rtd project-version-list --help
 
-
-
 project-version-details
 -----------------------
 
 .. program-output:: lftools-uv rtd project-version-details --help
-
-
 
 project-version-update
 ----------------------
 
 .. program-output:: lftools-uv rtd project-version-update --help
 
-
-
-project-create
---------------
-
-.. program-output:: lftools-uv rtd project-create --help
-
-
-
 project-build-list
 ------------------
 
 .. program-output:: lftools-uv rtd project-build-list --help
-
-
 
 project-build-details
 ---------------------
 
 .. program-output:: lftools-uv rtd project-build-details --help
 
-
-
 project-build-trigger
 ---------------------
 
 .. program-output:: lftools-uv rtd project-build-trigger --help
 
+subproject-list
+---------------
 
+.. program-output:: lftools-uv rtd subproject-list --help
 
+subproject-details
+------------------
+
+.. program-output:: lftools-uv rtd subproject-details --help
+
+subproject-create
+-----------------
+
+.. program-output:: lftools-uv rtd subproject-create --help
+
+subproject-delete
+-----------------
+
+.. program-output:: lftools-uv rtd subproject-delete --help
+
+Configuration
+=============
 
 API requires a [rtd] section in ~/.config/lftools/lftools.ini:
 

--- a/lftools_uv/api/endpoints/readthedocs.py
+++ b/lftools_uv/api/endpoints/readthedocs.py
@@ -8,21 +8,113 @@
 # http://www.eclipse.org/legal/epl-v10.html
 ##############################################################################
 
-"""Read the Docs REST API interface."""
+"""Read the Docs REST API interface.
+
+Every method in this module returns typed Python data (``dict``,
+``list`` or ``bool``) and raises a :class:`ReadTheDocsError` subclass on
+failure. Presentation concerns -- JSON serialisation, table rendering
+and human-readable prose -- belong to the command-line layer in
+:mod:`lftools_uv.typer_apps.rtd`.
+"""
 
 from __future__ import annotations
 
 __author__ = "DW Talton"
 
 import json
-from typing import cast
+import re
+from typing import TYPE_CHECKING, cast
 
 import lftools_uv.api.client as client
 from lftools_uv import config
 from lftools_uv.api.client import ApiResponse
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import requests
+
 _LIST_OBJECT_TYPE = list[object]
 _DICT_STR_OBJECT_TYPE = dict[str, object]
+
+_HTTP_NOT_FOUND = 404
+_HTTP_BAD_REQUEST = 400
+
+#: Characters Read the Docs preserves verbatim in a version slug.
+_SLUG_KEEP = re.compile(r"[^a-z0-9._-]+")
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class ReadTheDocsError(Exception):
+    """Base class for all Read the Docs errors raised by this module."""
+
+
+class ReadTheDocsAPIError(ReadTheDocsError):
+    """Raised when the Read the Docs API returns an error response.
+
+    Carries the HTTP status code so callers can branch on it rather
+    than matching against prose in the response body.
+    """
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ReadTheDocsNotFoundError(ReadTheDocsAPIError):
+    """Raised when a project, version, build or subproject is absent."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, _HTTP_NOT_FOUND)
+
+
+class ReadTheDocsValidationError(ReadTheDocsError):
+    """Raised for client-side validation failures."""
+
+
+# ---------------------------------------------------------------------------
+# Slug helpers
+# ---------------------------------------------------------------------------
+
+
+def version_slug(branch: str) -> str:
+    """Convert a branch name into a Read the Docs version slug.
+
+    Read the Docs stores a version under a slugified form of the branch
+    name: it lowercases the value and replaces every character outside
+    ``[a-z0-9._-]`` with a hyphen. A branch named ``maintenance/3.7.10``
+    is therefore addressable as ``maintenance-3.7.10``, and ``mr/879/1``
+    as ``mr-879-1``.
+
+    Passing an unslugified branch name to the API produces a request
+    path that does not resolve, so always route branch names through
+    this function before building a request.
+
+    Args:
+        branch: A git branch name, for example ``maintenance/3.7.10``.
+
+    Returns:
+        The corresponding Read the Docs version slug.
+
+    Raises:
+        ReadTheDocsValidationError: If ``branch`` is empty, or slugifies
+            to an empty string.
+    """
+    if not branch or not branch.strip():
+        msg = "Branch name cannot be empty"
+        raise ReadTheDocsValidationError(msg)
+
+    slug = _SLUG_KEEP.sub("-", branch.strip().lower()).strip("-")
+
+    if not slug:
+        msg = f"Branch name {branch!r} does not yield a usable version slug"
+        raise ReadTheDocsValidationError(msg)
+
+    return slug
 
 
 class ReadTheDocs(client.RestApi):
@@ -45,6 +137,59 @@ class ReadTheDocs(client.RestApi):
 
         super().__init__(**params)
 
+    # -- Response handling ---------------------------------------------------
+
+    @staticmethod
+    def _detail_of(response: ApiResponse) -> str:
+        """Return the API's ``detail`` message, when it supplies one."""
+        if isinstance(response, tuple):
+            body = response[1]
+            if isinstance(body, dict):
+                detail = body.get("detail")
+                if isinstance(detail, str):
+                    return detail
+            if isinstance(body, str) and body:
+                return body
+        return ""
+
+    def _check(self, response: ApiResponse, context: str) -> requests.Response:
+        """Raise a typed error when a response carries a failure status.
+
+        Args:
+            response: The value returned by a request helper.
+            context: Human-readable description of the attempted
+                operation, used to build the error message.
+
+        Returns:
+            The underlying :class:`requests.Response`.
+
+        Raises:
+            ReadTheDocsNotFoundError: On HTTP 404.
+            ReadTheDocsAPIError: On any other status at or above 400.
+        """
+        resp = self._response_of(response)
+
+        if resp.status_code < _HTTP_BAD_REQUEST:
+            return resp
+
+        detail = self._detail_of(response)
+        suffix = f": {detail}" if detail else ""
+
+        if resp.status_code == _HTTP_NOT_FOUND:
+            msg = f"{context} not found{suffix}"
+            raise ReadTheDocsNotFoundError(msg)
+
+        msg = f"{context} failed with HTTP {resp.status_code}{suffix}"
+        raise ReadTheDocsAPIError(msg, resp.status_code)
+
+    def _get_json(self, url: str, context: str) -> dict[str, object]:
+        """GET a URL and return its JSON object body."""
+        response: ApiResponse = self.get(url)
+        _ = self._check(response, context)
+        return self._json_body(response)
+
+    # -- Projects ------------------------------------------------------------
+
     def project_list(self) -> list[str]:
         """Return a list of projects.
 
@@ -52,12 +197,10 @@ class ReadTheDocs(client.RestApi):
         not their pretty name ['name']. Since we use these for getting
         details, triggering builds, etc., the pretty name is useless.
 
-        :param kwargs:
         :return: [projects]
         """
-        response: ApiResponse = self.get("projects/?limit=999")  # NOQA
-        result: dict[str, object] = self._json_body(response)
-        data: object = result["results"]
+        result = self._get_json("projects/?limit=999", "Project list")  # NOQA
+        data: object = result.get("results")
         project_list: list[str] = []
 
         if isinstance(data, list):
@@ -74,100 +217,139 @@ class ReadTheDocs(client.RestApi):
         """Retrieve the details of a specific project.
 
         :param project: The project's slug
-        :param kwargs:
         :return: {result}
+        :raises ReadTheDocsNotFoundError: If the project does not exist.
         """
-        response: ApiResponse = self.get(f"projects/{project}/?expand=active_versions")
-        result: dict[str, object] = self._json_body(response)
-        return result
+        return self._get_json(
+            f"projects/{project}/?expand=active_versions",
+            f"Project {project!r}",
+        )
+
+    def project_exists(self, project: str) -> bool:
+        """Report whether a project exists.
+
+        Prefer this over matching the prose in an error body, which
+        varies between API versions.
+
+        :param project: The project's slug
+        :return: True when the project exists.
+        """
+        try:
+            _ = self.project_details(project)
+        except ReadTheDocsNotFoundError:
+            return False
+        return True
 
     def project_version_list(self, project: str) -> list[str]:
         """Retrieve a list of all ACTIVE versions of a project.
 
         :param project: The project's slug
-        :return: {result}
+        :return: [version slugs]
         """
-        response: ApiResponse = self.get(f"projects/{project}/versions/?active=True")
-        result: dict[str, object] = self._json_body(response)
+        result = self._get_json(
+            f"projects/{project}/versions/?active=True",
+            f"Version list for project {project!r}",
+        )
         more_results: str | None = None
         versions: list[str] = []
 
-        # I feel like there must be a better way...but, this works. -DWTalton
-        initial_versions: object = result["results"]
+        initial_versions: object = result.get("results")
         if isinstance(initial_versions, list):
-            for version in cast(_LIST_OBJECT_TYPE, initial_versions):
-                if isinstance(version, dict):
-                    version_dict = cast(_DICT_STR_OBJECT_TYPE, version)
-                    slug: object = version_dict["slug"]
-                    if isinstance(slug, str):
-                        versions.append(slug)
+            versions.extend(self._version_slugs(initial_versions))
 
-        next_val: object = result["next"]
+        next_val: object = result.get("next")
         if isinstance(next_val, str):
             more_results = next_val.rsplit("/", 1)[-1]
 
-        if more_results:
-            while more_results is not None:
-                next_response: ApiResponse = self.get(f"projects/{project}/versions/" + more_results)
-                get_more_results: dict[str, object] = self._json_body(next_response)
-                raw_next: object = get_more_results["next"]
-                more_results = raw_next if isinstance(raw_next, str) else None
+        while more_results is not None:
+            get_more_results = self._get_json(
+                f"projects/{project}/versions/" + more_results,
+                f"Version list for project {project!r}",
+            )
+            raw_next: object = get_more_results.get("next")
+            more_results = raw_next if isinstance(raw_next, str) else None
 
-                results_data: object = get_more_results["results"]
-                if isinstance(results_data, list):
-                    for version in cast(_LIST_OBJECT_TYPE, results_data):
-                        if isinstance(version, dict):
-                            version_dict = cast(_DICT_STR_OBJECT_TYPE, version)
-                            slug = version_dict["slug"]
-                            if isinstance(slug, str):
-                                versions.append(slug)
+            results_data: object = get_more_results.get("results")
+            if isinstance(results_data, list):
+                versions.extend(self._version_slugs(results_data))
 
-                if more_results is not None:
-                    more_results = more_results.rsplit("/", 1)[-1]
+            if more_results is not None:
+                more_results = more_results.rsplit("/", 1)[-1]
 
         return versions
 
-    def project_version_details(self, project: str, version: str) -> str:
+    @staticmethod
+    def _version_slugs(data: list[object]) -> list[str]:
+        """Extract the ``slug`` field from a list of version objects."""
+        slugs: list[str] = []
+        for version in data:
+            if isinstance(version, dict):
+                version_dict = cast(_DICT_STR_OBJECT_TYPE, version)
+                slug: object = version_dict.get("slug")
+                if isinstance(slug, str):
+                    slugs.append(slug)
+        return slugs
+
+    def project_version_details(self, project: str, version: str) -> dict[str, object]:
         """Retrieve details of a single version.
 
         :param project: The project's slug
-        :param version: The version's slug
+        :param version: The version's slug. Route branch names through
+                        :func:`version_slug` first.
         :return: {result}
+        :raises ReadTheDocsNotFoundError: If the version does not exist.
         """
-        response: ApiResponse = self.get(f"projects/{project}/versions/{version}/")
-        result: dict[str, object] = self._json_body(response)
-        return json.dumps(result, indent=2)
+        return self._get_json(
+            f"projects/{project}/versions/{version}/",
+            f"Version {version!r} of project {project!r}",
+        )
 
-    def project_version_update(self, project: str, version: str, active: bool) -> ApiResponse:
+    def project_version_update(self, project: str, version: str, active: bool) -> dict[str, object]:
         """Edit version activity.
 
         :param project: The project slug
         :param version: The version slug
-        :param active: 'true' or 'false'
-        :return: {result}
+        :param active: Whether the version should be active
+        :return: {status payload}
         """
         data: dict[str, bool] = {"active": active}
 
         json_data: str = json.dumps(data)
         result: ApiResponse = self.patch(f"projects/{project}/versions/{version}/", data=json_data)
-        return result
+        resp = self._check(result, f"Update of version {version!r} for project {project!r}")
 
-    def project_update(self, project: str, *args: object) -> tuple[bool, int]:
+        return {
+            "status": "success",
+            "operation": "project-version-update",
+            "project": project,
+            "version": version,
+            "active": active,
+            "status_code": resp.status_code,
+        }
+
+    def project_update(self, project: str, updates: Mapping[str, object]) -> dict[str, object]:
         """Update any project details.
 
         :param project: Project's name (slug).
-        :param args: Any of the JSON keys allows by RTD API.
-        :return: Bool
+        :param updates: Any of the JSON keys allowed by the RTD API.
+        :return: {status payload}
+        :raises ReadTheDocsValidationError: If ``updates`` is empty.
         """
-        data: object = args[0]
-        json_data: str = json.dumps(data)
-        result: ApiResponse = self.patch(f"projects/{project}/", data=json_data)
-        resp = self._response_of(result)
+        if not updates:
+            msg = f"No fields supplied to update for project {project!r}"
+            raise ReadTheDocsValidationError(msg)
 
-        if resp.status_code == 204:
-            return True, resp.status_code
-        else:
-            return False, resp.status_code
+        json_data: str = json.dumps(dict(updates))
+        result: ApiResponse = self.patch(f"projects/{project}/", data=json_data)
+        resp = self._check(result, f"Update of project {project!r}")
+
+        return {
+            "status": "success",
+            "operation": "project-update",
+            "project": project,
+            "updated": dict(updates),
+            "status_code": resp.status_code,
+        }
 
     def project_create(
         self,
@@ -177,7 +359,7 @@ class ReadTheDocs(client.RestApi):
         homepage: str,
         programming_language: str,
         language: str,
-    ) -> ApiResponse:
+    ) -> dict[str, object]:
         """Create a new Read the Docs project.
 
         :param name: Project name. Any spaces will convert to dashes for the
@@ -190,8 +372,7 @@ class ReadTheDocs(client.RestApi):
                         swift, vb, r, objc, css, ts, scala, groovy, coffee,
                         lua, haskell, other, words
         :param language: Most two letter language abbreviations: en, es, etc.
-        :param kwargs:
-        :return: {results}
+        :return: {result}
         """
         data: dict[str, str | dict[str, str]] = {
             "name": name,
@@ -203,50 +384,62 @@ class ReadTheDocs(client.RestApi):
 
         json_data: str = json.dumps(data)
         result: ApiResponse = self.post("projects/", data=json_data)
-        return result
+        _ = self._check(result, f"Creation of project {name!r}")
+        return self._json_body(result)
 
-    def project_build_list(self, project: str) -> str:
+    # -- Builds --------------------------------------------------------------
+
+    def project_build_list(self, project: str) -> list[dict[str, object]]:
         """Retrieve the project's running build list.
 
         For future expansion, the statuses are cloning,
         installing, building.
 
         :param project: The project's slug
-        :param kwargs:
-        :return: {result}
+        :return: [builds]. An empty list when no builds are running.
         """
-        response: ApiResponse = self.get(f"projects/{project}/builds/?running=True")
-        result: dict[str, object] = self._json_body(response)
+        result = self._get_json(
+            f"projects/{project}/builds/?running=True",
+            f"Build list for project {project!r}",
+        )
 
-        count: object = result["count"]
-        if isinstance(count, int) and count > 0:
-            return json.dumps(result, indent=2)
-        else:
-            return "There are no active builds."
+        builds: list[dict[str, object]] = []
+        data: object = result.get("results")
+        if isinstance(data, list):
+            for build in cast(_LIST_OBJECT_TYPE, data):
+                if isinstance(build, dict):
+                    builds.append(cast(_DICT_STR_OBJECT_TYPE, build))
+        return builds
 
-    def project_build_details(self, project: str, build_id: str) -> str:
+    def project_build_details(self, project: str, build_id: str) -> dict[str, object]:
         """Retrieve the details of a specific build.
 
         :param project: The project's slug
         :param build_id: The build id
-        :param kwargs:
         :return: {result}
         """
-        response: ApiResponse = self.get(f"projects/{project}/builds/{build_id}/")
-        result: dict[str, object] = self._json_body(response)
-        return json.dumps(result, indent=2)
+        return self._get_json(
+            f"projects/{project}/builds/{build_id}/",
+            f"Build {build_id!r} of project {project!r}",
+        )
 
-    def project_build_trigger(self, project: str, version: str) -> str:
+    def project_build_trigger(self, project: str, version: str) -> dict[str, object]:
         """Trigger a project build.
 
         :param project: The project's slug
         :param version: The version of the project to build
-                        (must be an active version)
+                        (must be an active version). Route branch names
+                        through :func:`version_slug` first.
         :return: {result}
         """
         response: ApiResponse = self.post(f"projects/{project}/versions/{version}/builds/")
-        result: dict[str, object] = self._json_body(response)
-        return json.dumps(result, indent=2)
+        _ = self._check(
+            response,
+            f"Build trigger for version {version!r} of project {project!r}",
+        )
+        return self._json_body(response)
+
+    # -- Subprojects ---------------------------------------------------------
 
     def subproject_list(self, project: str) -> list[str]:
         """Return a list of subprojects.
@@ -254,12 +447,14 @@ class ReadTheDocs(client.RestApi):
         This returns the list of subprojects by their slug name ['slug'],
         not their pretty name ['name'].
 
-        :param kwargs:
+        :param project: The top-level project's slug
         :return: [subprojects]
         """
-        response: ApiResponse = self.get(f"projects/{project}/subprojects/?limit=999")  # NOQA
-        result: dict[str, object] = self._json_body(response)
-        data: object = result["results"]
+        result = self._get_json(
+            f"projects/{project}/subprojects/?limit=999",  # NOQA
+            f"Subproject list for project {project!r}",
+        )
+        data: object = result.get("results")
         subproject_list: list[str] = []
 
         if isinstance(data, list):
@@ -275,18 +470,28 @@ class ReadTheDocs(client.RestApi):
 
         return subproject_list
 
+    def subproject_exists(self, project: str, subproject: str) -> bool:
+        """Report whether a project/subproject relationship exists.
+
+        :param project: The top-level project's slug
+        :param subproject: The subordinated project's slug
+        :return: True when the relationship exists.
+        """
+        return subproject in self.subproject_list(project)
+
     def subproject_details(self, project: str, subproject: str) -> dict[str, object]:
         """Retrieve the details of a specific subproject.
 
-        :param project:
-        :param subproject:
-        :return:
+        :param project: The top-level project's slug
+        :param subproject: The subordinated project's slug
+        :return: {result}
         """
-        response: ApiResponse = self.get(f"projects/{project}/subprojects/{subproject}/")
-        result: dict[str, object] = self._json_body(response)
-        return result
+        return self._get_json(
+            f"projects/{project}/subprojects/{subproject}/",
+            f"Subproject {subproject!r} of project {project!r}",
+        )
 
-    def subproject_create(self, project: str, subproject: str, alias: str | None = None) -> ApiResponse:
+    def subproject_create(self, project: str, subproject: str, alias: str | None = None) -> dict[str, object]:
         """Create a subproject.
 
         Subprojects are actually just top-level projects that
@@ -297,24 +502,42 @@ class ReadTheDocs(client.RestApi):
         :param project: The top-level project's slug
         :param subproject: The other project's slug that is to be subordinated
         :param alias: An alias (not required). (user-defined slug)
-        :return:
+        :return: {status payload}
         """
         data: dict[str, str | None] = {"child": subproject, "alias": alias}
         json_data: str = json.dumps(data)
         result: ApiResponse = self.post(f"projects/{project}/subprojects/", data=json_data)
-        return result
+        resp = self._check(
+            result,
+            f"Creation of subproject {subproject!r} under project {project!r}",
+        )
 
-    def subproject_delete(self, project: str, subproject: str) -> bool | tuple[bool, int]:
+        return {
+            "status": "success",
+            "operation": "subproject-create",
+            "project": project,
+            "subproject": subproject,
+            "alias": alias,
+            "status_code": resp.status_code,
+        }
+
+    def subproject_delete(self, project: str, subproject: str) -> dict[str, object]:
         """Delete project/sub relationship.
 
-        :param project:
-        :param subproject:
-        :return:
+        :param project: The top-level project's slug
+        :param subproject: The subordinated project's slug
+        :return: {status payload}
         """
         result: ApiResponse = self.delete(f"projects/{project}/subprojects/{subproject}/")
-        resp = self._response_of(result)
+        resp = self._check(
+            result,
+            f"Deletion of subproject {subproject!r} from project {project!r}",
+        )
 
-        if resp.status_code == 204:
-            return True
-        else:
-            return False, resp.status_code
+        return {
+            "status": "success",
+            "operation": "subproject-delete",
+            "project": project,
+            "subproject": subproject,
+            "status_code": resp.status_code,
+        }

--- a/lftools_uv/cli/rtd.py
+++ b/lftools_uv/cli/rtd.py
@@ -8,26 +8,48 @@
 # http://www.eclipse.org/legal/epl-v10.html
 ##############################################################################
 
-"""Read the Docs interface."""
+"""Read the Docs interface.
+
+.. deprecated::
+    This Click command group is retained for backwards compatibility and
+    reachable only via ``LEGACY_CLI=1``. It reproduces the historical
+    output formats verbatim, including their inconsistencies. New
+    callers should use the Typer implementation in
+    :mod:`lftools_uv.typer_apps.rtd`, which offers ``--json`` on every
+    command.
+"""
 
 __author__ = "DW Talton"
 
 
+import json
 import logging
 from pprint import pformat
 
 import click
 
 from lftools_uv.api.endpoints import readthedocs
+from lftools_uv.api.endpoints.readthedocs import ReadTheDocsError, ReadTheDocsNotFoundError
 
 log = logging.getLogger(__name__)
+
+_DEPRECATION_NOTICE = (
+    "The legacy Click 'rtd' commands are deprecated and will be removed "
+    "in a future release. Use the default Typer CLI, which provides "
+    "--json output on every command."
+)
+
+
+def _emit_json(data: object) -> None:
+    """Print a payload as JSON, matching the historical output format."""
+    log.info(json.dumps(data, indent=2))
 
 
 @click.group()
 @click.pass_context
 def rtd(ctx):
     """Read the Docs interface."""
-    pass
+    log.warning(_DEPRECATION_NOTICE)
 
 
 @click.command(name="project-list")
@@ -77,7 +99,7 @@ def project_version_update(ctx, project_slug, version_slug, active):
     """
     r = readthedocs.ReadTheDocs()
     data = r.project_version_update(project_slug, version_slug, active)
-    log.info(data)
+    log.info(pformat(data))
 
 
 @click.command(name="project-version-details")
@@ -88,7 +110,7 @@ def project_version_details(ctx, project_slug, version_slug):
     """Retrieve project version details."""
     r = readthedocs.ReadTheDocs()
     data = r.project_version_details(project_slug, version_slug)
-    log.info(data)
+    _emit_json(data)
 
 
 @click.command(name="project-create")
@@ -116,7 +138,7 @@ def project_create(ctx, project_name, repository_url, repository_type, homepage,
 @click.argument("project-name")
 @click.pass_context
 def project_update(ctx, project_name):
-    """Create a new project."""
+    """Update an existing project."""
     r = readthedocs.ReadTheDocs()
     d = {}
     for item in ctx.args:
@@ -133,7 +155,10 @@ def project_build_list(ctx, project_slug):
     """Retrieve a list of a project's builds."""
     r = readthedocs.ReadTheDocs()
     data = r.project_build_list(project_slug)
-    log.info(data)
+    if data:
+        _emit_json({"count": len(data), "results": data})
+    else:
+        log.info("There are no active builds.")
 
 
 @click.command(name="project-build-details")
@@ -144,7 +169,7 @@ def project_build_details(ctx, project_slug, build_id):
     """Retrieve specific project build details."""
     r = readthedocs.ReadTheDocs()
     data = r.project_build_details(project_slug, build_id)
-    log.info(data)
+    _emit_json(data)
 
 
 @click.command(name="project-build-trigger")
@@ -155,7 +180,7 @@ def project_build_trigger(ctx, project_slug, version_slug):
     """Trigger a new build."""
     r = readthedocs.ReadTheDocs()
     data = r.project_build_trigger(project_slug, version_slug)
-    log.info(data)
+    _emit_json(data)
 
 
 @click.command(name="subproject-list")
@@ -201,11 +226,15 @@ def subproject_create(ctx, project_slug, subproject_slug):
 def subproject_delete(ctx, project_slug, subproject_slug):
     """Delete a project-subproject relationship."""
     r = readthedocs.ReadTheDocs()
-    data = r.subproject_delete(project_slug, subproject_slug)
-    if data:
-        log.info(f"Successfully removed the {project_slug} {subproject_slug} relationship")
-    else:
+    try:
+        _ = r.subproject_delete(project_slug, subproject_slug)
+    except ReadTheDocsNotFoundError:
         log.error("Request failed. Is there a subproject relationship?")
+        return
+    except ReadTheDocsError:
+        log.exception("Request failed")
+        return
+    log.info(f"Successfully removed the {project_slug} {subproject_slug} relationship")
 
 
 rtd.add_command(project_list)

--- a/lftools_uv/typer_apps/rtd.py
+++ b/lftools_uv/typer_apps/rtd.py
@@ -7,171 +7,582 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 ##############################################################################
-"""Typer version of Read the Docs commands."""
+"""Typer implementation of the Read the Docs commands.
 
+Every command accepts ``--json`` and emits a machine-readable payload on
+stdout when asked. Human-oriented output renders as a table. Errors and
+warnings go to stderr so that a caller parsing stdout never has its
+stream corrupted by a diagnostic.
+"""
+
+from __future__ import annotations
+
+import json
 import logging
+from typing import TYPE_CHECKING, Any
 
 import typer
+from tabulate import tabulate
 
-from lftools_uv.api.endpoints.readthedocs import ReadTheDocs
+from lftools_uv.api.endpoints.readthedocs import (
+    ReadTheDocs,
+    ReadTheDocsError,
+    version_slug,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 log = logging.getLogger(__name__)
 
-# Create the rtd subcommand group
 rtd_app = typer.Typer(
     name="rtd",
-    help="Read the Docs interface",
+    help="Read the Docs interface.",
     add_completion=False,
+    no_args_is_help=True,
 )
 
 
+# ---------------------------------------------------------------------------
+# Shared output helpers
+# ---------------------------------------------------------------------------
+
+
+def emit_error(message: str) -> None:
+    """Write an error message to stderr.
+
+    Centralizes the format so that every Read the Docs command presents
+    errors identically. Does NOT exit; the caller decides whether to
+    raise ``typer.Exit``.
+    """
+    typer.echo(f"Error: {message}", err=True)
+
+
+def handle_rtd_error(exc: ReadTheDocsError) -> typer.Exit:
+    """Format a :class:`ReadTheDocsError` and return ``typer.Exit``.
+
+    Callers should ``raise`` the returned ``typer.Exit`` to abort.
+    """
+    emit_error(str(exc))
+    return typer.Exit(code=1)
+
+
+def emit_table(rows: Sequence[Sequence[Any]], headers: Sequence[str]) -> None:
+    """Print a human-readable table to stdout using ``tabulate``."""
+    typer.echo(tabulate(list(rows), headers=list(headers)))
+
+
+def emit_json(payload: Any) -> None:
+    """Print a JSON payload to stdout with indent=2."""
+    typer.echo(json.dumps(payload, indent=2, sort_keys=False, default=str))
+
+
+def _wants_json(ctx: typer.Context, json_output: bool) -> bool:
+    """Resolve the effective ``--json`` setting.
+
+    The flag is accepted both on the group callback and on each command,
+    so a user may write either ``rtd --json project-list`` or
+    ``rtd project-list --json``.
+    """
+    if json_output:
+        return True
+    options: dict[str, Any] = ctx.obj or {}
+    return options.get("json_output") is True
+
+
+def _client() -> ReadTheDocs:
+    """Build an API client."""
+    return ReadTheDocs()
+
+
+def _json_option() -> Any:
+    """Build the per-command ``--json`` option.
+
+    Returns ``Any`` because ``typer.Option`` yields an ``OptionInfo``
+    sentinel that Typer replaces with a ``bool`` at call time.
+    """
+    return typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of a table.",
+    )
+
+
 @rtd_app.callback()
-def rtd_callback() -> None:
+def rtd_callback(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of a table.",
+    ),
+) -> None:
     """Read the Docs interface."""
-    pass
+    ctx.obj = {
+        **(ctx.obj or {}),
+        "json_output": json_output,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Projects
+# ---------------------------------------------------------------------------
 
 
 @rtd_app.command("project-list")
-def project_list() -> None:
+def project_list(
+    ctx: typer.Context,
+    json_output: bool = _json_option(),
+) -> None:
     """Get a list of Read the Docs projects.
 
-    Returns a list of RTD projects for the account whose
-    token is configured in lftools.ini. This returns the
-    slug name, not the pretty name.
+    Returns projects by their slug name, not their pretty name, since
+    the slug is what other commands accept.
 
     Examples:
         lftools-uv rtd project-list
+        lftools-uv rtd project-list --json
     """
     try:
-        rtd_client = ReadTheDocs()
-        projects = rtd_client.project_list()
-        if projects:
-            typer.echo("Read the Docs Projects:")
-            for project in projects:
-                typer.echo(f"  - {project}")
-        else:
-            typer.echo("No projects found")
-    except Exception as e:
-        log.exception("Failed to get project list")
-        typer.echo(f"Error: Failed to get project list: {e}", err=True)
-        raise typer.Exit(1) from None
+        projects = _client().project_list()
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json({"projects": projects})
+        return
+
+    if not projects:
+        typer.echo("No projects found")
+        return
+    emit_table([[p] for p in projects], ["Project Slug"])
 
 
 @rtd_app.command("project-details")
 def project_details(
+    ctx: typer.Context,
     project_slug: str = typer.Argument(..., help="Project slug name"),
+    json_output: bool = _json_option(),
 ) -> None:
     """Get details for a specific Read the Docs project.
 
-    Args:
-        project_slug: The slug name of the project
-
     Examples:
-        lftools-uv rtd project-details my-project
+        lftools-uv rtd project-details onap-cps
+        lftools-uv rtd project-details onap-cps --json
     """
     try:
-        rtd_client = ReadTheDocs()
-        details = rtd_client.project_details(project_slug)
-        if details:
-            typer.echo(f"Project Details for '{project_slug}':")
-            typer.echo(f"  Name: {details.get('name', 'N/A')}")
-            typer.echo(f"  Description: {details.get('description', 'N/A')}")
-            typer.echo(f"  Language: {details.get('language', 'N/A')}")
-            typer.echo(f"  Repository URL: {details.get('repository_url', 'N/A')}")
-            typer.echo(f"  Default Version: {details.get('default_version', 'N/A')}")
-        else:
-            typer.echo(f"Project '{project_slug}' not found")
-            raise typer.Exit(1)
-    except Exception as e:
-        log.exception("Failed to get project details")
-        typer.echo(f"Error: Failed to get project details: {e}", err=True)
-        raise typer.Exit(1) from None
+        details = _client().project_details(project_slug)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(details)
+        return
+
+    rows = [
+        ["Name", details.get("name", "")],
+        ["Slug", details.get("slug", "")],
+        ["Language", details.get("language", "")],
+        ["Programming Language", details.get("programming_language", "")],
+        ["Default Version", details.get("default_version", "")],
+        ["Homepage", details.get("homepage", "")],
+    ]
+    emit_table(rows, ["Field", "Value"])
 
 
 @rtd_app.command("project-create")
 def project_create(
-    name: str = typer.Argument(..., help="Project name"),
-    repo_url: str = typer.Argument(..., help="Repository URL"),
-    description: str | None = typer.Option(None, "--description", help="Project description"),
-    language: str = typer.Option("en", "--language", help="Project language code"),
+    ctx: typer.Context,
+    project_name: str = typer.Argument(..., help="Project name"),
+    repository_url: str = typer.Argument(..., help="Repository URL"),
+    repository_type: str = typer.Argument(..., help="Repository type: git, hg, bzr or svn"),
+    homepage: str = typer.Argument(..., help="Project homepage URL"),
+    programming_language: str = typer.Argument(..., help="Programming language abbreviation, e.g. py"),
+    language: str = typer.Argument(..., help="Two-letter language code, e.g. en"),
+    json_output: bool = _json_option(),
 ) -> None:
     """Create a new Read the Docs project.
 
-    Args:
-        name: The name of the project
-        repo_url: The repository URL
-        description: Project description (optional)
-        language: Project language code (default: en)
-
     Examples:
-        lftools-uv rtd project-create "My Project" https://github.com/user/repo
-        lftools-uv rtd project-create "My Project" https://github.com/user/repo --description "A great project"
+        lftools-uv rtd project-create onap-cps https://example.org/cps git https://onap-cps.readthedocs.io py en
     """
     try:
-        rtd_client = ReadTheDocs()
-        # Note: The actual API signature may differ - this is a placeholder implementation
-        result = rtd_client.project_create(
-            name=name,
-            repository_url=repo_url,
-            repository_type="git",
-            homepage="",
-            programming_language="python",
-            language=language,
+        result = _client().project_create(
+            project_name,
+            repository_url,
+            repository_type,
+            homepage,
+            programming_language,
+            language,
         )
-        if result:
-            typer.echo(f"✅ Project '{name}' created successfully")
-        else:
-            typer.echo(f"Failed to create project '{name}'")
-            raise typer.Exit(1)
-    except Exception as e:
-        log.exception("Failed to create project")
-        typer.echo(f"Error: Failed to create project: {e}", err=True)
-        raise typer.Exit(1) from None
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(result)
+        return
+    typer.echo(f"Created project '{project_name}'")
 
 
-@rtd_app.command("project-update")
+@rtd_app.command(
+    "project-update",
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+)
 def project_update(
+    ctx: typer.Context,
     project_slug: str = typer.Argument(..., help="Project slug name"),
-    name: str | None = typer.Option(None, "--name", help="New project name"),
-    description: str | None = typer.Option(None, "--description", help="New project description"),
-    repo_url: str | None = typer.Option(None, "--repo-url", help="New repository URL"),
+    json_output: bool = _json_option(),
 ) -> None:
     """Update an existing Read the Docs project.
 
-    Args:
-        project_slug: The slug name of the project to update
-        name: New project name (optional)
-        description: New project description (optional)
-        repo_url: New repository URL (optional)
+    Accepts any number of ``key=value`` pairs matching the fields the
+    Read the Docs API allows.
 
     Examples:
-        lftools-uv rtd project-update my-project --name "New Name"
-        lftools-uv rtd project-update my-project --description "Updated description"
+        lftools-uv rtd project-update onap-cps default_version=latest
+    """
+    updates: dict[str, str] = {}
+    for item in ctx.args:
+        if "=" not in item:
+            emit_error(f"Expected key=value, received {item!r}")
+            raise typer.Exit(code=1)
+        key, value = item.split("=", 1)
+        updates[key] = value
+
+    if not updates:
+        emit_error("No update parameters provided")
+        raise typer.Exit(code=1)
+
+    try:
+        result = _client().project_update(project_slug, updates)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(result)
+        return
+    typer.echo(f"Updated project '{project_slug}'")
+
+
+# ---------------------------------------------------------------------------
+# Versions
+# ---------------------------------------------------------------------------
+
+
+@rtd_app.command("project-version-list")
+def project_version_list(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Project slug name"),
+    json_output: bool = _json_option(),
+) -> None:
+    """Retrieve the active versions of a project.
+
+    Examples:
+        lftools-uv rtd project-version-list onap-cps
     """
     try:
-        if name is None and description is None and repo_url is None:
-            typer.echo("No update parameters provided")
-            raise typer.Exit(1)
+        versions = _client().project_version_list(project_slug)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
 
-        rtd_client = ReadTheDocs()
-        update_data: dict[str, object] = {}
-        if name is not None:
-            update_data["name"] = name
-        if description is not None:
-            update_data["description"] = description
-        if repo_url is not None:
-            update_data["repository"] = {"url": repo_url}
+    if _wants_json(ctx, json_output):
+        emit_json({"project": project_slug, "versions": versions})
+        return
 
-        success, status_code = rtd_client.project_update(project_slug, update_data)
-        if success:
-            typer.echo(f"✅ Project '{project_slug}' updated successfully")
-        else:
-            typer.echo(f"Failed to update project '{project_slug}' (HTTP {status_code})")
-            raise typer.Exit(1)
-    except Exception as e:
-        log.exception("Failed to update project")
-        typer.echo(f"Error: Failed to update project: {e}", err=True)
-        raise typer.Exit(1) from None
+    if not versions:
+        typer.echo("No active versions found")
+        return
+    emit_table([[v] for v in versions], ["Version Slug"])
+
+
+@rtd_app.command("project-version-details")
+def project_version_details(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Project slug name"),
+    version_slug_arg: str = typer.Argument(..., metavar="VERSION_SLUG", help="Version slug name"),
+    from_branch: bool = typer.Option(
+        False,
+        "--from-branch",
+        help="Treat VERSION_SLUG as a git branch name and slugify it first.",
+    ),
+    json_output: bool = _json_option(),
+) -> None:
+    """Retrieve details of a single version.
+
+    Read the Docs addresses a version by its slug, so a branch named
+    ``maintenance/3.7.10`` is stored as ``maintenance-3.7.10``. Pass
+    ``--from-branch`` to convert a branch name automatically.
+
+    Examples:
+        lftools-uv rtd project-version-details onap-cps latest
+        lftools-uv rtd project-version-details onap-cps maintenance/3.7.10 --from-branch
+    """
+    try:
+        target = version_slug(version_slug_arg) if from_branch else version_slug_arg
+        details = _client().project_version_details(project_slug, target)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(details)
+        return
+
+    rows = [
+        ["Slug", details.get("slug", "")],
+        ["Verbose Name", details.get("verbose_name", "")],
+        ["Active", details.get("active", "")],
+        ["Built", details.get("built", "")],
+        ["Type", details.get("type", "")],
+    ]
+    emit_table(rows, ["Field", "Value"])
+
+
+@rtd_app.command("project-version-update")
+def project_version_update(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Project slug name"),
+    version_slug_arg: str = typer.Argument(..., metavar="VERSION_SLUG", help="Version slug name"),
+    active: bool = typer.Argument(..., help="Whether the version should be active"),
+    from_branch: bool = typer.Option(
+        False,
+        "--from-branch",
+        help="Treat VERSION_SLUG as a git branch name and slugify it first.",
+    ),
+    json_output: bool = _json_option(),
+) -> None:
+    """Update a version's active flag.
+
+    Examples:
+        lftools-uv rtd project-version-update onap-cps maintenance/3.7.10 true --from-branch
+    """
+    try:
+        target = version_slug(version_slug_arg) if from_branch else version_slug_arg
+        result = _client().project_version_update(project_slug, target, active)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(result)
+        return
+    state = "active" if active else "inactive"
+    typer.echo(f"Marked version '{result['version']}' of '{project_slug}' as {state}")
+
+
+# ---------------------------------------------------------------------------
+# Builds
+# ---------------------------------------------------------------------------
+
+
+@rtd_app.command("project-build-list")
+def project_build_list(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Project slug name"),
+    json_output: bool = _json_option(),
+) -> None:
+    """Retrieve a project's running builds.
+
+    With ``--json`` the payload always carries a ``builds`` list, empty
+    when nothing is running, so a caller can parse the result without a
+    special case. Table output prints a short message instead.
+
+    Examples:
+        lftools-uv rtd project-build-list onap-cps --json
+    """
+    try:
+        builds = _client().project_build_list(project_slug)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json({"project": project_slug, "count": len(builds), "builds": builds})
+        return
+
+    if not builds:
+        typer.echo("There are no active builds.")
+        return
+    rows = [
+        [
+            b.get("id", ""),
+            b.get("version", ""),
+            b.get("state", ""),
+            b.get("success", ""),
+        ]
+        for b in builds
+    ]
+    emit_table(rows, ["Build ID", "Version", "State", "Success"])
+
+
+@rtd_app.command("project-build-details")
+def project_build_details(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Project slug name"),
+    build_id: str = typer.Argument(..., help="Build identifier"),
+    json_output: bool = _json_option(),
+) -> None:
+    """Retrieve the details of a specific build.
+
+    Examples:
+        lftools-uv rtd project-build-details onap-cps 9584913 --json
+    """
+    try:
+        details = _client().project_build_details(project_slug, build_id)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(details)
+        return
+
+    rows = [
+        ["ID", details.get("id", "")],
+        ["Version", details.get("version", "")],
+        ["State", details.get("state", "")],
+        ["Success", details.get("success", "")],
+        ["Duration", details.get("duration", "")],
+    ]
+    emit_table(rows, ["Field", "Value"])
+
+
+@rtd_app.command("project-build-trigger")
+def project_build_trigger(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Project slug name"),
+    version_slug_arg: str = typer.Argument(..., metavar="VERSION_SLUG", help="Version slug to build"),
+    from_branch: bool = typer.Option(
+        False,
+        "--from-branch",
+        help="Treat VERSION_SLUG as a git branch name and slugify it first.",
+    ),
+    json_output: bool = _json_option(),
+) -> None:
+    """Trigger a build of a project version.
+
+    Examples:
+        lftools-uv rtd project-build-trigger onap-cps latest
+        lftools-uv rtd project-build-trigger onap-cps maintenance/3.7.10 --from-branch
+    """
+    try:
+        target = version_slug(version_slug_arg) if from_branch else version_slug_arg
+        result = _client().project_build_trigger(project_slug, target)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(result)
+        return
+
+    build = result.get("build")
+    build_id = build.get("id", "") if isinstance(build, dict) else ""
+    typer.echo(f"Triggered build {build_id} for '{project_slug}'")
+
+
+# ---------------------------------------------------------------------------
+# Subprojects
+# ---------------------------------------------------------------------------
+
+
+@rtd_app.command("subproject-list")
+def subproject_list(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Parent project slug name"),
+    json_output: bool = _json_option(),
+) -> None:
+    """Get a list of subprojects for a project.
+
+    Examples:
+        lftools-uv rtd subproject-list onap
+    """
+    try:
+        subprojects = _client().subproject_list(project_slug)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json({"project": project_slug, "subprojects": subprojects})
+        return
+
+    if not subprojects:
+        typer.echo("No subprojects found")
+        return
+    emit_table([[s] for s in subprojects], ["Subproject Slug"])
+
+
+@rtd_app.command("subproject-details")
+def subproject_details(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Parent project slug name"),
+    subproject_slug: str = typer.Argument(..., help="Subproject slug name"),
+    json_output: bool = _json_option(),
+) -> None:
+    """Retrieve the details of a specific subproject.
+
+    Examples:
+        lftools-uv rtd subproject-details onap onap-cps --json
+    """
+    try:
+        details = _client().subproject_details(project_slug, subproject_slug)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(details)
+        return
+
+    child = details.get("child")
+    child_slug = child.get("slug", "") if isinstance(child, dict) else ""
+    rows = [
+        ["Parent", project_slug],
+        ["Child", child_slug],
+        ["Alias", details.get("alias", "")],
+    ]
+    emit_table(rows, ["Field", "Value"])
+
+
+@rtd_app.command("subproject-create")
+def subproject_create(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Parent project slug name"),
+    subproject_slug: str = typer.Argument(..., help="Subproject slug name"),
+    alias: str | None = typer.Option(None, "--alias", help="Optional user-defined alias"),
+    json_output: bool = _json_option(),
+) -> None:
+    """Create a project/subproject relationship.
+
+    Examples:
+        lftools-uv rtd subproject-create onap onap-cps
+    """
+    try:
+        result = _client().subproject_create(project_slug, subproject_slug, alias)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(result)
+        return
+    typer.echo(f"Created the {project_slug} {subproject_slug} relationship")
+
+
+@rtd_app.command("subproject-delete")
+def subproject_delete(
+    ctx: typer.Context,
+    project_slug: str = typer.Argument(..., help="Parent project slug name"),
+    subproject_slug: str = typer.Argument(..., help="Subproject slug name"),
+    json_output: bool = _json_option(),
+) -> None:
+    """Delete a project/subproject relationship.
+
+    Examples:
+        lftools-uv rtd subproject-delete onap onap-cps
+    """
+    try:
+        result = _client().subproject_delete(project_slug, subproject_slug)
+    except ReadTheDocsError as exc:
+        raise handle_rtd_error(exc) from exc
+
+    if _wants_json(ctx, json_output):
+        emit_json(result)
+        return
+    typer.echo(f"Removed the {project_slug} {subproject_slug} relationship")
 
 
 def get_rtd_app() -> typer.Typer:

--- a/tests/test_rtd.py
+++ b/tests/test_rtd.py
@@ -16,6 +16,12 @@ import pytest
 import responses
 
 import lftools_uv.api.endpoints.readthedocs as client
+from lftools_uv.api.endpoints.readthedocs import (
+    ReadTheDocsAPIError,
+    ReadTheDocsNotFoundError,
+    ReadTheDocsValidationError,
+    version_slug,
+)
 
 creds = {"authtype": "token", "endpoint": "https://readthedocs.org/api/v3/", "token": "xyz"}
 rtd = client.ReadTheDocs(creds=creds)
@@ -24,6 +30,41 @@ FIXTURE_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     "fixtures",
 )
+
+
+# ---------------------------------------------------------------------------
+# Version slug conversion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("branch", "expected"),
+    [
+        ("master", "master"),
+        ("latest", "latest"),
+        ("maintenance/3.7.10", "maintenance-3.7.10"),
+        ("mr/879/126960/2", "mr-879-126960-2"),
+        ("Montreal", "montreal"),
+        ("feature/ABC-123_thing", "feature-abc-123_thing"),
+        ("release/1.0", "release-1.0"),
+        ("  spaced/branch  ", "spaced-branch"),
+    ],
+)
+def test_version_slug(branch, expected):
+    """Branch names convert to the slug Read the Docs stores."""
+    assert version_slug(branch) == expected
+
+
+@pytest.mark.parametrize("branch", ["", "   ", "///", "!!!"])
+def test_version_slug_rejects_unusable(branch):
+    """Empty or punctuation-only branch names raise."""
+    with pytest.raises(ReadTheDocsValidationError):
+        version_slug(branch)
+
+
+# ---------------------------------------------------------------------------
+# Projects
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.datafiles(
@@ -49,7 +90,63 @@ def test_project_details(datafiles):
     responses.add(
         responses.GET, url="https://readthedocs.org/api/v3/projects/TestProject1/", json=json_data, status=200
     )
-    assert "slug" in rtd.project_details("TestProject1")
+    details = rtd.project_details("TestProject1")
+    assert isinstance(details, dict)
+    assert "slug" in details
+
+
+@responses.activate
+def test_project_details_not_found():
+    """A 404 raises a typed error rather than returning prose."""
+    responses.add(
+        responses.GET,
+        url="https://readthedocs.org/api/v3/projects/nope/",
+        json={"detail": "Not found."},
+        status=404,
+    )
+    with pytest.raises(ReadTheDocsNotFoundError) as excinfo:
+        rtd.project_details("nope")
+    assert excinfo.value.status_code == 404
+
+
+@responses.activate
+def test_project_details_server_error():
+    """A 500 raises an API error carrying the status code."""
+    responses.add(
+        responses.GET,
+        url="https://readthedocs.org/api/v3/projects/boom/",
+        json={"detail": "Server Error"},
+        status=500,
+    )
+    with pytest.raises(ReadTheDocsAPIError) as excinfo:
+        rtd.project_details("boom")
+    assert excinfo.value.status_code == 500
+
+
+@pytest.mark.datafiles(
+    os.path.join(FIXTURE_DIR, "rtd"),
+)
+@responses.activate
+def test_project_exists_true(datafiles):
+    os.chdir(str(datafiles))
+    json_file = open("project_details.json")
+    json_data = json.loads(json_file.read())
+    responses.add(
+        responses.GET, url="https://readthedocs.org/api/v3/projects/TestProject1/", json=json_data, status=200
+    )
+    assert rtd.project_exists("TestProject1") is True
+
+
+@responses.activate
+def test_project_exists_false():
+    """Absence reports as False rather than an error string."""
+    responses.add(
+        responses.GET,
+        url="https://readthedocs.org/api/v3/projects/nope/",
+        json={"detail": "Not found."},
+        status=404,
+    )
+    assert rtd.project_exists("nope") is False
 
 
 @pytest.mark.datafiles(
@@ -84,7 +181,23 @@ def test_project_version_details(datafiles):
         json=json_data,
         status=200,
     )
-    assert "slug" in rtd.project_version_details("TestProject1", "latest")
+    details = rtd.project_version_details("TestProject1", "latest")
+    assert isinstance(details, dict)
+    assert "slug" in details
+
+
+@responses.activate
+def test_project_version_details_uses_slug():
+    """A slugified branch resolves; the raw branch name would not."""
+    responses.add(
+        responses.GET,
+        url="https://readthedocs.org/api/v3/projects/onap-cps/versions/maintenance-3.7.10/",
+        json={"slug": "maintenance-3.7.10", "verbose_name": "maintenance/3.7.10", "active": False},
+        status=200,
+    )
+    details = rtd.project_version_details("onap-cps", version_slug("maintenance/3.7.10"))
+    assert details["verbose_name"] == "maintenance/3.7.10"
+    assert details["active"] is False
 
 
 @responses.activate
@@ -95,7 +208,10 @@ def test_project_version_update():
         body="",
         status=204,
     )
-    assert rtd.project_version_update("TestProject1", "latest", True)
+    result = rtd.project_version_update("TestProject1", "latest", True)
+    assert result["status"] == "success"
+    assert result["version"] == "latest"
+    assert result["active"] is True
 
 
 @responses.activate
@@ -108,9 +224,34 @@ def test_project_create():
         "language": "en",
     }
     responses.add(responses.POST, url="https://readthedocs.org/api/v3/projects/", json=data, status=201)
-    assert rtd.project_create(
+    result = rtd.project_create(
         "TestProject1", "https://repository_url", "my_repo_type", "https://homepageurl", "py", "en"
     )
+    assert result["name"] == "TestProject1"
+
+
+@responses.activate
+def test_project_update():
+    responses.add(
+        responses.PATCH,
+        url="https://readthedocs.org/api/v3/projects/TestProject1/",
+        body="",
+        status=204,
+    )
+    result = rtd.project_update("TestProject1", {"default_version": "latest"})
+    assert result["status"] == "success"
+    assert result["updated"] == {"default_version": "latest"}
+
+
+def test_project_update_rejects_empty_payload():
+    """An empty update raises a typed error rather than IndexError."""
+    with pytest.raises(ReadTheDocsValidationError):
+        rtd.project_update("TestProject1", {})
+
+
+# ---------------------------------------------------------------------------
+# Builds
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.datafiles(
@@ -128,7 +269,22 @@ def test_project_build_list(datafiles):
         status=200,
         match_querystring=True,
     )
-    assert "success" in rtd.project_build_list("testproject1")
+    builds = rtd.project_build_list("testproject1")
+    assert isinstance(builds, list)
+    assert builds[0]["success"] is True
+
+
+@responses.activate
+def test_project_build_list_empty_returns_list():
+    """No running builds yields an empty list, never prose."""
+    responses.add(
+        responses.GET,
+        url="https://readthedocs.org/api/v3/projects/testproject1/builds/?running=True",
+        json={"count": 0, "results": []},
+        status=200,
+        match_querystring=True,
+    )
+    assert rtd.project_build_list("testproject1") == []
 
 
 @pytest.mark.datafiles(
@@ -145,19 +301,42 @@ def test_project_build_details(datafiles):
         json=json_data,
         status=200,
     )
-    assert "id" in rtd.project_build_details("testproject1", "9584913")
+    details = rtd.project_build_details("testproject1", "9584913")
+    assert isinstance(details, dict)
+    assert "id" in details
 
 
 @responses.activate
 def test_project_build_trigger():
-    data = {"project": "testproject1", "version": "latest"}
+    data = {"project": "testproject1", "version": "latest", "build": {"id": 12345}}
     responses.add(
         responses.POST,
         url="https://readthedocs.org/api/v3/projects/testproject1/versions/latest/builds/",  # noqa
         json=data,
         status=201,
     )
-    assert rtd.project_build_trigger("testproject1", "latest")
+    result = rtd.project_build_trigger("testproject1", "latest")
+    build = result["build"]
+    assert isinstance(build, dict)
+    assert build["id"] == 12345
+
+
+@responses.activate
+def test_project_build_trigger_unknown_version():
+    """Triggering an unknown version raises rather than emitting a jq-breaking body."""
+    responses.add(
+        responses.POST,
+        url="https://readthedocs.org/api/v3/projects/onap-cps/versions/maintenance-3.7.10/builds/",
+        json={"detail": "Not found."},
+        status=404,
+    )
+    with pytest.raises(ReadTheDocsNotFoundError):
+        rtd.project_build_trigger("onap-cps", "maintenance-3.7.10")
+
+
+# ---------------------------------------------------------------------------
+# Subprojects
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.datafiles(
@@ -182,6 +361,24 @@ def test_subproject_list(datafiles):
     os.path.join(FIXTURE_DIR, "rtd"),
 )
 @responses.activate
+def test_subproject_exists(datafiles):
+    os.chdir(str(datafiles))
+    json_file = open("subproject_list.json")
+    json_data = json.loads(json_file.read())
+    responses.add(
+        responses.GET,
+        url="https://readthedocs.org/api/v3/projects/TestProject1/subprojects/?limit=999",
+        json=json_data,
+        status=200,
+        match_querystring=True,
+    )
+    assert rtd.subproject_exists("TestProject1", "testproject2") is True
+
+
+@pytest.mark.datafiles(
+    os.path.join(FIXTURE_DIR, "rtd"),
+)
+@responses.activate
 def test_subproject_details(datafiles):
     os.chdir(str(datafiles))
     json_file = open("subproject_details.json")
@@ -192,7 +389,9 @@ def test_subproject_details(datafiles):
         json=json_data,
         status=200,
     )
-    assert "child" in rtd.subproject_details("TestProject1", "testproject2")
+    details = rtd.subproject_details("TestProject1", "testproject2")
+    assert isinstance(details, dict)
+    assert "child" in details
 
 
 @responses.activate
@@ -202,8 +401,30 @@ def test_subproject_create():
         url="https://readthedocs.org/api/v3/projects/TestProject1/subprojects/",
         status=201,  # NOQA
     )
-    assert rtd.subproject_create("TestProject1", "testproject2")
+    result = rtd.subproject_create("TestProject1", "testproject2")
+    assert result["status"] == "success"
+    assert result["subproject"] == "testproject2"
 
 
+@responses.activate
 def test_subproject_delete():
-    assert "untested because responses doesn't have DELETE support"
+    responses.add(
+        responses.DELETE,
+        url="https://readthedocs.org/api/v3/projects/TestProject1/subprojects/testproject2/",
+        status=204,
+    )
+    result = rtd.subproject_delete("TestProject1", "testproject2")
+    assert result["status"] == "success"
+
+
+@responses.activate
+def test_subproject_delete_missing():
+    """Deleting an absent relationship raises a typed error."""
+    responses.add(
+        responses.DELETE,
+        url="https://readthedocs.org/api/v3/projects/TestProject1/subprojects/nope/",
+        json={"detail": "Not found."},
+        status=404,
+    )
+    with pytest.raises(ReadTheDocsNotFoundError):
+        rtd.subproject_delete("TestProject1", "nope")

--- a/tests/unit/test_rtd_cli.py
+++ b/tests/unit/test_rtd_cli.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2026 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+"""Unit tests for the Read the Docs Typer CLI layer.
+
+Covers command registration, the ``--json`` contract on both the group
+callback and individual commands, branch-to-slug conversion via
+``--from-branch``, and the routing of diagnostics to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from lftools_uv.api.endpoints.readthedocs import (
+    ReadTheDocsAPIError,
+    ReadTheDocsNotFoundError,
+)
+from lftools_uv.typer_apps.rtd import get_rtd_app, rtd_app
+from tests.test_utils import clean_cli_output
+
+runner = CliRunner()
+
+#: Every command the documentation pipeline calls.
+PIPELINE_COMMANDS = [
+    "project-details",
+    "project-create",
+    "project-update",
+    "project-version-details",
+    "project-version-update",
+    "project-build-trigger",
+    "project-build-details",
+    "subproject-list",
+    "subproject-create",
+]
+
+
+def test_rtd_app_registered() -> None:
+    """The rtd Typer app exposes help."""
+    result = runner.invoke(rtd_app, ["--help"])
+    assert result.exit_code == 0
+    assert "read the docs" in clean_cli_output(result.stdout).lower()
+
+
+def test_get_rtd_app_returns_app() -> None:
+    """The registration helper returns the module-level app."""
+    assert get_rtd_app() is rtd_app
+
+
+@pytest.mark.parametrize("command", PIPELINE_COMMANDS)
+def test_pipeline_commands_present(command: str) -> None:
+    """Commands the documentation workflows depend on must exist.
+
+    The previous Typer implementation shipped four of fourteen
+    commands, which broke any caller migrating from legacy lftools.
+    """
+    result = runner.invoke(rtd_app, [command, "--help"])
+    assert result.exit_code == 0, f"{command} missing from the rtd app"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "project-list",
+        "project-details",
+        "project-version-list",
+        "project-version-details",
+        "project-build-list",
+        "project-build-details",
+        "project-build-trigger",
+        "subproject-list",
+        "subproject-details",
+        "subproject-create",
+        "subproject-delete",
+        "project-create",
+        "project-update",
+        "project-version-update",
+    ],
+)
+def test_every_command_offers_json(command: str) -> None:
+    """Each command advertises --json for machine-readable output.
+
+    Rich may inject ANSI styling inside the option name, so strip escape
+    sequences before matching.
+    """
+    result = runner.invoke(rtd_app, [command, "--help"])
+    assert result.exit_code == 0
+    assert "--json" in clean_cli_output(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# JSON output contract
+# ---------------------------------------------------------------------------
+
+
+def test_project_list_json_is_parsable() -> None:
+    """--json emits a payload that parses cleanly."""
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_list.return_value = ["onap", "onap-cps"]
+        result = runner.invoke(rtd_app, ["project-list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {"projects": ["onap", "onap-cps"]}
+
+
+def test_json_flag_accepted_on_group() -> None:
+    """--json works before the subcommand as well as after."""
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_list.return_value = ["onap"]
+        result = runner.invoke(rtd_app, ["--json", "project-list"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"projects": ["onap"]}
+
+
+def test_project_list_table_by_default() -> None:
+    """Without --json the output renders as a table, not JSON."""
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_list.return_value = ["onap-cps"]
+        result = runner.invoke(rtd_app, ["project-list"])
+
+    assert result.exit_code == 0
+    assert "Project Slug" in clean_cli_output(result.stdout)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.stdout)
+
+
+def test_build_list_empty_emits_empty_array() -> None:
+    """An empty build list stays parsable rather than turning into prose.
+
+    The legacy endpoint returned the sentence 'There are no active
+    builds.', which broke callers piping output to jq.
+    """
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_build_list.return_value = []
+        result = runner.invoke(rtd_app, ["project-build-list", "onap-cps", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["builds"] == []
+    assert payload["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Branch to slug conversion
+# ---------------------------------------------------------------------------
+
+
+def test_from_branch_slugifies_build_trigger() -> None:
+    """--from-branch converts a slashed branch before calling the API."""
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_build_trigger.return_value = {"build": {"id": 1}}
+        result = runner.invoke(
+            rtd_app,
+            ["project-build-trigger", "onap-cps", "maintenance/3.7.10", "--from-branch", "--json"],
+        )
+
+    assert result.exit_code == 0
+    api.return_value.project_build_trigger.assert_called_once_with("onap-cps", "maintenance-3.7.10")
+
+
+def test_without_from_branch_value_passes_through() -> None:
+    """A plain slug reaches the API unchanged."""
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_build_trigger.return_value = {"build": {"id": 1}}
+        result = runner.invoke(rtd_app, ["project-build-trigger", "onap-cps", "latest", "--json"])
+
+    assert result.exit_code == 0
+    api.return_value.project_build_trigger.assert_called_once_with("onap-cps", "latest")
+
+
+def test_from_branch_slugifies_version_details() -> None:
+    """--from-branch applies to version lookups too."""
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_version_details.return_value = {"slug": "maintenance-3.7.10"}
+        result = runner.invoke(
+            rtd_app,
+            ["project-version-details", "onap-cps", "maintenance/3.7.10", "--from-branch", "--json"],
+        )
+
+    assert result.exit_code == 0
+    api.return_value.project_version_details.assert_called_once_with("onap-cps", "maintenance-3.7.10")
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_not_found_exits_non_zero_with_stderr_message() -> None:
+    """A missing project exits 1 and reports the failure as a diagnostic.
+
+    Click and Typer split stderr on some versions and mix it into stdout
+    on others, so combine both streams before matching, matching the
+    approach the Zulip CLI tests take.
+    """
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_details.side_effect = ReadTheDocsNotFoundError("Project 'nope' not found")
+        result = runner.invoke(rtd_app, ["project-details", "nope", "--json"])
+
+    assert result.exit_code == 1
+    combined = result.output + (getattr(result, "stderr", "") or "")
+    assert "not found" in clean_cli_output(combined).lower()
+
+
+def test_error_keeps_stdout_free_of_diagnostics() -> None:
+    """A failure must not write the diagnostic into a JSON stdout stream.
+
+    When the runner separates the streams, stdout stays empty so a
+    caller piping it to a parser never receives an error message.
+    """
+    split_runner = CliRunner()
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_details.side_effect = ReadTheDocsNotFoundError("Project 'nope' not found")
+        result = split_runner.invoke(rtd_app, ["project-details", "nope", "--json"])
+
+    assert result.exit_code == 1
+    stderr = getattr(result, "stderr", "") or ""
+    if stderr:
+        # Streams are separated on this Click/Typer version.
+        assert "not found" in clean_cli_output(stderr).lower()
+        assert "not found" not in clean_cli_output(result.stdout).lower()
+
+
+def test_api_error_exits_non_zero() -> None:
+    """A server error exits non-zero rather than emitting a broken payload."""
+    with mock.patch("lftools_uv.typer_apps.rtd.ReadTheDocs") as api:
+        api.return_value.project_details.side_effect = ReadTheDocsAPIError("boom", 500)
+        result = runner.invoke(rtd_app, ["project-details", "boom"])
+
+    assert result.exit_code == 1
+
+
+def test_project_update_rejects_malformed_pairs() -> None:
+    """A key=value typo reports an error instead of silently succeeding."""
+    result = runner.invoke(rtd_app, ["project-update", "onap-cps", "notapair"])
+    assert result.exit_code == 1
+
+
+def test_project_update_requires_parameters() -> None:
+    """Calling update with no pairs is an error."""
+    result = runner.invoke(rtd_app, ["project-update", "onap-cps"])
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary

The `rtd` stack carried three defects that broke the ONAP documentation
pipeline and blocked its migration from legacy `lftools` to `lftools-uv`.
This rebuilds the endpoint layer, completes the Typer command group, and
adds machine-readable output throughout.

## Motivation

### 1. Missing commands

The entry point defaults to the Typer CLI. Its `rtd` group shipped four of
the fourteen commands the Click group provides, and six of the nine commands
the documentation workflows call existed only behind `LEGACY_CLI=1`:

```console
$ uvx lftools-uv rtd project-build-trigger onap-cps latest
No such command 'project-build-trigger'. Did you mean 'project-update', 'project-list'?
```

The Typer source carried `# Note: The actual API signature may differ - this
is a placeholder implementation`.

### 2. Inconsistent output

The endpoint layer returned five different shapes across fourteen commands:
JSON text from three methods, `dict` from four, bare lists from three,
`ApiResponse` objects from two, and English prose from two.
`project_build_list` returned JSON when builds existed and the sentence
`There are no active builds.` when none did.

Because `project_details` returned a `dict` that the CLI rendered with
`pprint.pformat`, callers needed `yq` rather than `jq`. `yq` depends on
`argcomplete`, whose 3.7.1 release broke every ONAP merge job running
Python 3.8 on 2026-08-04.

### 3. No slug conversion

Read the Docs addresses a version by a slugified branch name, so
`maintenance/3.7.10` lives at `maintenance-3.7.10`. The API received the raw
branch name, returned a body that was not an object, and `jq` failed:

```text
INFO: Checking if read the docs has seen branch maintenance/3.7.10
jq: error (at <stdin>:1): Cannot index string with string "active"
##[error]Process completed with exit code 5.
```

Every ONAP merge failure since the `argcomplete` fix carries this signature.

## Changes

### `api/endpoints/readthedocs.py`

- Every method returns typed data (`dict`, `list[dict]`, `list[str]`). No
  pre-serialised JSON strings, `ApiResponse` leaks, tuples or prose.
- New error hierarchy: `ReadTheDocsError` → `ReadTheDocsAPIError` (carrying
  `status_code`) → `ReadTheDocsNotFoundError`, plus
  `ReadTheDocsValidationError`.
- `version_slug()` converts a branch name to a Read the Docs version slug.
- `project_exists()` and `subproject_exists()` replace matching prose in
  error bodies, retiring the divergent `Not found.` and
  `No Project matches the given query.` checks.
- A single `_check()` maps HTTP status to typed errors, rather than each
  method inventing its own convention.

### `typer_apps/rtd.py`

Full parity at fourteen commands, following the conventions the Zulip app
established:

- `--json` on the group callback and on every command.
- `tabulate` for human output.
- Payloads on stdout, diagnostics on stderr.
- `--from-branch` on the three commands that accept a version.
- Collections emit an empty list rather than prose, so a parser needs no
  special case.

### `cli/rtd.py`

Retained with its historical output preserved verbatim, so existing callers
see no change. Now emits a deprecation warning. Removal stays out of scope
pending a survey of Jenkins consumers.

### `docs/commands/rtd.rst`

Documents `--json`, the slug rules and `--from-branch`. Adds the sections
missing for `project-update` and the four `subproject-*` commands.

## Verification

| Check | Result |
| --- | --- |
| `rtd` tests | 13 → 71 passing |
| Full suite | 816 passed, no regressions |
| `ruff`, `ruff format` | Pass |
| `mypy`, `basedpyright` | Pass, zero errors |
| `prek` (all hooks) | Pass |

Slug conversion against the exact ONAP failure case:

```text
maintenance/3.7.10  -> maintenance-3.7.10
mr/879/126960/2     -> mr-879-126960-2
Montreal            -> montreal
```

New test coverage spans slug conversion, HTTP status to error mapping, the
empty-collection contract, `--from-branch` call-through, the `--json`
surface on every command, and stderr routing.

## Compatibility notes

- The Click group behaves exactly as before, so `LEGACY_CLI=1` callers are
  unaffected.
- Endpoint return types change. The only in-tree consumers are the two CLI
  layers, both updated here.
- Typer `project-create` now takes the same six positional arguments as
  Click, replacing the placeholder two-positional form. This makes migration
  from legacy `lftools` a pure rename.
