### PR TITLE
Fix: Make failing code paths diagnosable

### DIFF
--- a/lftools_uv/api/endpoints/gerrit.py
+++ b/lftools_uv/api/endpoints/gerrit.py
@@ -493,7 +493,9 @@ class Gerrit(client.RestApi):
             log.info(resp)
             log.error("A problem was encountered while querying the Gerrit API: %s", exc)
             log.debug(resp.text)
-            sys.exit(resp.status_code)
+            # Not resp.status_code: an unparsable body can arrive with any
+            # status, and an HTTP code is not a meaningful process exit code.
+            sys.exit(1)
 
         if results_dict:
             log.info("Project already exists")

--- a/lftools_uv/api/endpoints/gerrit.py
+++ b/lftools_uv/api/endpoints/gerrit.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import time
 from typing import cast
 from urllib.parse import quote
@@ -332,9 +333,9 @@ class Gerrit(client.RestApi):
             try:
                 response: ApiResponse = self.get(access_str)
                 result = self._json_body(response)
-            except Exception:
-                log.info("Not found %s", access_str)
-                exit(1)
+            except Exception as exc:
+                log.exception("Failed to query %s: %s", access_str, exc)
+                sys.exit(1)
             log.info("found %s %s", access_str, mylist)
         return result
 
@@ -383,7 +384,7 @@ class Gerrit(client.RestApi):
         if resp.status_code == 409:
             log.info(edit_result)
             log.info("Conflict detected exiting")
-            exit(0)
+            sys.exit(0)
 
         else:
             access_str = f"changes/{changeid}/edit:publish"
@@ -488,17 +489,17 @@ class Gerrit(client.RestApi):
         results_dict: object = None
         try:
             results_dict = json.loads(json_text)  # pyright: ignore[reportAny]
-        except json.decoder.JSONDecodeError:
+        except json.decoder.JSONDecodeError as exc:
             log.info(resp)
-            log.info("A problem was encountered while querying the Gerrit API.")
+            log.error("A problem was encountered while querying the Gerrit API: %s", exc)
             log.debug(resp.text)
-            exit(resp.status_code)
+            sys.exit(resp.status_code)
 
         if results_dict:
             log.info("Project already exists")
-            exit(1)
+            sys.exit(1)
         if check:
-            exit(0)
+            sys.exit(0)
 
         saml_group: str = f"saml/{ldap_group}"
         log.info("SAML group name: %s", saml_group)

--- a/lftools_uv/cli/errors.py
+++ b/lftools_uv/cli/errors.py
@@ -77,6 +77,8 @@ from functools import wraps
 from types import ModuleType
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
+from .state import AppState  # noqa: F401
+
 # Optional import guarded to avoid hard dependency on Click
 click: ModuleType | None
 try:
@@ -227,15 +229,8 @@ def handle_errors(
 # Convenience alias with default behavior
 error_handler = handle_errors()
 
-
 __all__: list[str] = [
     "handle_errors",
     "error_handler",
-    "AppState",  # re-export optional for convenience if imported after state
+    "AppState",
 ]
-
-# Optional re-export if state module already loaded (avoid circular import)
-try:  # pragma: no cover - optional convenience
-    from .state import AppState  # noqa: F401
-except Exception:  # pragma: no cover
-    pass

--- a/lftools_uv/cli/github_cli.py
+++ b/lftools_uv/cli/github_cli.py
@@ -190,7 +190,7 @@ def updaterepo(ctx, organization, repository, has_issues, has_projects, has_wiki
 
         if repo_actual is None:
             log.error("repo not found")
-            exit(1)
+            sys.exit(1)
 
         for team in teams:
             if team.name == add_team:

--- a/lftools_uv/deploy.py
+++ b/lftools_uv/deploy.py
@@ -99,14 +99,14 @@ def _request_post(url: str, data: str, headers: dict[str, str]) -> requests.Resp
     resp: requests.Response | None = None
     try:
         resp = requests.post(url, data=data, headers=headers, timeout=30)
-    except requests.exceptions.MissingSchema:
-        log.debug("in _request_post. MissingSchema")
+    except requests.exceptions.MissingSchema as exc:
+        log.debug("POST to %s failed with a missing URL scheme: %s", url, exc)
         _log_error_and_exit(f"Not valid URL: {url}")
-    except requests.exceptions.ConnectionError:
-        log.debug("in _request_post. ConnectionError")
+    except requests.exceptions.ConnectionError as exc:
+        log.debug("POST to %s could not connect: %s", url, exc)
         _log_error_and_exit(f"Could not connect to URL: {url}")
-    except requests.exceptions.InvalidURL:
-        log.debug("in _request_post. InvalidURL")
+    except requests.exceptions.InvalidURL as exc:
+        log.debug("POST to %s used an invalid URL: %s", url, exc)
         _log_error_and_exit(f"Invalid URL: {url}")
     assert resp is not None  # noqa: S101
     return resp

--- a/lftools_uv/git/gerrit.py
+++ b/lftools_uv/git/gerrit.py
@@ -81,9 +81,10 @@ class Gerrit:
         commit_msg_hook_path = f"{local_hooks_path}/commit-msg"
 
         try:
-            os.mkdir(local_hooks_path)
-        except FileExistsError:
-            log.debug(f"Directory {local_hooks_path} already exists")
+            os.makedirs(local_hooks_path, exist_ok=True)
+        except OSError as exc:
+            log.error("Could not create hooks directory %s: %s", local_hooks_path, exc)
+            raise
         with requests.get(hook_url) as hook:
             hook.raise_for_status()
             with open(commit_msg_hook_path, "w") as file:
@@ -93,11 +94,8 @@ class Gerrit:
     def add_file(self, filepath: str, content: str) -> None:
         """Add a file to the current git repo."""
         if filepath.find("/") >= 0:
-            try:
-                log.debug(f"Making directories for {filepath[0]}")
-                os.makedirs(os.path.split(filepath)[0])
-            except FileExistsError:
-                log.debug("Directories already exist, skipping")
+            log.debug(f"Making directories for {filepath[0]}")
+            os.makedirs(os.path.split(filepath)[0], exist_ok=True)
         with open(filepath, "w") as newfile:
             newfile.write(content)
         self.repo.git.add(filepath)

--- a/lftools_uv/git/gerrit.py
+++ b/lftools_uv/git/gerrit.py
@@ -225,12 +225,13 @@ class Gerrit:
         try:
             credential_json = config.get_setting(self.fqdn, "additional_credentials")
             additional_credentials = json.loads(credential_json)
-        except configparser.NoOptionError:
-            log.debug("No additional credentials found")
-        except json.decoder.JSONDecodeError:
+        except configparser.NoOptionError as exc:
+            log.debug("No additional credentials found: %s", exc)
+        except json.decoder.JSONDecodeError as exc:
             log.error(
-                'Improperly formatted JSON in "additional_credentials". '
-                + "Please ensure that all credentials are on a single line, and are not quoted."
+                'Improperly formatted JSON in "additional_credentials" (%s). '
+                "Please ensure that all credentials are on a single line, and are not quoted.",
+                exc,
             )
 
         if not nexus3_url:
@@ -249,8 +250,8 @@ class Gerrit:
         elif nexus3_ports:
             try:
                 nexus3_port_list = nexus3_ports.split(",")
-            except AttributeError:
-                log.error("Invalid nexus3_ports designated.")
+            except AttributeError as exc:
+                log.error("Invalid nexus3_ports designated: %s", exc)
 
         jinja_env = Environment(
             loader=PackageLoader(_LFTOOLS_UV_GIT), autoescape=select_autoescape(), keep_trailing_newline=True

--- a/lftools_uv/lfidapi.py
+++ b/lftools_uv/lfidapi.py
@@ -65,7 +65,7 @@ def helper_search_members(group: str) -> list[dict[str, str]] | None:
             check_response_code(response)
         except requests.HTTPError as e:
             log.exception(e)
-            exit(1)
+            sys.exit(1)
         result = response.json()
         members: list[dict[str, str]] = result["members"]
         # Avoid logging PII (member data) - use debug level only for non-sensitive metadata
@@ -91,7 +91,7 @@ def helper_user(user: str, group: str, delete: bool | str) -> None:
         check_response_code(response)
     except requests.HTTPError as e:
         log.exception(e)
-        exit(1)
+        sys.exit(1)
     # Avoid logging PII - only log operation success
     log.debug("User operation completed successfully")
 
@@ -118,7 +118,7 @@ def helper_invite(email: str, group: str) -> None:
         check_response_code(response)
     except requests.HTTPError as e:
         log.exception(e)
-        exit(1)
+        sys.exit(1)
     # Avoid logging PII - only log operation success
     log.debug("Invite operation completed successfully")
 
@@ -140,7 +140,7 @@ def helper_create_group(group: str) -> None:
             check_response_code(response)
         except requests.HTTPError as e:
             log.exception(e)
-            exit(1)
+            sys.exit(1)
         # Avoid logging potentially sensitive response data
         log.debug("Group creation completed successfully")
 

--- a/lftools_uv/nexus/cmd.py
+++ b/lftools_uv/nexus/cmd.py
@@ -37,8 +37,8 @@ def get_credentials(settings_file: str | None, url: str | None = None) -> dict[s
         try:
             with open(settings_file) as f:
                 settings: dict[str, str] = yaml.safe_load(f)
-        except OSError:
-            log.error(f'Error reading settings file "{settings_file}"')
+        except OSError as exc:
+            log.error(f'Error reading settings file "{settings_file}": {exc}')
             sys.exit(1)
 
         if url and {"user", "password"}.issubset(settings):
@@ -65,8 +65,8 @@ def get_url(settings_file: str | None) -> str:
         try:
             with open(settings_file) as f:
                 settings = yaml.safe_load(f)
-        except OSError:
-            log.error(f'Error reading settings file "{settings_file}"')
+        except OSError as exc:
+            log.error(f'Error reading settings file "{settings_file}": {exc}')
             sys.exit(1)
 
         if "nexus" in settings:
@@ -94,8 +94,8 @@ def reorder_staged_repos(settings_file: str) -> None:
 
     try:
         repo_id = _nexus.get_repo_group("Staging Repositories")
-    except LookupError:
-        log.error("Staging repository 'Staging Repositories' cannot be found")
+    except LookupError as exc:
+        log.error(f"Staging repository 'Staging Repositories' cannot be found: {exc}")
         sys.exit(1)
 
     repo_details = cast(dict[str, Any], _nexus.get_repo_group_details(repo_id))

--- a/lftools_uv/nexus/release_docker_hub.py
+++ b/lftools_uv/nexus/release_docker_hub.py
@@ -354,8 +354,8 @@ class DockerTagClass(TagClass):
                         still_more = True
                     else:
                         still_more = False
-                except Exception:
-                    log.debug(f"Issue fetching tags for {combined_repo_name}")
+                except Exception as exc:
+                    log.warning("Issue fetching tags for %s: %s", combined_repo_name, exc)
             else:
                 self.repository_exist = False
                 return

--- a/lftools_uv/nexus/release_docker_hub.py
+++ b/lftools_uv/nexus/release_docker_hub.py
@@ -355,7 +355,12 @@ class DockerTagClass(TagClass):
                     else:
                         still_more = False
                 except Exception as exc:
-                    log.warning("Issue fetching tags for %s: %s", combined_repo_name, exc)
+                    # Leaving still_more and docker_tag_url unchanged here would
+                    # re-fetch the same page forever, re-adding tags each time.
+                    log.error("Malformed tag response for %s: %s", combined_repo_name, exc)
+                    raise requests.HTTPError(
+                        f"Malformed tag response from Docker Hub for {combined_repo_name}"
+                    ) from exc
             else:
                 self.repository_exist = False
                 return

--- a/lftools_uv/openstack/cmd.py
+++ b/lftools_uv/openstack/cmd.py
@@ -15,6 +15,7 @@ __author__ = "Thanh Ha"
 
 import re
 import subprocess
+import sys
 
 import click
 
@@ -99,7 +100,7 @@ def upload(ctx, image, name, disk_format):
         print(f"PASS Image format matches {disk_format}")
     else:
         print(f"ERROR Image is not in {disk_format} format")
-        exit(1)
+        sys.exit(1)
 
     os_image.upload(ctx.obj["os_cloud"], image, name, disk_format)
 

--- a/lftools_uv/openstack/stack.py
+++ b/lftools_uv/openstack/stack.py
@@ -158,9 +158,12 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
             total_cost += get_server_cost(server)
         print("total: " + str(total_cost))
     except Exception:
-        log.exception("Error calculating stack cost")
-        log.warning("Returning 0 total cost due to error")
-        print("total: 0.0")
+        # The per-server pricing lookup above already falls back to 0.0 on a
+        # flaky pricing API, so reaching here means stack enumeration itself
+        # failed and no total can be derived. Reporting 0.0 would be
+        # indistinguishable from a genuinely idle stack, so fail instead.
+        log.exception("Unable to calculate cost for stack %s", stack_name)
+        sys.exit(1)
 
 
 def delete(os_cloud: str, name_or_id: str, force: bool = False, timeout: int = 900) -> bool | None:

--- a/lftools_uv/shell/autocorrectinfofile.py
+++ b/lftools_uv/shell/autocorrectinfofile.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/lftools_uv/shell/dco.py
+++ b/lftools_uv/shell/dco.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 from os import chdir, getcwd
 
 log = logging.getLogger(__name__)
@@ -55,7 +56,7 @@ def get_branches(path=getcwd(), invert=False):
             return False
     except subprocess.CalledProcessError as e:
         log.exception(e)
-        exit(1)
+        sys.exit(1)
 
 
 def check(path=getcwd(), signoffs_dir="dco_signoffs"):
@@ -64,7 +65,7 @@ def check(path=getcwd(), signoffs_dir="dco_signoffs"):
     try:
         hashes = get_branches(path, invert=True)
         if not hashes:
-            exit(0)
+            sys.exit(0)
         else:
             missing = []
             for commit in hashes:
@@ -72,7 +73,7 @@ def check(path=getcwd(), signoffs_dir="dco_signoffs"):
                     missing.append(commit.split(" ")[0])
 
             if not missing:
-                exit(0)
+                sys.exit(0)
 
             # de-dupe the commit list
             missing_list = list(dict.fromkeys(missing))
@@ -87,10 +88,10 @@ def check(path=getcwd(), signoffs_dir="dco_signoffs"):
             if missing_list:
                 for commit in missing_list:
                     log.info(f"{commit}")
-                exit(1)
+                sys.exit(1)
     except subprocess.CalledProcessError as e:
         log.exception(e)
-        exit(1)
+        sys.exit(1)
 
 
 def match(path=getcwd(), signoffs_dir="dco_signoffs"):
@@ -100,7 +101,7 @@ def match(path=getcwd(), signoffs_dir="dco_signoffs"):
         hashes = get_branches(path)
         exit_code = 0
         if not hashes:
-            exit(exit_code)
+            sys.exit(exit_code)
 
         # de-dupe the commit list
         hashes_list = list(dict.fromkeys(hashes))
@@ -137,7 +138,7 @@ def match(path=getcwd(), signoffs_dir="dco_signoffs"):
                 )
                 exit_code = 1
 
-        exit(exit_code)
+        sys.exit(exit_code)
     except subprocess.CalledProcessError as e:
         log.exception(e)
-        exit(1)
+        sys.exit(1)

--- a/lftools_uv/shell/deploy.py
+++ b/lftools_uv/shell/deploy.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/lftools_uv/shell/fix_yamllint.py
+++ b/lftools_uv/shell/fix_yamllint.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/lftools_uv/shell/gerrit_create.py
+++ b/lftools_uv/shell/gerrit_create.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/lftools_uv/shell/inactivecommitters.py
+++ b/lftools_uv/shell/inactivecommitters.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/lftools_uv/shell/sign.py
+++ b/lftools_uv/shell/sign.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/lftools_uv/shell/version.py
+++ b/lftools_uv/shell/version.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/lftools_uv/shell/yaml4info.py
+++ b/lftools_uv/shell/yaml4info.py
@@ -46,8 +46,8 @@ def main():
     try:
         result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
-    except FileNotFoundError:
-        print(f"Error: Could not execute shell script at {shell_script}", file=sys.stderr)
+    except FileNotFoundError as exc:
+        print(f"Error: Could not execute shell script at {shell_script}: {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/tests/test_openstack_stack.py
+++ b/tests/test_openstack_stack.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: EPL-1.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Tests for OpenStack stack operations."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lftools_uv.openstack import stack as os_stack
+
+
+@patch("lftools_uv.openstack.stack.openstack.connect")
+def test_cost_with_no_servers_reports_zero(mock_connect, capsys):
+    """A stack holding no servers costs nothing and succeeds."""
+    mock_cloud = MagicMock()
+    mock_connect.return_value = mock_cloud
+    mock_cloud.orchestration.resources.return_value = []
+
+    os_stack.cost("test-cloud", "empty-stack")
+
+    assert capsys.readouterr().out.strip() == "total: 0.0"
+
+
+@patch("lftools_uv.openstack.stack.openstack.connect")
+def test_cost_exits_non_zero_when_enumeration_fails(mock_connect, capsys, caplog):
+    """Stack enumeration failing must fail the command, not report 0.0.
+
+    The per-server pricing lookup already falls back to 0.0 when the pricing
+    API misbehaves, so reaching the outer handler means no total can be
+    derived at all. Reporting 0.0 there would be indistinguishable from a
+    genuinely idle stack, and a pipeline reading the figure would silently
+    under-report.
+    """
+    mock_cloud = MagicMock()
+    mock_connect.return_value = mock_cloud
+    mock_cloud.orchestration.resources.side_effect = RuntimeError("enumeration failed")
+
+    with pytest.raises(SystemExit) as exc_info:
+        os_stack.cost("test-cloud", "broken-stack")
+
+    assert exc_info.value.code == 1
+    assert "total:" not in capsys.readouterr().out
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)


### PR DESCRIPTION
## Summary

PR 2 of the stacked series clearing the `aislop` audit findings. This one makes
failing code paths diagnosable, clearing all 23 `ai-slop/silent-recovery`
findings and the single `ai-slop/python-broad-except` finding.

Verified finding count: **144 → 119**.

> **Stacked on #645.** Base is `fix/aislop-comment-hygiene`, so this diff shows
> only this PR's changes. Merge #645 first.

## Commits

### 1. `Fix: Use sys.exit instead of the builtin exit`

`exit` is injected into builtins by the `site` module as an interactive
convenience. It is absent under `python -S` and in embedded/frozen
interpreters, where these calls would raise `NameError` instead of terminating —
and every one of them is on an error path. Replaces the bare calls in
`cli/github_cli.py`, `lfidapi.py`, `openstack/cmd.py` and `shell/dco.py`.

### 2. `Fix: Include the caught error in failure logs`

Nineteen handlers logged a fixed string and discarded the exception they had
just caught. `Error reading settings file "x"` does not say whether the file was
missing, unreadable, or a directory; `in _request_post. ConnectionError` said
less than the exception it replaced.

Each handler now binds the exception and interpolates it into the log call.

Two Gerrit messages change severity to match their behaviour: a failed
sanity-check query and an unparsable API response both abort the command, so
they log at `ERROR` rather than `INFO`.

The Gerrit endpoint's `exit()` → `sys.exit()` migration lands in this commit
rather than the previous one because those calls sit inside the same handlers
being rewritten and cannot be split cleanly.

### 3. `Fix: Create directories with exist_ok`

Two sites created a directory in a `try` and caught `FileExistsError` only to log
that it already existed — which is what `exist_ok` provides. Worse, a genuine
permission or read-only-filesystem error took the same silent debug path as the
benign case. The hook directory now reports and re-raises `OSError`.

### 4. `Refactor: Import AppState unconditionally`

The `AppState` re-export sat behind `except Exception: pass`, annotated as a
circular-import guard. **No cycle exists** — `cli/state.py` imports only from the
standard library. The handler suppressed nothing it was meant to, while hiding
genuine failures and leaving a name promised by `__all__` silently absent.

### 5. `Fix: Fail when the stack cost cannot be derived` ⚠️ behaviour change

**This one deserves reviewer attention.**

`openstack stack cost` wrapped the whole calculation in `except Exception`,
logged, then printed `total: 0.0`. That is indistinguishable from a genuinely
idle stack, so a pipeline parsing the figure would silently under-report.

The per-server pricing lookup *already* degrades gracefully on its own — it
catches timeouts and URL errors from the vexxhost pricing API, warns, and
contributes `0.0` for that server. So reaching the outer handler means stack or
resource enumeration itself failed and **no** total can be derived.

It now logs and exits non-zero rather than printing a fabricated total. The
genuine empty case (a stack with no servers) still prints `total: 0.0` and exits
successfully.

### 6. `Fix: Address Copilot review feedback`

Three findings from the automated review, all valid:

- **A genuine infinite loop.** In the Docker Hub tag fetch, a malformed response
  left `still_more` and `docker_tag_url` unchanged inside `while still_more:`,
  so the same page was fetched forever, re-adding its tags each pass. It span
  silently before because the handler logged at `debug`; raising the level to
  `warning` in this branch is what exposed it. Now raises.
- `sys.exit(resp.status_code)` → `sys.exit(1)`. An unparsable body can arrive
  with any status, and an HTTP code is not a meaningful process exit code.
- Added `tests/test_openstack_stack.py`, covering the behaviour change in
  commit 5 — which had no test, exactly the gap Principle I exists to close.

## Verification

- Commits were split by hunk, and replaying the groups in sequence was
  verified to reproduce the combined tree byte-for-byte.
- `uv run pytest tests/` — 826 passed
- `prek run --all-files` — clean
- `ruff check` / `ruff format` / `mypy` / `basedpyright` — clean

## Follow-ups noted, deliberately not in scope

- `shell/dco.py` accumulates `git log` output across branches but pops only one
  trailing blank entry, so blanks from all but the last branch survive. This is
  pre-existing and unrelated to slop; flagging it rather than fixing it here.

*(An earlier version of this description claimed 19 bare `exit()` calls remained
after this PR. That was wrong — `main` had exactly 19, across five files, and
all of them are converted here. A scan of the branch finds none left.)*
