### PR TITLE
Fix: Omit the alias key from subproject creation

### DIFF
--- a/lftools_uv/api/endpoints/readthedocs.py
+++ b/lftools_uv/api/endpoints/readthedocs.py
@@ -503,8 +503,16 @@ class ReadTheDocs(client.RestApi):
         :param subproject: The other project's slug that is to be subordinated
         :param alias: An alias (not required). (user-defined slug)
         :return: {status payload}
+
+        The alias key stays out of the payload when no alias arrives.
+        Sending an explicit JSON null makes readthedocs.org fail with an
+        unhandled HTTP 500 rather than a validation error, and the server
+        already defaults the alias to the child's slug when the key is
+        absent.
         """
-        data: dict[str, str | None] = {"child": subproject, "alias": alias}
+        data: dict[str, str] = {"child": subproject}
+        if alias is not None:
+            data["alias"] = alias
         json_data: str = json.dumps(data)
         result: ApiResponse = self.post(f"projects/{project}/subprojects/", data=json_data)
         resp = self._check(

--- a/tests/test_rtd.py
+++ b/tests/test_rtd.py
@@ -407,6 +407,60 @@ def test_subproject_create():
 
 
 @responses.activate
+def test_subproject_create_omits_absent_alias():
+    """The payload carries no alias key when the caller supplies none.
+
+    readthedocs.org fails with an unhandled HTTP 500 when the alias
+    arrives as an explicit JSON null, rather than rejecting it as
+    invalid, and it defaults the alias to the child's slug when the key
+    stays absent. Every ONAP project publishing documentation for the
+    first time hit the 500 through rtd-build-action, which passes no
+    alias. See lfreleng-actions/rtd-build-action#5.
+    """
+    responses.add(
+        responses.POST,
+        url="https://readthedocs.org/api/v3/projects/TestProject1/subprojects/",
+        status=201,
+    )
+    _ = rtd.subproject_create("TestProject1", "testproject2")
+    body = responses.calls[0].request.body
+    assert body is not None
+    payload = json.loads(body)
+    assert payload == {"child": "testproject2"}
+    assert "alias" not in payload
+
+
+@responses.activate
+def test_subproject_create_sends_supplied_alias():
+    """A caller-supplied alias reaches the payload unchanged."""
+    responses.add(
+        responses.POST,
+        url="https://readthedocs.org/api/v3/projects/TestProject1/subprojects/",
+        status=201,
+    )
+    _ = rtd.subproject_create("TestProject1", "testproject2", alias="docs")
+    body = responses.calls[0].request.body
+    assert body is not None
+    payload = json.loads(body)
+    assert payload == {"child": "testproject2", "alias": "docs"}
+
+
+@responses.activate
+def test_subproject_create_sends_empty_alias():
+    """An explicit empty-string alias survives; the guard omits None."""
+    responses.add(
+        responses.POST,
+        url="https://readthedocs.org/api/v3/projects/TestProject1/subprojects/",
+        status=201,
+    )
+    _ = rtd.subproject_create("TestProject1", "testproject2", alias="")
+    body = responses.calls[0].request.body
+    assert body is not None
+    payload = json.loads(body)
+    assert payload == {"child": "testproject2", "alias": ""}
+
+
+@responses.activate
 def test_subproject_delete():
     responses.add(
         responses.DELETE,


### PR DESCRIPTION
## Summary

`subproject_create()` serialised the optional alias into the payload
unconditionally, so a caller supplying none sent an explicit JSON `null` —
which readthedocs.org fails on with an unhandled **HTTP 500** rather than a
validation error.

```diff
-        data: dict[str, str | None] = {"child": subproject, "alias": alias}
+        data: dict[str, str] = {"child": subproject}
+        if alias is not None:
+            data["alias"] = alias
```

Fixes the root cause of lfreleng-actions/rtd-build-action#5 /
lfreleng-actions/docs-workflows#13.

## The evidence

One key separates failure from success, reproduced against the live API with
the same account, parent and child:

```text
POST /api/v3/projects/onap/subprojects/
  {"child": "onap-policy-clamp", "alias": null}   →  HTTP 500  text/html
  {"child": "onap-policy-clamp"}                  →  HTTP 201  application/json
                                                     "alias": "onap-policy-clamp"
```

The server defaults the alias to the child's slug when the key is absent, so
omitting it produces exactly the relationship the null was meant to imply.

## Impact this had

`rtd-build-action` drives `lftools-uv rtd subproject-create <parent> <child>` —
no alias — so **every project publishing documentation through
`docs-workflows` for the first time failed its merge** with a fatal
`Verified -1`. Worse, the failure never healed: the first attempt creates the
RTD project, so each retry skips creation and repeats the failing attach,
stranding a live project orphaned from its umbrella.

ONAP `policy/clamp` hit it twice before diagnosis
([run 1](https://github.com/onap/.github/actions/runs/32148357955),
[run 2](https://github.com/onap/.github/actions/runs/32151018499)). Projects
already attached pass both steps as no-ops, which is what kept the defect
hidden until the first genuinely new project arrived.

## Live verification, end to end

Installed this branch with `uv tool install -e .` and ran the exact blocked
command against readthedocs.org, using an isolated `HOME` so no local
configuration was touched, with the same credentials the ONAP CI uses:

```console
$ lftools-uv rtd subproject-delete onap onap-policy-clamp     # recreate the stranded state
Removed the onap onap-policy-clamp relationship

$ uvx --from 'lftools-uv==0.5.3' lftools-uv rtd subproject-create onap onap-policy-clamp
Error: Creation of subproject 'onap-policy-clamp' under project 'onap' failed with HTTP 500:
  Server error ...

$ lftools-uv rtd subproject-create onap onap-policy-clamp     # this branch, 0.5.5.dev2
Created the onap onap-policy-clamp relationship

$ lftools-uv rtd subproject-details onap onap-policy-clamp
Parent   onap
Child    onap-policy-clamp
Alias    onap-policy-clamp
```

The released `0.5.3` reproduces the CI failure through the CLI itself; this
branch succeeds with the identical invocation. The public API confirms the
relationship (66 subprojects under `onap`, clamp attached), so production ends
in the correct state.

## Tests

Three added, pinning the payload shape in every direction:

- `test_subproject_create_omits_absent_alias` — payload is exactly
  `{"child": …}` with no `alias` key. **Fails against the previous code.**
- `test_subproject_create_sends_supplied_alias` — a caller-supplied alias
  reaches the payload unchanged.
- `test_subproject_create_sends_empty_alias` — an explicit empty string
  survives; the `is not None` guard omits only the null case.

I audited the module for siblings: `subproject_create` was the single site
serialising an optional value unconditionally.

## Verification

| Check | Result |
| --- | --- |
| `uv run pytest tests/` | 824 passed |
| New payload test vs old code | Fails, as intended |
| `uv run ruff check lftools_uv/ tests/` | All checks passed |
| `prek run --all-files` | All hooks pass |
| Live A/B against readthedocs.org | 0.5.3 fails, this branch succeeds |

## Follow-ups (the release cascade)

1. Release this (`v0.5.5`).
2. `rtd-build-action`: bump the default `lftools_version` from `0.5.3`, plus
   the error-surfacing improvement from #5 (an HTML 500 currently embeds a
   DOCTYPE fragment into a Gerrit-fatal error string).
3. `docs-workflows`: pin bump; closes lfreleng-actions/docs-workflows#13.
4. Upstream: readthedocs.org 500ing on a null optional field deserves a bug
   report with this reproduction — a `400` naming the field would have made
   this a five-minute diagnosis.