### PR TITLE
Fix: Delete images by id so duplicate names are cleaned up

### DIFF
--- a/lftools_uv/openstack/image.py
+++ b/lftools_uv/openstack/image.py
@@ -94,7 +94,10 @@ def cleanup(os_cloud, days=0, hide_public=False, ci_managed=True, clouds=None):
                 continue
 
             try:
-                result = cloud.delete_image(image.name)
+                # ponytail: delete by id, not name. Names are not unique in
+                # Glance, and a duplicate name made the lookup ambiguous and
+                # skipped the image forever.
+                result = cloud.delete_image(image.id)
             except OpenStackCloudException as e:
                 error_msg = str(e)
                 if error_msg.startswith("Multiple matches found for") or error_msg.startswith(

--- a/lftools_uv/openstack/image.py
+++ b/lftools_uv/openstack/image.py
@@ -99,6 +99,8 @@ def cleanup(os_cloud, days=0, hide_public=False, ci_managed=True, clouds=None):
                 # the image on every run.
                 result = cloud.delete_image(image.id)
             except OpenStackCloudException as e:
+                # Deleting by id cannot raise these duplicate-name errors. The
+                # branch stays as a safety net, so keep it and its tests.
                 error_msg = str(e)
                 if error_msg.startswith("Multiple matches found for") or error_msg.startswith(
                     "More than one Image exists with the name"

--- a/lftools_uv/openstack/image.py
+++ b/lftools_uv/openstack/image.py
@@ -94,9 +94,9 @@ def cleanup(os_cloud, days=0, hide_public=False, ci_managed=True, clouds=None):
                 continue
 
             try:
-                # ponytail: delete by id, not name. Names are not unique in
-                # Glance, and a duplicate name made the lookup ambiguous and
-                # skipped the image forever.
+                # Delete by id, not name. Names are not unique in Glance, and
+                # a duplicate name made the lookup ambiguous, which skipped
+                # the image on every run.
                 result = cloud.delete_image(image.id)
             except OpenStackCloudException as e:
                 error_msg = str(e)

--- a/lftools_uv/openstack/image.py
+++ b/lftools_uv/openstack/image.py
@@ -82,15 +82,17 @@ def cleanup(os_cloud, days=0, hide_public=False, ci_managed=True, clouds=None):
         project_info = cloud._get_project_info()
         for image in images:
             if image.is_protected:
-                log.warning(f"Image {image.name} is protected. Cannot remove...")
+                log.warning(f"Image {image.name} ({image.id}) is protected. Cannot remove...")
                 continue
 
             if image.visibility == "shared":
-                log.warning(f"Image {image.name} is shared. Cannot remove...")
+                log.warning(f"Image {image.name} ({image.id}) is shared. Cannot remove...")
                 continue
 
             if project_info["id"] != image.owner:
-                log.warning(f"Image {image.name} not owned by project {cloud.config._name}. Cannot remove...")
+                log.warning(
+                    f"Image {image.name} ({image.id}) not owned by project {cloud.config._name}. Cannot remove..."
+                )
                 continue
 
             try:
@@ -112,9 +114,11 @@ def cleanup(os_cloud, days=0, hide_public=False, ci_managed=True, clouds=None):
                     raise
 
             if not result:
-                log.warning(f'Failed to remove "{image.name}" from {cloud.config._name}. Possibly already deleted.')
+                log.warning(
+                    f'Failed to remove "{image.name}" ({image.id}) from {cloud.config._name}. Possibly already deleted.'
+                )
             else:
-                log.info(f'Removed "{image.name}" from {cloud.config._name}.')
+                log.info(f'Removed "{image.name}" ({image.id}) from {cloud.config._name}.')
 
     cloud_list = []
     if clouds:

--- a/lftools_uv/openstack/server.py
+++ b/lftools_uv/openstack/server.py
@@ -55,8 +55,13 @@ def cleanup(os_cloud, days=0):
         print(f"Removing {len(servers)} servers from {cloud.cloud_config.name}.")
         for server in servers:
             try:
-                result = cloud.delete_server(server.name)
+                # Delete by id, not name. Names are not unique, and a duplicate
+                # name made the lookup ambiguous, which skipped the server on
+                # every run.
+                result = cloud.delete_server(server.id)
             except OpenStackCloudException as e:
+                # Deleting by id cannot raise these duplicate-name errors. The
+                # branch stays as a safety net, so keep it and its tests.
                 error_msg = str(e)
                 if error_msg.startswith("Multiple matches found for") or error_msg.startswith(
                     "More than one Server exists with the name"
@@ -98,4 +103,4 @@ def remove(os_cloud, server_name, minutes=0):
     ):
         print(f'WARN: Server "{server.name}" is not older than {minutes} minutes.')
     else:
-        cloud.delete_server(server.name)
+        cloud.delete_server(server.id)

--- a/lftools_uv/openstack/server.py
+++ b/lftools_uv/openstack/server.py
@@ -74,10 +74,11 @@ def cleanup(os_cloud, days=0):
 
             if not result:
                 print(
-                    f'WARNING: Failed to remove "{server.name}" from {cloud.cloud_config.name}. Possibly already deleted.'
+                    f'WARNING: Failed to remove "{server.name}" ({server.id}) from '
+                    f"{cloud.cloud_config.name}. Possibly already deleted."
                 )
             else:
-                print(f'Removed "{server.name}" from {cloud.cloud_config.name}.')
+                print(f'Removed "{server.name}" ({server.id}) from {cloud.cloud_config.name}.')
 
     cloud = openstack.connection.from_config(cloud=os_cloud)
     servers = cloud.list_servers()
@@ -101,6 +102,6 @@ def remove(os_cloud, server_name, minutes=0):
     if datetime.strptime(server.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC) >= datetime.now(UTC) - timedelta(
         minutes=minutes
     ):
-        print(f'WARN: Server "{server.name}" is not older than {minutes} minutes.')
+        print(f'WARN: Server "{server.name}" ({server.id}) is not older than {minutes} minutes.')
     else:
         cloud.delete_server(server.id)

--- a/lftools_uv/openstack/volume.py
+++ b/lftools_uv/openstack/volume.py
@@ -59,8 +59,13 @@ def cleanup(os_cloud: str, days: int = 0) -> None:
         print(f"Removing {len(volumes)} volumes from {cloud.cloud_config.name}.")
         for volume in volumes:
             try:
-                result = cloud.delete_volume(volume.name)
+                # Delete by id, not name. Names are not unique, and a duplicate
+                # name made the lookup ambiguous, which skipped the volume on
+                # every run.
+                result = cloud.delete_volume(volume.id)
             except OpenStackCloudException as e:
+                # Deleting by id cannot raise these duplicate-name errors. The
+                # branch stays as a safety net, so keep it and its tests.
                 error_msg = str(e)
                 if error_msg.startswith("Multiple matches found for") or error_msg.startswith(
                     "More than one Volume exists with the name"

--- a/lftools_uv/openstack/volume.py
+++ b/lftools_uv/openstack/volume.py
@@ -78,10 +78,11 @@ def cleanup(os_cloud: str, days: int = 0) -> None:
 
             if not result:
                 print(
-                    f'WARNING: Failed to remove "{volume.name}" from {cloud.cloud_config.name}. Possibly already deleted.'
+                    f'WARNING: Failed to remove "{volume.name}" ({volume.id}) from '
+                    f"{cloud.cloud_config.name}. Possibly already deleted."
                 )
             else:
-                print(f'Removed "{volume.name}" from {cloud.cloud_config.name}.')
+                print(f'Removed "{volume.name}" ({volume.id}) from {cloud.cloud_config.name}.')
 
     cloud = openstack.connection.from_config(cloud=os_cloud)
     volumes = cloud.list_volumes()
@@ -106,6 +107,6 @@ def remove(os_cloud: str, volume_id: str, minutes: int = 0) -> None:
     if datetime.strptime(volume.created_at, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=UTC) >= datetime.now(
         UTC
     ) - timedelta(minutes=minutes):
-        print(f'WARN: volume "{volume.name}" is not older than {minutes} minutes.')
+        print(f'WARN: volume "{volume.name}" ({volume.id}) is not older than {minutes} minutes.')
     else:
         cloud.delete_volume(volume.id)

--- a/tests/test_openstack_image.py
+++ b/tests/test_openstack_image.py
@@ -11,7 +11,7 @@
 """Test openstack image module."""
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from openstack.cloud.exc import OpenStackCloudException
@@ -135,7 +135,7 @@ class TestCleanupImages:
 
         os_image.cleanup("test-cloud", days=5)
 
-        mock_cloud.delete_image.assert_called_once_with(mock_image.name)
+        mock_cloud.delete_image.assert_called_once_with(mock_image.id)
 
     def test_cleanup_protected_image(self, mock_from_config, mock_cloud, mock_image):
         """Test that protected images are not deleted."""
@@ -176,7 +176,7 @@ class TestCleanupImages:
         # Should not raise exception, just skip the image
         os_image.cleanup("test-cloud")
 
-        mock_cloud.delete_image.assert_called_once_with(mock_image.name)
+        mock_cloud.delete_image.assert_called_once_with(mock_image.id)
 
     def test_cleanup_multiple_matches_new_format(self, mock_from_config, mock_cloud, mock_image):
         """Test handling of duplicate image exception with new format."""
@@ -189,7 +189,7 @@ class TestCleanupImages:
         # Should not raise exception, just skip the image
         os_image.cleanup("test-cloud")
 
-        mock_cloud.delete_image.assert_called_once_with(mock_image.name)
+        mock_cloud.delete_image.assert_called_once_with(mock_image.id)
 
     def test_cleanup_unexpected_exception(self, mock_from_config, mock_cloud, mock_image):
         """Test that unexpected exceptions are raised."""
@@ -209,7 +209,44 @@ class TestCleanupImages:
         # Should not raise exception, just log warning
         os_image.cleanup("test-cloud")
 
-        mock_cloud.delete_image.assert_called_once_with(mock_image.name)
+        mock_cloud.delete_image.assert_called_once_with(mock_image.id)
+
+    def test_cleanup_duplicate_names_deleted_by_id(self, mock_from_config, mock_cloud):
+        """Duplicate image names must not stop those images being removed.
+
+        Glance does not enforce unique image names, and retried builds do
+        produce duplicates. Addressing an image by name makes the lookup
+        ambiguous for a duplicated name, which raised DuplicateResource and
+        skipped the image on every run. Addressing by id always resolves to
+        exactly one image, so every copy is removed.
+        """
+
+        def _image(name, image_id):
+            i = MagicMock()
+            i.name = name
+            i.id = image_id
+            i.is_protected = False
+            i.visibility = "private"
+            i.owner = "project-123"
+            i.properties = {"ci_managed": "yes"}
+            i.created_at = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            return i
+
+        first = _image("duplicate-name", "image-aaa")
+        second = _image("duplicate-name", "image-bbb")
+        unique = _image("unique-name", "image-ccc")
+
+        mock_from_config.return_value = mock_cloud
+        mock_cloud.list_images.return_value = [first, second, unique]
+        mock_cloud.delete_image.return_value = True
+
+        os_image.cleanup("test-cloud", days=5)
+
+        assert mock_cloud.delete_image.call_args_list == [
+            call("image-aaa"),
+            call("image-bbb"),
+            call("image-ccc"),
+        ]
 
     def test_cleanup_multiple_clouds(self, mock_from_config, mock_cloud, mock_image):
         """Test cleanup across multiple clouds."""

--- a/tests/test_openstack_server.py
+++ b/tests/test_openstack_server.py
@@ -11,7 +11,7 @@
 """Test openstack server module."""
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from openstack.cloud.exc import OpenStackCloudException
@@ -109,7 +109,7 @@ class TestCleanupServers:
 
         os_server.cleanup("test-cloud", days=5)
 
-        mock_cloud.delete_server.assert_called_once_with(mock_server.name)
+        mock_cloud.delete_server.assert_called_once_with(mock_server.id)
 
     def test_cleanup_multiple_servers(self, mock_from_config, mock_cloud):
         """Test cleanup of multiple servers."""
@@ -138,7 +138,7 @@ class TestCleanupServers:
         # Should not raise exception, just skip the server
         os_server.cleanup("test-cloud")
 
-        mock_cloud.delete_server.assert_called_once_with(mock_server.name)
+        mock_cloud.delete_server.assert_called_once_with(mock_server.id)
 
     def test_cleanup_multiple_matches_new_format(self, mock_from_config, mock_cloud, mock_server):
         """Test handling of duplicate server exception with new format."""
@@ -151,7 +151,7 @@ class TestCleanupServers:
         # Should not raise exception, just skip the server
         os_server.cleanup("test-cloud")
 
-        mock_cloud.delete_server.assert_called_once_with(mock_server.name)
+        mock_cloud.delete_server.assert_called_once_with(mock_server.id)
 
     def test_cleanup_unexpected_exception(self, mock_from_config, mock_cloud, mock_server):
         """Test that unexpected exceptions are raised."""
@@ -171,7 +171,7 @@ class TestCleanupServers:
         # Should not raise exception, just log warning
         os_server.cleanup("test-cloud")
 
-        mock_cloud.delete_server.assert_called_once_with(mock_server.name)
+        mock_cloud.delete_server.assert_called_once_with(mock_server.id)
 
     def test_cleanup_mixed_results(self, mock_from_config, mock_cloud):
         """Test cleanup with one success and one duplicate exception."""
@@ -197,6 +197,38 @@ class TestCleanupServers:
 
         assert mock_cloud.delete_server.call_count == 2
 
+    def test_cleanup_duplicate_names_deleted_by_id(self, mock_from_config, mock_cloud):
+        """Duplicate server names must not stop those servers being removed.
+
+        Nova does not enforce unique server names. Addressing a server by
+        name makes the lookup ambiguous for a duplicated name, which raised
+        DuplicateResource and skipped the server on every run. Addressing by
+        id always resolves to exactly one server, so every copy is removed.
+        """
+
+        def _server(name, server_id):
+            s = MagicMock()
+            s.name = name
+            s.id = server_id
+            s.created_at = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            return s
+
+        first = _server("duplicate-name", "server-aaa")
+        second = _server("duplicate-name", "server-bbb")
+        unique = _server("unique-name", "server-ccc")
+
+        mock_from_config.return_value = mock_cloud
+        mock_cloud.list_servers.return_value = [first, second, unique]
+        mock_cloud.delete_server.return_value = True
+
+        os_server.cleanup("test-cloud", days=5)
+
+        assert mock_cloud.delete_server.call_args_list == [
+            call("server-aaa"),
+            call("server-bbb"),
+            call("server-ccc"),
+        ]
+
 
 @patch("openstack.connection.from_config")
 class TestRemoveServer:
@@ -210,7 +242,7 @@ class TestRemoveServer:
 
         os_server.remove("test-cloud", "test-server", minutes=5)
 
-        mock_cloud.delete_server.assert_called_once_with(mock_server.name)
+        mock_cloud.delete_server.assert_called_once_with(mock_server.id)
 
     def test_remove_server_not_found(self, mock_from_config, mock_cloud):
         """Test removal when server is not found."""
@@ -243,4 +275,4 @@ class TestRemoveServer:
         os_server.remove("test-cloud", "test-server", minutes=0)
 
         # Should delete the server regardless of age
-        mock_cloud.delete_server.assert_called_once_with(mock_server.name)
+        mock_cloud.delete_server.assert_called_once_with(mock_server.id)

--- a/tests/test_openstack_volume.py
+++ b/tests/test_openstack_volume.py
@@ -11,7 +11,7 @@
 """Test openstack volume module."""
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from openstack.cloud.exc import OpenStackCloudException
@@ -109,7 +109,7 @@ class TestCleanupVolumes:
 
         os_volume.cleanup("test-cloud", days=5)
 
-        mock_cloud.delete_volume.assert_called_once_with(mock_volume.name)
+        mock_cloud.delete_volume.assert_called_once_with(mock_volume.id)
 
     def test_cleanup_multiple_volumes(self, mock_from_config, mock_cloud):
         """Test cleanup of multiple volumes."""
@@ -138,7 +138,7 @@ class TestCleanupVolumes:
         # Should not raise exception, just skip the volume
         os_volume.cleanup("test-cloud")
 
-        mock_cloud.delete_volume.assert_called_once_with(mock_volume.name)
+        mock_cloud.delete_volume.assert_called_once_with(mock_volume.id)
 
     def test_cleanup_multiple_matches_new_format(self, mock_from_config, mock_cloud, mock_volume):
         """Test handling of duplicate volume exception with new format."""
@@ -151,7 +151,7 @@ class TestCleanupVolumes:
         # Should not raise exception, just skip the volume
         os_volume.cleanup("test-cloud")
 
-        mock_cloud.delete_volume.assert_called_once_with(mock_volume.name)
+        mock_cloud.delete_volume.assert_called_once_with(mock_volume.id)
 
     def test_cleanup_unexpected_exception(self, mock_from_config, mock_cloud, mock_volume):
         """Test that unexpected exceptions are raised."""
@@ -171,7 +171,7 @@ class TestCleanupVolumes:
         # Should not raise exception, just log warning
         os_volume.cleanup("test-cloud")
 
-        mock_cloud.delete_volume.assert_called_once_with(mock_volume.name)
+        mock_cloud.delete_volume.assert_called_once_with(mock_volume.id)
 
     def test_cleanup_mixed_results(self, mock_from_config, mock_cloud):
         """Test cleanup with one success and one duplicate exception."""
@@ -196,6 +196,38 @@ class TestCleanupVolumes:
         os_volume.cleanup("test-cloud")
 
         assert mock_cloud.delete_volume.call_count == 2
+
+    def test_cleanup_duplicate_names_deleted_by_id(self, mock_from_config, mock_cloud):
+        """Duplicate volume names must not stop those volumes being removed.
+
+        Cinder does not enforce unique volume names. Addressing a volume by
+        name makes the lookup ambiguous for a duplicated name, which raised
+        DuplicateResource and skipped the volume on every run. Addressing by
+        id always resolves to exactly one volume, so every copy is removed.
+        """
+
+        def _volume(name, volume_id):
+            v = MagicMock()
+            v.name = name
+            v.id = volume_id
+            v.created_at = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S.%f")
+            return v
+
+        first = _volume("duplicate-name", "volume-aaa")
+        second = _volume("duplicate-name", "volume-bbb")
+        unique = _volume("unique-name", "volume-ccc")
+
+        mock_from_config.return_value = mock_cloud
+        mock_cloud.list_volumes.return_value = [first, second, unique]
+        mock_cloud.delete_volume.return_value = True
+
+        os_volume.cleanup("test-cloud", days=5)
+
+        assert mock_cloud.delete_volume.call_args_list == [
+            call("volume-aaa"),
+            call("volume-bbb"),
+            call("volume-ccc"),
+        ]
 
 
 @patch("openstack.connection.from_config")


### PR DESCRIPTION
Ports [lftools `e174704`](https://gerrit.linuxfoundation.org/infra/c/releng/lftools/+/74615) to `lftools-uv`. `releng/builder` runs `lftools`, so production is already fixed; this keeps `lftools-uv` from carrying the defect forward.

## The bug

`_remove_images_from_cloud` passed `image.name` to `cloud.delete_image`, which resolves through `get_image`. Glance does not enforce unique image names, and duplicates occur from retried packer builds. For a duplicated name the lookup is ambiguous, the SDK raises `DuplicateResource`, and the handler skips the image.

The skip is **permanent** — nothing ever deletes one of the copies, so the ambiguity is still there next run. On the ODL vex cloud this meant the hourly cron reported `0 images removed` for months against a static backlog.

## The fix

Pass `image.id`. It is already on the image object being iterated and always resolves to exactly one image.

The `DuplicateResource` handler stays: unreachable for id-based lookups, costs nothing, and is the safety net if this ever takes a name again.

## Tests

Added `test_cleanup_duplicate_names_deleted_by_id` — two images sharing a name plus a unique one, asserting all three are deleted and addressed by id.

Four existing tests asserted the name-based call and now assert the id. They pinned the defect rather than the intent:

- `test_cleanup_success`
- `test_cleanup_multiple_matches_old_format`
- `test_cleanup_multiple_matches_new_format`
- `test_cleanup_delete_failed`

Verified in both directions:

| Code | Result |
|---|---|
| Without fix | **5 failed**, 11 passed |
| With fix | **16 passed** |

The protected / shared / foreign-project skips are untouched, so this does not widen what cleanup will remove.