### PR TITLE
Style: Clear aislop comment-hygiene findings

### DIFF
--- a/lftools_uv/api/endpoints/gerrit.py
+++ b/lftools_uv/api/endpoints/gerrit.py
@@ -60,10 +60,6 @@ class Gerrit(client.RestApi):
 
         super().__init__(**params)
 
-    # -----------------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------------
-
     @staticmethod
     def _as_dict(obj: object) -> dict[str, object]:
         """Narrow an object to ``dict[str, object]``.
@@ -80,10 +76,6 @@ class Gerrit(client.RestApi):
         if isinstance(obj, str):
             return obj
         return str(obj) if obj is not None else ""
-
-    # -----------------------------------------------------------------------
-    # Changes
-    # -----------------------------------------------------------------------
 
     def create_change(
         self,
@@ -183,8 +175,6 @@ class Gerrit(client.RestApi):
         gerrit_project test/test1
         jjbrepo ci-mangement
         """
-        ###############################################################
-        # Setup
         signed_off_by: str = config.get_setting(fqdn, "sob")
         gerrit_project_dashed: str = gerrit_project.replace("/", "-")
         filename: str = f"{gerrit_project_dashed}.yaml"
@@ -329,10 +319,6 @@ class Gerrit(client.RestApi):
                 return self._json_body(abandon_response)
         return None
 
-    # -----------------------------------------------------------------------
-    # Sanity & review helpers
-    # -----------------------------------------------------------------------
-
     def sanity_check(self, _fqdn: str, gerrit_project: str) -> dict[str, object]:
         """Perform a sanity check."""
         gerrit_project_encoded: str = quote(gerrit_project, safe="", encoding=None, errors=None)
@@ -369,8 +355,6 @@ class Gerrit(client.RestApi):
         signed_off_by: str = config.get_setting(fqdn, "sob")
         _ = self.sanity_check(fqdn, gerrit_project)
 
-        ###############################################################
-        # Create A change set.
         filename: str = ".gitreview"
         payload: str = self.create_change(filename, gerrit_project, issue_id, signed_off_by)
         log.info(payload)
@@ -381,8 +365,6 @@ class Gerrit(client.RestApi):
         log.info(result)
         changeid: str = self._str_val(result.get("id"))
 
-        ###############################################################
-        # Add a file to a change set.
         my_inline_file: str = f"""
         [gerrit]
         host={fqdn}
@@ -422,13 +404,8 @@ class Gerrit(client.RestApi):
             submit_result: ApiResponse = self.submit_change(fqdn, gerrit_project, changeid, publish_payload)
             log.info(submit_result)
 
-    # -----------------------------------------------------------------------
-    # Groups
-    # -----------------------------------------------------------------------
-
     def create_saml_group(self, _fqdn: str, ldap_group: str) -> ApiResponse:
         """Create saml group from ldap group."""
-        ###############################################################
         payload: str = json.dumps({"visible_to_all": "false"})
         saml_group: str = f"saml/{ldap_group}"
         saml_group_encoded: str = quote(saml_group, safe="", encoding=None, errors=None)
@@ -439,8 +416,6 @@ class Gerrit(client.RestApi):
 
     def add_github_rights(self, _fqdn: str, gerrit_project: str) -> None:
         """Grant github read to a project."""
-        ###############################################################
-        # Github Rights
 
         gerrit_project_encoded: str = quote(gerrit_project, safe="", encoding=None, errors=None)
         # GET /groups/?m=test%2F HTTP/1.0
@@ -481,10 +456,6 @@ class Gerrit(client.RestApi):
             log.info(pretty)
         else:
             log.info("Error no githubid found")
-
-    # -----------------------------------------------------------------------
-    # Projects
-    # -----------------------------------------------------------------------
 
     def create_project(
         self,

--- a/lftools_uv/api/endpoints/nexus2.py
+++ b/lftools_uv/api/endpoints/nexus2.py
@@ -51,10 +51,6 @@ class Nexus2(client.RestApi):
 
         super().__init__(**params)
 
-    # -----------------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------------
-
     @staticmethod
     def _as_dict(obj: object) -> dict[str, object]:
         """Narrow an object to ``dict[str, object]``.
@@ -86,10 +82,6 @@ class Nexus2(client.RestApi):
                 typed_data: list[object] = cast(_LIST_OBJECT_TYPE, data)
                 return [cast("dict[str, object]", item) for item in typed_data if isinstance(item, dict)]
         return []
-
-    # -----------------------------------------------------------------------
-    # Privileges
-    # -----------------------------------------------------------------------
 
     def privilege_list(self) -> list[list[object]]:
         """List privileges."""
@@ -143,10 +135,6 @@ class Nexus2(client.RestApi):
         if resp.status_code == 204:
             return "Privilege successfully deleted."
         return f"Failed to delete privilege {privilege_id}."
-
-    # -----------------------------------------------------------------------
-    # Repositories
-    # -----------------------------------------------------------------------
 
     def repo_list(self) -> list[list[object]]:
         """Get a list of repositories."""
@@ -255,10 +243,6 @@ class Nexus2(client.RestApi):
         log.error("Failed to delete repository %s", repo_id)
         sys.exit(1)
 
-    # -----------------------------------------------------------------------
-    # Roles
-    # -----------------------------------------------------------------------
-
     def role_list(self) -> list[list[object]]:
         """List all roles."""
         response: ApiResponse = self.get("service/local/roles")
@@ -349,10 +333,6 @@ class Nexus2(client.RestApi):
         if resp.status_code == 204:
             return "Role successfully deleted."
         return f"Failed to delete role {role_id}."
-
-    # -----------------------------------------------------------------------
-    # Users
-    # -----------------------------------------------------------------------
 
     def user_list(self) -> list[list[object]]:
         """List all users."""

--- a/lftools_uv/api/endpoints/nexus2.py
+++ b/lftools_uv/api/endpoints/nexus2.py
@@ -264,7 +264,6 @@ class Nexus2(client.RestApi):
             role: dict[str, object] = self._as_dict(raw_role)
             if not role:
                 continue
-            # Build multiline strings for tabulate display
             roles_string: str = ""
             privs_string: str = ""
             roles_obj: object = role.get("roles")

--- a/lftools_uv/api/endpoints/nexus3.py
+++ b/lftools_uv/api/endpoints/nexus3.py
@@ -51,10 +51,6 @@ class Nexus3(client.RestApi):
 
         super().__init__(**params)
 
-    # -----------------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------------
-
     @staticmethod
     def _as_dict(obj: object) -> dict[str, object]:
         """Narrow an object to ``dict[str, object]``.
@@ -83,10 +79,6 @@ class Nexus3(client.RestApi):
             ]
         return []
 
-    # -----------------------------------------------------------------------
-    # Roles
-    # -----------------------------------------------------------------------
-
     def create_role(self, name: str, description: str, privileges: str, roles: str) -> str:
         """Create a new role.
 
@@ -114,10 +106,6 @@ class Nexus3(client.RestApi):
             return f"Role {name} created"
         resp.raise_for_status()
         return "Failed to create role"
-
-    # -----------------------------------------------------------------------
-    # Scripts
-    # -----------------------------------------------------------------------
 
     def create_script(self, name: str, content: str) -> str:
         """Create a new script.
@@ -219,10 +207,6 @@ class Nexus3(client.RestApi):
                 list_of_scripts.append(str(script.get("name", "")))
         return list_of_scripts
 
-    # -----------------------------------------------------------------------
-    # Tags
-    # -----------------------------------------------------------------------
-
     def create_tag(self, name: str, attributes: str | None) -> str:
         """Create a new tag.
 
@@ -308,10 +292,6 @@ class Nexus3(client.RestApi):
         if list_of_tags:
             return list_of_tags
         return "There are no tags"
-
-    # -----------------------------------------------------------------------
-    # Users
-    # -----------------------------------------------------------------------
 
     def create_user(
         self,
@@ -414,10 +394,6 @@ class Nexus3(client.RestApi):
                 )
         return list_of_users
 
-    # -----------------------------------------------------------------------
-    # Assets & Components
-    # -----------------------------------------------------------------------
-
     def list_assets(self, repository: str) -> list[str] | str:
         """List the assets of a given repo.
 
@@ -471,10 +447,6 @@ class Nexus3(client.RestApi):
             list_of_assets.append(str(item.get("path", "")))
         return list_of_assets
 
-    # -----------------------------------------------------------------------
-    # Blob stores
-    # -----------------------------------------------------------------------
-
     def list_blobstores(self) -> list[str]:
         """List server blobstores."""
         response: ApiResponse = self.get("service/rest/beta/blobstores")
@@ -485,10 +457,6 @@ class Nexus3(client.RestApi):
             if blob:
                 list_of_blobstores.append(str(blob.get("name", "")))
         return list_of_blobstores
-
-    # -----------------------------------------------------------------------
-    # Privileges
-    # -----------------------------------------------------------------------
 
     def list_privileges(self) -> list[list[object]]:
         """List server-configured privileges."""
@@ -508,10 +476,6 @@ class Nexus3(client.RestApi):
                 )
         return list_of_privileges
 
-    # -----------------------------------------------------------------------
-    # Repositories
-    # -----------------------------------------------------------------------
-
     def list_repositories(self) -> list[str]:
         """List server repositories."""
         response: ApiResponse = self.get("service/rest/v1/repositories")
@@ -523,10 +487,6 @@ class Nexus3(client.RestApi):
                 list_of_repositories.append(str(repo.get("name", "")))
         return list_of_repositories
 
-    # -----------------------------------------------------------------------
-    # Roles (list)
-    # -----------------------------------------------------------------------
-
     def list_roles(self) -> list[list[str]]:
         """List server roles."""
         response: ApiResponse = self.get("service/rest/beta/security/roles")
@@ -537,10 +497,6 @@ class Nexus3(client.RestApi):
             if role:
                 list_of_roles.append([str(role.get("name", ""))])
         return list_of_roles
-
-    # -----------------------------------------------------------------------
-    # Tasks
-    # -----------------------------------------------------------------------
 
     def list_tasks(self) -> list[list[object]]:
         """List all tasks."""
@@ -557,10 +513,6 @@ class Nexus3(client.RestApi):
                 ]
             )
         return list_of_tasks
-
-    # -----------------------------------------------------------------------
-    # Staging
-    # -----------------------------------------------------------------------
 
     def staging_promotion(self, destination_repo: str, tag: str) -> ApiResponse:
         """Promote repo assets to a new location.

--- a/lftools_uv/api/endpoints/readthedocs.py
+++ b/lftools_uv/api/endpoints/readthedocs.py
@@ -44,11 +44,6 @@ _HTTP_BAD_REQUEST = 400
 _SLUG_KEEP = re.compile(r"[^a-z0-9._-]+")
 
 
-# ---------------------------------------------------------------------------
-# Error hierarchy
-# ---------------------------------------------------------------------------
-
-
 class ReadTheDocsError(Exception):
     """Base class for all Read the Docs errors raised by this module."""
 
@@ -74,11 +69,6 @@ class ReadTheDocsNotFoundError(ReadTheDocsAPIError):
 
 class ReadTheDocsValidationError(ReadTheDocsError):
     """Raised for client-side validation failures."""
-
-
-# ---------------------------------------------------------------------------
-# Slug helpers
-# ---------------------------------------------------------------------------
 
 
 def version_slug(branch: str) -> str:

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -60,11 +60,6 @@ if TYPE_CHECKING:  # pragma: no cover
 log = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Domain exceptions
-# ---------------------------------------------------------------------------
-
-
 class ZulipError(Exception):
     """Base class for all Zulip-related errors raised by this module."""
 
@@ -112,11 +107,6 @@ class ZulipValidationError(ZulipError):
     """Raised for client-side validation failures (e.g. mutex flags)."""
 
 
-# ---------------------------------------------------------------------------
-# Optional-dependency detection
-# ---------------------------------------------------------------------------
-
-
 def zulip_available() -> bool:
     """Return ``True`` when the optional ``zulip`` package is importable."""
     return _zulip_module is not None
@@ -136,11 +126,6 @@ def _require_zulip() -> Any:
             "The 'zulip' Python package is not installed. Install with: pip install \"lftools-uv[zulip]\""
         )
     return _zulip_module
-
-
-# ---------------------------------------------------------------------------
-# Configuration resolution (FR-011 / FR-012)
-# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -255,11 +240,6 @@ def resolve_config(
     )
 
 
-# ---------------------------------------------------------------------------
-# Client factory
-# ---------------------------------------------------------------------------
-
-
 def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None) -> Any:
     """Instantiate a ``zulip.Client`` from the resolved configuration.
 
@@ -289,11 +269,6 @@ def get_client(zuliprc: Path | None = None, *, config: ZulipConfig | None = None
         api_key=resolved.api_key,
         site=resolved.site,
     )
-
-
-# ---------------------------------------------------------------------------
-# Feature-level detection (FR-019)
-# ---------------------------------------------------------------------------
 
 
 #: Hardcoded feature-level thresholds determined by consulting the Zulip
@@ -365,11 +340,6 @@ def check_feature_level(
         )
 
 
-# ---------------------------------------------------------------------------
-# Channel resolution
-# ---------------------------------------------------------------------------
-
-
 def _fetch_streams(client: Any, include_archived: bool) -> list[dict[str, Any]]:
     """Return the raw stream listing from the Zulip server.
 
@@ -439,11 +409,6 @@ def resolve_channel(
                     f"Channel '{name}' is archived. Use --include-archived to operate on archived channels."
                 )
     raise ZulipNotFoundError(f"Channel '{name}' not found")
-
-
-# ---------------------------------------------------------------------------
-# User resolution
-# ---------------------------------------------------------------------------
 
 
 IdMode = Literal["email", "id", "name"]
@@ -531,11 +496,6 @@ def resolve_users(
     """
     members = _fetch_users(client)
     return [_resolve_single_user(ident, members, mode=mode) for ident in identifiers]
-
-
-# ---------------------------------------------------------------------------
-# Group resolution
-# ---------------------------------------------------------------------------
 
 
 #: Display-name → API name mapping for built-in system role groups.
@@ -686,11 +646,6 @@ def resolve_groups(
     return resolved, _build_group_setting_value(group_ids)
 
 
-# ---------------------------------------------------------------------------
-# US1 — List Channels (T022)
-# ---------------------------------------------------------------------------
-
-
 def _normalize_channel(stream: dict[str, Any]) -> dict[str, Any]:
     """Project a raw Zulip stream dict into the documented shape.
 
@@ -735,11 +690,6 @@ def list_channels(client: Any, *, include_archived: bool = False) -> list[dict[s
     """
     streams = _fetch_streams(client, include_archived=include_archived)
     return [_normalize_channel(s) for s in streams]
-
-
-# ---------------------------------------------------------------------------
-# Channel folders
-# ---------------------------------------------------------------------------
 
 
 def _normalize_channel_folder(raw: dict[str, Any]) -> dict[str, Any]:
@@ -1123,11 +1073,6 @@ def resolve_channel_folder_token(client: Any, token: str) -> int | None:
     )
 
 
-# ---------------------------------------------------------------------------
-# Channel subscribers (US7)
-# ---------------------------------------------------------------------------
-
-
 def list_subscribers(
     client: Any,
     *,
@@ -1213,11 +1158,6 @@ def list_subscribers(
     return enriched
 
 
-# ---------------------------------------------------------------------------
-# User listing (US2)
-# ---------------------------------------------------------------------------
-
-
 def _normalize_user(member: dict[str, Any]) -> dict[str, Any]:
     """Project a raw Zulip ``members`` entry to the CLI/JSON contract shape.
 
@@ -1274,11 +1214,6 @@ def list_users(
             continue
         result.append(_normalize_user(member))
     return result
-
-
-# ---------------------------------------------------------------------------
-# Group listing (US3)
-# ---------------------------------------------------------------------------
 
 
 def _normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
@@ -1366,11 +1301,6 @@ def list_groups(
         return matches
 
     return normalized
-
-
-# ---------------------------------------------------------------------------
-# US4 — Create Channel (T034)
-# ---------------------------------------------------------------------------
 
 
 #: Valid topic-policy values per spec.
@@ -1581,11 +1511,6 @@ def create_channel(
     return result
 
 
-# ---------------------------------------------------------------------------
-# Subscription management (US5)
-# ---------------------------------------------------------------------------
-
-
 #: Spec-defined maximum number of users that can be subscribed in a single
 #: invocation. See data-model.md / contracts/cli-commands.md.
 MAX_SUBSCRIBE_USERS = 50
@@ -1753,10 +1678,6 @@ def subscribe_users(
         "results": results,
         "errors": errors,
     }
-
-
-# Subscription mutations (US6 — unsubscribe)
-# ---------------------------------------------------------------------------
 
 
 def unsubscribe_users(
@@ -1930,10 +1851,6 @@ def unsubscribe_users(
     }
 
 
-# Channel update (US8 — FR-004)
-# ---------------------------------------------------------------------------
-
-
 #: Allowed values for the ``--type`` flag on ``channel update``.
 ChannelType = Literal["public", "private", "web-public"]
 
@@ -2024,9 +1941,6 @@ def update_channel(
     * Returns the standard ``MutationResult`` dict
       (``status``/``channel_id``/``channel_name``/``operation``).
     """
-    # ------------------------------------------------------------------
-    # Argument validation
-    # ------------------------------------------------------------------
     subscribe_list: list[str] = list(subscribe_user_specs or [])
     settings_specified = (
         any(
@@ -2064,9 +1978,6 @@ def update_channel(
     if folder_id is not None:
         _validate_channel_folder_assignment_id(folder_id)
 
-    # ------------------------------------------------------------------
-    # Feature-level gating (FR-019)
-    # ------------------------------------------------------------------
     if channel_type == "web-public":
         # Fetch server settings ONCE and reuse for both the feature-
         # level check (by priming the cached level) and the spectator-
@@ -2115,9 +2026,6 @@ def update_channel(
     if folder_id is not None or folder_id_specified:
         check_feature_level(client, FEATURE_LEVELS["channel-folders"], feature_name="channel-folders")
 
-    # ------------------------------------------------------------------
-    # Resolve target channel
-    # ------------------------------------------------------------------
     channel = resolve_channel(
         client,
         name=name,
@@ -2133,9 +2041,7 @@ def update_channel(
         raise ZulipAPIError(f"Resolved channel missing name: {channel!r}")
     resolved_name = name_raw
 
-    # ------------------------------------------------------------------
     # Resolve --allow-group (with lockout-aware allow_nobody)
-    # ------------------------------------------------------------------
     # ``allow_group`` is always resolved with allow_nobody=True; the
     # lockout-prevention block below decides whether a Nobody-only
     # value is acceptable in the current context. (Per spec, Nobody is
@@ -2156,9 +2062,6 @@ def update_channel(
     if can_remove_subscribers_group is not None:
         _, can_remove_value = resolve_groups(client, can_remove_subscribers_group)
 
-    # ------------------------------------------------------------------
-    # Lockout prevention on type→private (spec scenarios 13/14, FR-004)
-    # ------------------------------------------------------------------
     is_type_to_private = channel_type == "private" and not bool(channel.get("invite_only"))
     if is_type_to_private:
         has_subs_to_add = bool(subscribe_list)
@@ -2182,13 +2085,11 @@ def update_channel(
                     "non-Nobody --allow-group to retain access."
                 )
 
-    # ------------------------------------------------------------------
     # Resolve --subscribe identifiers. When supplied we actually
     # subscribe the users BEFORE issuing the PATCH so that
     # type-to-private conversions truly retain access — relying on the
     # lockout-prevention bypass without actually subscribing would
     # still lock the channel out.
-    # ------------------------------------------------------------------
     if subscribe_list and channel_type != "private":
         raise ZulipValidationError("--subscribe is only valid when using --type private")
     if subscribe_list and user_id_mode is None:
@@ -2224,9 +2125,6 @@ def update_channel(
                 msg = str(sub_response.get("msg") or sub_response)
             raise ZulipAPIError(f"Subscribe-during-update failed: {msg or sub_response!r}")
 
-    # ------------------------------------------------------------------
-    # Build PATCH request
-    # ------------------------------------------------------------------
     request: dict[str, Any] = {}
     if new_name is not None:
         request["new_name"] = new_name
@@ -2244,9 +2142,6 @@ def update_channel(
     if folder_id is not None or folder_id_specified:
         request["folder_id"] = folder_id
 
-    # ------------------------------------------------------------------
-    # PATCH /api/v1/streams/{stream_id}
-    # ------------------------------------------------------------------
     try:
         response = client.call_endpoint(
             url=f"streams/{stream_id}",
@@ -2272,10 +2167,6 @@ def update_channel(
     if folder_id is not None or folder_id_specified:
         result["folder_id"] = folder_id
     return result
-
-
-# Topic policy convenience helpers (FR-021)
-# ---------------------------------------------------------------------------
 
 
 def _normalize_topic_policy(raw_policy: Any) -> TopicPolicy:
@@ -2384,10 +2275,6 @@ def set_topic_policy(
     }
 
 
-# US9 — Archive a channel (T054)
-# ---------------------------------------------------------------------------
-
-
 def archive_channel(
     client: Any,
     channel: str | int,
@@ -2472,11 +2359,6 @@ def archive_channel(
         "channel_name": name,
         "operation": "archive",
     }
-
-
-# ---------------------------------------------------------------------------
-# Channel mutations — unarchive (US10)
-# ---------------------------------------------------------------------------
 
 
 def unarchive_channel(

--- a/lftools_uv/api/endpoints/zulip.py
+++ b/lftools_uv/api/endpoints/zulip.py
@@ -1413,7 +1413,6 @@ def create_channel(
             "Private channels require at least one --subscribe user or a non-Nobody --allow-group to prevent lockout."
         )
 
-    # Build subscription payload
     subscription: dict[str, Any] = {"name": name}
     if description:
         subscription["description"] = description

--- a/lftools_uv/cli/gerrit.py
+++ b/lftools_uv/cli/gerrit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2018 The Linux Foundation and others.

--- a/lftools_uv/nexus/cmd.py
+++ b/lftools_uv/nexus/cmd.py
@@ -161,13 +161,11 @@ def create_repos(config_file: str, settings_file: str | None, url: str) -> None:
     ) -> None:
         if extra_privs is None:
             extra_privs = []
-        # Create target
         try:
             target_id = _nexus.get_target(name)
         except LookupError:
             target_id = _nexus.create_target(name, targets)
 
-        # Create privileges
         privs_set = [
             "create",
             "delete",
@@ -183,14 +181,12 @@ def create_repos(config_file: str, settings_file: str | None, url: str) -> None:
             except LookupError:
                 privs[priv] = _nexus.create_priv(name, target_id, priv)
 
-        # Create Role
         try:
             role_id = _nexus.get_role(name)
             log.info(f"Role {role_id} already exists.")
         except LookupError:
             role_id = _nexus.create_role(name, list(privs.values()))
 
-        # Create user
         try:
             _nexus.get_user(name)
             log.info(f"User {name} already exists.")
@@ -459,7 +455,6 @@ def release_staging_repos(repos: tuple[str, ...], verify: bool, nexus_url: str =
         is_repo_closed = []
 
         for act in activities:
-            # Check for failures
             act_text = "".join(act.itertext())
             if re.search("ruleFailed", act_text):
                 failures2.append(get_activity_text(act))
@@ -481,7 +476,6 @@ def release_staging_repos(repos: tuple[str, ...], verify: bool, nexus_url: str =
                 if add_str_if_not_exist(message, failures2):
                     failures.append(msg_text)
 
-        # Start check result
         if len(failures) != 0 or len(failures2) != 0:
             log.info("\n".join(map(str, failures2)))
             log.info("\n".join(map(str, failures)))

--- a/lftools_uv/nexus/release_docker_hub.py
+++ b/lftools_uv/nexus/release_docker_hub.py
@@ -662,7 +662,6 @@ def get_nexus3_catalog(
         split_catalog = raw_catalog.split(":")
         TmpCatalog = split_catalog[1].split(",")
         for word in TmpCatalog:
-            # Remove all projects that do not start with org_name
             use_this_repo = False
             project: list[str] = []
             if repo_is_filename and repo_is_in_file(word, find_pattern):

--- a/lftools_uv/schema.py
+++ b/lftools_uv/schema.py
@@ -31,7 +31,6 @@ def check_schema_file(yamlfile: str, schemafile: str) -> None:
     with open(schemafile) as _:
         schema_file: dict[str, Any] = yaml.safe_load(_)  # pyright: ignore[reportExplicitAny,reportAny]
 
-    # Load the schema
     validation: jsonschema.Draft4Validator = jsonschema.Draft4Validator(
         schema_file, format_checker=jsonschema.FormatChecker()
     )

--- a/lftools_uv/shell/autocorrectinfofile.py
+++ b/lftools_uv/shell/autocorrectinfofile.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/autocorrectinfofile.py
+++ b/lftools_uv/shell/autocorrectinfofile.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/shell/dco.py
+++ b/lftools_uv/shell/dco.py
@@ -47,7 +47,8 @@ def get_branches(path=getcwd(), invert=False):
             )
             hashlist = hashlist + hashes
         if hashlist:
-            # remove a trailing blank list entry
+            # ``git log`` terminates its output with a newline, so the
+            # ``split`` above leaves an empty final element.
             hashlist.pop()
             return hashlist
         else:
@@ -76,7 +77,6 @@ def check(path=getcwd(), signoffs_dir="dco_signoffs"):
             # de-dupe the commit list
             missing_list = list(dict.fromkeys(missing))
 
-            # Check for dco_signoffs file
             if os.path.isdir(signoffs_dir):
                 missing_list = [
                     commit

--- a/lftools_uv/shell/deploy.py
+++ b/lftools_uv/shell/deploy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/deploy.py
+++ b/lftools_uv/shell/deploy.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/shell/fix_yamllint.py
+++ b/lftools_uv/shell/fix_yamllint.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/fix_yamllint.py
+++ b/lftools_uv/shell/fix_yamllint.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/shell/gerrit_create.py
+++ b/lftools_uv/shell/gerrit_create.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/gerrit_create.py
+++ b/lftools_uv/shell/gerrit_create.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/shell/inactivecommitters.py
+++ b/lftools_uv/shell/inactivecommitters.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/inactivecommitters.py
+++ b/lftools_uv/shell/inactivecommitters.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/shell/sign.py
+++ b/lftools_uv/shell/sign.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/sign.py
+++ b/lftools_uv/shell/sign.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/shell/version.py
+++ b/lftools_uv/shell/version.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/version.py
+++ b/lftools_uv/shell/version.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/shell/yaml4info.py
+++ b/lftools_uv/shell/yaml4info.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017, 2023 The Linux Foundation and others.

--- a/lftools_uv/shell/yaml4info.py
+++ b/lftools_uv/shell/yaml4info.py
@@ -42,7 +42,6 @@ def main():
         print(f"  - {venv_location}", file=sys.stderr)
         sys.exit(1)
 
-    # Execute the shell script with all command line arguments
     cmd = [str(shell_script)] + sys.argv[1:]
     try:
         result = subprocess.run(cmd, check=False)

--- a/lftools_uv/typer_apps/gerrit.py
+++ b/lftools_uv/typer_apps/gerrit.py
@@ -24,7 +24,6 @@ _HELP_GERRIT_PROJECT = "Gerrit project name"
 
 log = logging.getLogger(__name__)
 
-# Create the Typer app for gerrit commands
 gerrit_app = typer.Typer(help="GERRIT TOOLS.")
 
 

--- a/lftools_uv/typer_apps/gerrit.py
+++ b/lftools_uv/typer_apps/gerrit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2018 The Linux Foundation and others.

--- a/lftools_uv/typer_apps/infofile.py
+++ b/lftools_uv/typer_apps/infofile.py
@@ -22,7 +22,6 @@ _MSG_REQUIRES_LEGACY_CLI = "Note: This command requires the original lftools CLI
 
 log = logging.getLogger(__name__)
 
-# Create the infofile subcommand group
 infofile_app = typer.Typer(
     name="infofile",
     help="INFO.yaml file management tools",

--- a/lftools_uv/typer_apps/jenkins.py
+++ b/lftools_uv/typer_apps/jenkins.py
@@ -25,10 +25,8 @@ log = logging.getLogger(__name__)
 
 _MSG_CREDS_NOT_SET = "Username or password not set."
 
-# Create the main Typer app for jenkins commands
 jenkins_app = typer.Typer(help="Query information about the Jenkins Server.")
 
-# Create sub-apps for command groups
 builds_app = typer.Typer(help="Information regarding current builds and the queue.")
 jobs_app = typer.Typer(help="Command to update Jenkins Jobs.")
 nodes_app = typer.Typer(help="Find information about builders connected to Jenkins Master.")
@@ -64,7 +62,6 @@ def jenkins_callback(
         return
 
     try:
-        # Initialize the Jenkins object and pass it to sub-commands
         jenkins_client = Jenkins(server, user, password, config_file=conf)
         if ctx.obj is None:
             ctx.obj = {}
@@ -301,7 +298,6 @@ for (node in Jenkins.instance.computers) {
         raise typer.Exit(1) from None
 
 
-# Builds subcommands
 @builds_app.command("running")
 def builds_running(ctx: typer.Context) -> None:
     """Show all the currently running builds."""
@@ -550,7 +546,6 @@ def plugins_sec(ctx: typer.Context) -> None:
         r = requests.get("http://updates.jenkins-ci.org/update-center.actual.json")
         warn = r.json()["warnings"]
 
-        # create a dict of relevant info from jenkins update center
         secdict = {}
         for w in warn:
             name = w["name"]
@@ -561,7 +556,6 @@ def plugins_sec(ctx: typer.Context) -> None:
             nv = {name: lastversion}
             secdict.update(nv)
 
-        # create a dict of our active plugins
         activedict = {}
         jenkins = ctx.obj["jenkins"]
         plugins = jenkins.server.get_plugins()
@@ -583,7 +577,6 @@ def plugins_sec(ctx: typer.Context) -> None:
             t1 = (ourversion,)
             t2 = (theirversion,)
             if t1 <= t2:
-                # Print Vulnerable Version\t Installed Version\t Link
                 for w in warn:
                     name = w["name"]
                     url = w["url"]
@@ -591,6 +584,8 @@ def plugins_sec(ctx: typer.Context) -> None:
                     for version in w["versions"]:
                         lastversion = version.get("lastVersion")
                     if name == key and secdict[key] == lastversion:
+                        # Tab-separated columns: vulnerable version,
+                        # installed version, then the advisory URL.
                         log.info("%s:%s\t%s:%s\t%s", key, secdict[key], key, activedict[key], url)
     except Exception:
         log.exception("Failed to check plugin security")

--- a/lftools_uv/typer_apps/jenkins.py
+++ b/lftools_uv/typer_apps/jenkins.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2017 The Linux Foundation and others.

--- a/lftools_uv/typer_apps/lfidapi.py
+++ b/lftools_uv/typer_apps/lfidapi.py
@@ -23,7 +23,6 @@ from lftools_uv.lfidapi import (
 
 log = logging.getLogger(__name__)
 
-# Create the lfidapi subcommand group
 lfidapi_app = typer.Typer(
     name="lfidapi",
     help="LFID API tools for managing groups and members",

--- a/lftools_uv/typer_apps/license.py
+++ b/lftools_uv/typer_apps/license.py
@@ -18,7 +18,6 @@ from lftools_uv.license import check_license, check_license_directory
 
 log = logging.getLogger(__name__)
 
-# Create the license subcommand group
 license_app = typer.Typer(
     name="license",
     help="Scan code for license headers",

--- a/lftools_uv/typer_apps/nexus2.py
+++ b/lftools_uv/typer_apps/nexus2.py
@@ -18,10 +18,8 @@ from lftools_uv.api.endpoints import nexus2
 
 log = logging.getLogger(__name__)
 
-# Create the main Typer app for nexus2 commands
 nexus2_app = typer.Typer(help="The Nexus2 API Interface.")
 
-# Create sub-apps for command groups
 privilege_app = typer.Typer(help="Privilege primary interface.")
 repo_app = typer.Typer(help="Repository primary interface.")
 role_app = typer.Typer(help="Role primary interface.")

--- a/lftools_uv/typer_apps/nexus2.py
+++ b/lftools_uv/typer_apps/nexus2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2019 The Linux Foundation and others.

--- a/lftools_uv/typer_apps/nexus3.py
+++ b/lftools_uv/typer_apps/nexus3.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: EPL-1.0
 ##############################################################################
 # Copyright (c) 2019 The Linux Foundation and others.

--- a/lftools_uv/typer_apps/nexus3.py
+++ b/lftools_uv/typer_apps/nexus3.py
@@ -19,10 +19,8 @@ from lftools_uv.api.endpoints import nexus3
 
 log = logging.getLogger(__name__)
 
-# Create the main Typer app for nexus3 commands
 nexus3_app = typer.Typer(help="The Nexus3 API Interface.")
 
-# Create sub-apps for command groups
 asset_app = typer.Typer(help="Asset primary interface.")
 privilege_app = typer.Typer(help="Privilege primary interface.")
 repository_app = typer.Typer(help="Repository primary interface.")

--- a/lftools_uv/typer_apps/openstack.py
+++ b/lftools_uv/typer_apps/openstack.py
@@ -20,14 +20,12 @@ from lftools_uv.openstack import server as os_server
 from lftools_uv.openstack import stack as os_stack
 from lftools_uv.openstack import volume as os_volume
 
-# Create the main OpenStack app
 openstack_app = typer.Typer(
     name="openstack",
     help="Provide an interface to OpenStack.",
     rich_markup_mode="markdown",
 )
 
-# Create sub-apps for each command group
 image_app = typer.Typer(name="image", help="Command for manipulating images.")
 object_app = typer.Typer(name="object", help="Command for manipulating objects.")
 server_app = typer.Typer(name="server", help="Command for manipulating servers.")

--- a/lftools_uv/typer_apps/root.py
+++ b/lftools_uv/typer_apps/root.py
@@ -54,7 +54,6 @@ def version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
-# Create the main Typer app
 app = typer.Typer(
     name="lftools-uv",
     help="Linux Foundation Release Engineering Tools (Typer-based)",
@@ -83,12 +82,10 @@ def main(
     This is the Typer-based version of lftools-uv. Enable it by setting
     the environment variable LFTOOLS_CLI_V2=1.
     """
-    # Configure debug logging
     if debug:
         logging.getLogger("").setLevel(logging.DEBUG)
         log.debug("DEBUG mode enabled.")
 
-    # Initialize application state
     if ctx.obj is None:
         ctx.obj = {}
 
@@ -100,7 +97,6 @@ def main(
     # Legacy compatibility - maintain the old context structure
     ctx.obj["DEBUG"] = debug
 
-    # Handle credentials
     if username is None:
         if interactive:
             username = typer.prompt("Username")
@@ -121,7 +117,6 @@ def main(
             except (configparser.NoOptionError, configparser.NoSectionError):
                 password = None
 
-    # Update state with credentials
     state.update_credentials(username, password)
 
     # Legacy compatibility - maintain old context keys

--- a/lftools_uv/typer_apps/rtd.py
+++ b/lftools_uv/typer_apps/rtd.py
@@ -43,11 +43,6 @@ rtd_app = typer.Typer(
 )
 
 
-# ---------------------------------------------------------------------------
-# Shared output helpers
-# ---------------------------------------------------------------------------
-
-
 def emit_error(message: str) -> None:
     """Write an error message to stderr.
 
@@ -122,11 +117,6 @@ def rtd_callback(
         **(ctx.obj or {}),
         "json_output": json_output,
     }
-
-
-# ---------------------------------------------------------------------------
-# Projects
-# ---------------------------------------------------------------------------
 
 
 @rtd_app.command("project-list")
@@ -264,11 +254,6 @@ def project_update(
     typer.echo(f"Updated project '{project_slug}'")
 
 
-# ---------------------------------------------------------------------------
-# Versions
-# ---------------------------------------------------------------------------
-
-
 @rtd_app.command("project-version-list")
 def project_version_list(
     ctx: typer.Context,
@@ -366,11 +351,6 @@ def project_version_update(
         return
     state = "active" if active else "inactive"
     typer.echo(f"Marked version '{result['version']}' of '{project_slug}' as {state}")
-
-
-# ---------------------------------------------------------------------------
-# Builds
-# ---------------------------------------------------------------------------
 
 
 @rtd_app.command("project-build-list")
@@ -474,11 +454,6 @@ def project_build_trigger(
     build = result.get("build")
     build_id = build.get("id", "") if isinstance(build, dict) else ""
     typer.echo(f"Triggered build {build_id} for '{project_slug}'")
-
-
-# ---------------------------------------------------------------------------
-# Subprojects
-# ---------------------------------------------------------------------------
 
 
 @rtd_app.command("subproject-list")

--- a/lftools_uv/typer_apps/schema.py
+++ b/lftools_uv/typer_apps/schema.py
@@ -18,7 +18,6 @@ from lftools_uv.schema import check_schema_file
 
 log = logging.getLogger(__name__)
 
-# Create the schema subcommand group
 schema_app = typer.Typer(
     name="schema",
     help="Verify YAML Schema",

--- a/lftools_uv/typer_apps/sign.py
+++ b/lftools_uv/typer_apps/sign.py
@@ -21,7 +21,6 @@ _MSG_SIGN_NOT_FOUND_LONG = "Error: 'sign' command not found in PATH. Please ensu
 
 log = logging.getLogger(__name__)
 
-# Create the sign subcommand group
 sign_app = typer.Typer(
     name="sign",
     help="GPG or Sigul sign files",

--- a/lftools_uv/typer_apps/utils.py
+++ b/lftools_uv/typer_apps/utils.py
@@ -21,7 +21,6 @@ from lftools_uv import helpers
 
 log = logging.getLogger(__name__)
 
-# Create the utils subcommand group
 utils_app = typer.Typer(
     name="utils",
     help="Tools to make life easier",

--- a/lftools_uv/typer_apps/version.py
+++ b/lftools_uv/typer_apps/version.py
@@ -21,7 +21,6 @@ _MSG_VERSION_NOT_FOUND_LONG = "Error: 'version' command not found in PATH. Pleas
 
 log = logging.getLogger(__name__)
 
-# Create the version subcommand group
 version_app = typer.Typer(
     name="version",
     help="Version bump script for Maven based projects",
@@ -144,7 +143,6 @@ def patch(
         lftools-uv version patch "Lithium-SR1" /path/to/patches
         lftools-uv version patch "1.2.3" /path/to/patches --project "MyProject"
     """
-    # Validate patch directory exists
     if not os.path.isdir(patch_dir):
         log.error(f"{patch_dir} is not a valid directory.")
         typer.echo(f"Error: {patch_dir} is not a valid directory.", err=True)

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -716,12 +716,10 @@ def channel_create(
 
     options = ctx.obj or {}
 
-    # Validate channel type
     if channel_type not in ("public", "private", "web-public"):
         emit_error(f"Invalid channel type: {channel_type!r}. Valid types: public, private, web-public")
         raise typer.Exit(code=1)
 
-    # Validate announce mutex
     if announce and no_announce:
         emit_error("--announce and --no-announce are mutually exclusive")
         raise typer.Exit(code=1)
@@ -731,7 +729,6 @@ def channel_create(
         emit_error(f"Invalid --topic-policy value: {topic_policy!r}. Valid values: allow, deny, follow-default")
         raise typer.Exit(code=1)
 
-    # Validate id mode flags
     id_mode = _validate_id_mode_flags(by_email, by_id, by_name, subscribe)
 
     # Determine announce value

--- a/lftools_uv/typer_apps/zulip.py
+++ b/lftools_uv/typer_apps/zulip.py
@@ -77,11 +77,6 @@ zulip_app = typer.Typer(
 )
 
 
-# ---------------------------------------------------------------------------
-# Shared option callbacks and helpers
-# ---------------------------------------------------------------------------
-
-
 def zuliprc_callback(value: Path | None) -> Path | None:
     """Validate the ``--zuliprc`` flag value.
 
@@ -192,11 +187,6 @@ def bulk_mutation_result(
     }
 
 
-# ---------------------------------------------------------------------------
-# Top-level callback (optional-dependency guard, FR-022)
-# ---------------------------------------------------------------------------
-
-
 @zulip_app.callback()
 def zulip_callback(
     ctx: typer.Context,
@@ -235,19 +225,6 @@ def zulip_callback(
         typer.echo(MISSING_EXTRA_MESSAGE, err=True)
         raise typer.Exit(code=1)
 
-
-# ---------------------------------------------------------------------------
-# US1 — channel list (T023)
-# ---------------------------------------------------------------------------
-#
-# NOTE: The ``channel`` sub-app is shared across the channel-scoped
-# user-story slices: US1 (channel list), US4 (channel create), US5
-# (channel subscribe), US6 (channel unsubscribe), and the remaining
-# US7-US10 channel commands. The first PR to land that touches a
-# channel command also lands this sub-app instantiation. If two PRs
-# instantiate the sub-app independently, the trivial merge conflict
-# on the ``channel_app = typer.Typer(...)`` line should be resolved
-# by keeping a single instance.
 
 channel_app = typer.Typer(
     name="channel",
@@ -629,11 +606,6 @@ def channel_subscribers(
     emit_table(rows, headers=("Full Name", "Email", "User ID"))
 
 
-# ---------------------------------------------------------------------------
-# US4 — channel create (T035)
-# ---------------------------------------------------------------------------
-
-
 def _validate_id_mode_flags(
     by_email: bool,
     by_id: bool,
@@ -839,11 +811,6 @@ def channel_create(
         raise typer.Exit(code=1)
 
 
-# ---------------------------------------------------------------------------
-# US2 — user list (T024)
-# ---------------------------------------------------------------------------
-
-
 user_app = typer.Typer(
     name="user",
     help="Inspect Zulip users.",
@@ -906,11 +873,6 @@ def user_list(
             row.append("yes" if not user["is_active"] else "no")
         rows.append(row)
     emit_table(rows, headers)
-
-
-# ---------------------------------------------------------------------------
-# `zulip group` sub-app (US3)
-# ---------------------------------------------------------------------------
 
 
 group_app = typer.Typer(
@@ -986,10 +948,6 @@ def group_list(
         for group in groups
     ]
     emit_table(rows, headers=headers)
-
-
-# T036 — `channel subscribe` CLI (US5)
-# ---------------------------------------------------------------------------
 
 
 def _resolve_id_mode(by_email: bool, by_id: bool, by_name: bool) -> Literal["email", "id", "name"]:
@@ -1176,10 +1134,6 @@ def channel_subscribe(
         raise typer.Exit(code=1)
 
 
-# `zulip channel unsubscribe` (US6 / T043)
-# ---------------------------------------------------------------------------
-
-
 @channel_app.command("unsubscribe")
 def channel_unsubscribe(
     ctx: typer.Context,
@@ -1364,11 +1318,6 @@ def channel_unsubscribe(
     # produce a non-zero exit code alongside ``error``.
     if payload["status"] in ("error", "partial"):
         raise typer.Exit(code=1)
-
-
-# ---------------------------------------------------------------------------
-# Channel update (US8)
-# ---------------------------------------------------------------------------
 
 
 def _validate_single_channel_target(
@@ -1572,11 +1521,6 @@ def channel_update(  # noqa: PLR0913 - CLI parity with contract
         emit_json(result)
     else:
         typer.echo(f"Updated channel '{result['channel_name']}' (id={result['channel_id']})")
-
-
-# ---------------------------------------------------------------------------
-# Topic policy convenience command (FR-021)
-# ---------------------------------------------------------------------------
 
 
 @channel_app.command("topic-policy")


### PR DESCRIPTION
## Summary

First PR in a stack that drives the `aislop` AI-slop audit findings for this
repository to zero. This one clears all **134 comment-hygiene findings**
(`ai-slop/narrative-comment` and `ai-slop/trivial-comment`).

Verified finding count: **278 → 144**.

## Correction to the reported baseline

The audit summary circulated for this repository listed 6 `critical`/`error`
findings under `security/vulnerable-dependency` (idna, msgpack, pip, pygments,
requests, urllib3). **These were false positives originating from the auditing
workstation, not from this repository.**

`aislop` shells out to whatever `pip-audit` is first on `PATH`, and `pip-audit`
invoked with no arguments audits *its own* environment. The auditing machine had
a stale `uv`-managed `pip-audit` tool venv. Running `uv run pip-audit` against
this project reports **no known vulnerabilities** — `uv.lock` already pins every
fixed version. After `uv tool upgrade pip-audit`, those 6 findings disappear
with no repository change. No action is needed here.

## Commits

1. **`Chore: Remove vestigial shebangs from modules`** — 12 findings

   Every `#!/usr/bin/env python3` line under `lftools_uv/` sat in a file with
   mode `100644`. These files are either imported as modules or installed as
   `[project.scripts]` console entry points, which generate their own wrappers,
   so none is ever executed as `./file.py`.

   This is also what caused the 12 licence-banner findings. The
   `narrative-comment` rule exempts a licence header only when the comment block
   begins on line 1; the shebang pushed the block to line 2, so the legacy
   Eclipse Public License banner was reported as decorative narration. Removing
   the shebang restores the exemption and leaves the licence headers
   byte-identical to the other 117 modules carrying the same banner — a one-line
   deletion per file rather than rewriting 130 headers.

2. **`Style: Remove decorative section banner comments`** — 84 findings

   Removes `# ---- / # Title / # ----` rules and spec-tracking headers such as
   `US4 - Create Channel (T034)` from the API endpoint and Typer command
   modules.

   Substantive comments that happened to sit inside those banners are
   **preserved**: the lockout-aware `allow_group` resolution note and the
   rationale for subscribing users before issuing the channel `PATCH`.

   Also drops the note explaining how to resolve a merge conflict on the shared
   `channel_app` instantiation between concurrently developed user-story slices;
   that described the development process, and those slices have all merged.

3. **`Style: Remove comments that restate the code`** — 48 findings + 2 reworded

   Removes 48 comments that repeated the statement directly below them.

   Two flagged comments carried real information and were **reworded rather than
   deleted**:
   - `shell/dco.py` — a bare `hashlist.pop()` gave no hint why a final element is
     discarded; the comment now names the cause.
   - `typer_apps/jenkins.py` — the comment documenting the tab-separated output
     columns now sits directly above the `log.info` call it describes.

## Note on `aislop fix`

`aislop fix` was **not** used, and should not be used on this repository. Trialled
on a throwaway clone, it strips SPDX/copyright headers (violating REUSE and
Constitution Principle III), deletes PEP 8 blank lines, and empties an
`if TYPE_CHECKING:` block leaving a syntax error — it introduced 27 new errors.
All changes here are manual.

## Verification

No code lines were removed; the diff is exclusively comment and blank lines,
confirmed by filtering the diff for non-comment deletions.

- `uv run pytest tests/` — 824 passed
- `uv run ruff check .` / `ruff format` — clean
- `mypy`, `basedpyright`, `reuse lint`, `codespell` — clean
- Full `prek run` gate passed on every commit

## Stack

This is **PR 1 of a stacked series**; later PRs target this branch so each
diff stays small enough for Copilot review. Please merge in order.

| # | Branch | Clears |
|---|---|---|
| 1 | `fix/aislop-comment-hygiene` (this PR) | 134 comment findings |
| 2 | `fix/aislop-error-observability` | 24 `silent-recovery` / `broad-except` |
| 3 | `fix/aislop-misc-findings` | 11 assorted |
| 4 | `fix/aislop-cli-output` | 72 `python-print-debug` |
| 5 | `refactor/aislop-cli-params` | 16 `too-many-params` |
| 6+ | `refactor/split-*` | 21 complexity findings |
