### PR TITLE
Fix: Bump PyPI publish action to v0.2.0

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: 'development'
           # Preserve the prior pipeline's behaviour: 'auto' selects trusted
@@ -97,7 +97,7 @@ jobs:
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: 'production'
           attestations: true


### PR DESCRIPTION
Bumps the PyPI publish action **v0.1.9 → v0.2.0** at both call sites, restoring tagged releases.

## Why

Tagged releases failed at the Test PyPI step, because the publish action pinned here carried a twine that rejects `Metadata-Version: 2.5` — which this project emits, since Hatchling 1.30 and newer default to it:

```
ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
         valid metadata version
```

Observed in [run 31725353675](https://github.com/lfreleng-actions/lftools-uv/actions/runs/31725353675/job/94533884530).

The rejection came from twine **inside the publish container**, not from PyPI. twine replaces `packaging`'s list of valid metadata versions with its own hard-coded copy, which stopped at `2.4`, so it could not be worked around from this repository. v0.2.0 carries a backend with twine 7.0, whose copy includes `2.5`.

PyPI itself already accepts the version — confirmed in production, since `lftools-uv` 0.5.3 published successfully from a metadata 2.5 artefact.

## What else v0.2.0 brings

- **All 30 open dependency security advisories cleared** in the backend, including two majors on the attestation signing path (`cryptography` 46→50, `pyopenssl` 25→26).
- **A metadata-version canary** in the backend's own CI: its test stub is now built with an *unpinned* Hatchling, so the newest core metadata version is always exercised against the pinned twine. A future metadata bump now breaks a job there rather than a release here.

## Scope

Both call sites move together, so the **Test PyPI** and **PyPI** jobs stay on one version of the publish action. Splitting them would leave the production path broken while Test PyPI passed — an unpleasant way to find out.

## Pin correctness

The tag is annotated, so the pinned value is the **commit** it points at, not the tag object:

```console
$ git cat-file -t v0.2.0
tag

$ git rev-parse v0.2.0
8798fe4e79f0c221b92f2c94a9ac3455d9ac178e   # tag object — NOT this

$ git rev-parse 'v0.2.0^{commit}'
276603f5d72b11427755ef139c6fb80489cec5d9   # commit — pinned
```

## Verification

- **Zizmor** (`--persona auditor`): no findings, and the baseline on `main` for the same file is also clean — so nothing introduced.
- Pre-commit hooks pass.
- The backend image behind v0.2.0 was built and verified against real metadata 2.5 artefacts: `twine check` PASSED for both wheel and sdist, and the attestation path (`Distribution.from_file`, TUF refresh, `SigningContext`) constructs successfully under the new majors.

## Limitation

The OIDC exchange and the actual attestation signing call need an ambient credential and could not be exercised locally. The first real trusted-publishing run after this merge is the true end-to-end test of that path, and it is worth watching rather than assuming, given the two major bumps that sit on it.
