### PR TITLE
Fix: Set an explicit coverage data_file path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ format:
 # Clean build artifacts and cache
 clean:
 	rm -rf build/ dist/ *.egg-info/
-	rm -rf .pytest_cache/ .coverage htmlcov/
+	rm -rf .pytest_cache/ .coverage htmlcov/ /tmp/lftools-uv-coverage/
 	rm -rf docs/_build/
 	find . -type d -name __pycache__ -delete
 	find . -type f -name "*.pyc" -delete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,13 @@ python_functions = ["test_*"]
 
 [tool.coverage.run]
 source = ["lftools_uv"]
+# Absolute path, deliberately outside the working tree. coverage.py
+# resolves a relative data_file against the current directory, and
+# several tests (e.g. tests/test_version.py) monkeypatch.chdir() into a
+# pytest-datafiles fixture directory and then assert over iterdir(), so
+# a stray .coverage written there would break them. Override with the
+# COVERAGE_FILE environment variable if a different location is needed.
+data_file = "/tmp/lftools-uv-coverage/.coverage"
 omit = [
     "*/tests/*",
     "*/test_*",


### PR DESCRIPTION
## Problem

The coverage configuration in `pyproject.toml` did not set `data_file`, so
coverage.py fell back to writing `.coverage` **relative to the current
working directory**.

That is unsafe in this repository. Several tests `chdir` into a
`pytest-datafiles` fixture directory and then assert over its contents —
for example `tests/test_version.py`:

```python
monkeypatch.chdir(datafiles / "version_bump")
...
for _file in (datafiles / "version_bump").iterdir():
```

A coverage data file written into that directory could therefore break
assertions in unrelated tests.

This also produces a job-summary warning from
`lfreleng-actions/python-test-action`:

> ⚠️ Coverage configuration warning
> Discovered coverage config does not set `data_file`.
> Tests sensitive to filesystem content may break.

## Changes

- `pyproject.toml` — set `data_file` under `[tool.coverage.run]` to an
  absolute location outside the working tree.
- `Makefile` — the `clean` target also clears the new location, which
  would otherwise silently stop removing coverage data.

## Why absolute

A relative `data_file` would still resolve against whichever directory a
test happened to `chdir` into, so it would not fix the problem. The
`COVERAGE_FILE` environment variable still takes precedence over the
config value, so the location remains overridable — verified against
coverage 7.13.1.

## Verification

- Full suite passes: **818 passed**.
- No `.coverage*` anywhere in the working tree afterwards; the data file
  is created at the configured path (coverage.py creates the parent
  directory itself).
- `coverage.xml` is still written to the repository root, so
  `sonar.python.coverage.reportPaths=coverage.xml` in
  `sonar-project.properties` is unaffected.
- The action's detection (`grep -qE '^[[:space:]]*data_file[[:space:]]*='`)
  now matches, so the warning is suppressed.

## Scope

This is independent of the Test PyPI publishing failure seen on the
`v0.5.3` tag. That failure is a `Metadata-Version: 2.5` rejection by the
twine bundled in the publish action, addressed separately in
modeseven-lfreleng-actions/gh-action-pypi-publish#109.
