### PR TITLE
Refactor: Separate command output from diagnostics

### DIFF
--- a/lftools_uv/__init__.py
+++ b/lftools_uv/__init__.py
@@ -45,7 +45,11 @@ class LogFormatter(logging.Formatter):
             return self.default_fmt.format(record)
 
 
-console_handler = logging.StreamHandler(sys.stdout)
+# Diagnostics go to stderr so that a caller may parse stdout without a warning
+# corrupting the stream. Command results are written to stdout by
+# lftools_uv.output.echo. See Principle VI of the project constitution and the
+# machine-readable output contract in docs/commands/rtd.rst.
+console_handler = logging.StreamHandler(sys.stderr)
 console_handler.setFormatter(LogFormatter())
 logging.getLogger("").setLevel(logging.INFO)
 logging.getLogger("").addHandler(console_handler)

--- a/lftools_uv/github_helper.py
+++ b/lftools_uv/github_helper.py
@@ -22,6 +22,7 @@ from github.Organization import Organization
 from github.Team import Team
 
 from lftools_uv import config
+from lftools_uv.output import echo
 
 if TYPE_CHECKING:
     from github.PaginatedList import PaginatedList
@@ -66,7 +67,7 @@ def helper_list(  # noqa: C901, PLR0912
 
     # Extend this to check if a repo exists
     if repos:
-        print("All repos for organization: ", organization)  # noqa: T201
+        echo(f"All repos for organization:  {organization}")
         all_repos = org.get_repos()
         for repo in all_repos:
             log.info(repo.name)
@@ -212,8 +213,7 @@ def helper_user_github(  # noqa: C901, PLR0912
         log.debug("User object retrieved successfully")
     except GithubException as ghe:
         log.error(ghe)
-        # Use print() for user-facing output to avoid logging PII
-        print("User not found")  # noqa: T201
+        echo("User not found")
         sys.exit(1)
 
     if not isinstance(user_raw, NamedUser):
@@ -225,8 +225,7 @@ def helper_user_github(  # noqa: C901, PLR0912
     is_member: bool = False
     try:
         is_member = org.has_in_members(user_object)
-        # Use print() for user-facing output to avoid logging PII
-        print(f"User membership status: {is_member}")  # noqa: T201
+        echo(f"User membership status: {is_member}")
     except GithubException as ghe:
         log.error(ghe)
 
@@ -251,11 +250,9 @@ def helper_user_github(  # noqa: C901, PLR0912
                 team_obj.remove_membership(user_object)
             except GithubException as ghe:
                 log.error(ghe)
-            # Use print() for user-facing output to avoid logging PII
-            print("Removing user from team")  # noqa: T201
+            echo("Removing user from team")
         else:
-            # Use print() for user-facing output to avoid logging PII
-            print("User is not a member of org, cannot delete")  # noqa: T201
+            echo("User is not a member of org, cannot delete")
             log.info("Code does not handle revoking invitations.")
 
     if user and not delete:
@@ -273,8 +270,7 @@ def helper_user_github(  # noqa: C901, PLR0912
                 )
             except GithubException as ghe:
                 log.error(ghe)
-            # Use print() for user-facing output to avoid logging PII
-            print("Sending Admin invite to user for team")  # noqa: T201
+            echo("Sending Admin invite to user for team")
 
         if not admin and is_member:
             try:
@@ -290,5 +286,4 @@ def helper_user_github(  # noqa: C901, PLR0912
                 )
             except GithubException as ghe:
                 log.error(ghe)
-            # Use print() for user-facing output to avoid logging PII
-            print("Sending invite to user for team")  # noqa: T201
+            echo("Sending invite to user for team")

--- a/lftools_uv/openstack/cluster.py
+++ b/lftools_uv/openstack/cluster.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 __author__ = "Anil Belur"
 
 import json
+import logging
 import sys
 from collections.abc import Iterator
 from typing import Any
@@ -23,6 +24,10 @@ import openstack
 import openstack.connection
 import requests
 from openstack.cloud.exc import OpenStackCloudException
+
+from lftools_uv.output import echo
+
+log = logging.getLogger(__name__)
 
 
 def _silo_name(jenkins: str) -> str:
@@ -69,23 +74,23 @@ def _fetch_builds_from(jenkins: str) -> list[str]:
             timeout=30,
         )
     except requests.exceptions.Timeout:
-        print(f"ERROR: Timeout fetching data from {jenkins_url}")
+        log.error("Timeout fetching data from %s", jenkins_url)
         return []
     except requests.exceptions.RequestException as e:
-        print(f"ERROR: Request failed for {jenkins_url}: {e}")
+        log.error("Request failed for %s: %s", jenkins_url, e)
         return []
     except Exception as e:
-        print(f"ERROR: Unexpected error fetching from {jenkins_url}: {e}")
+        log.exception("Unexpected error fetching from %s: %s", jenkins_url, e)
         return []
 
     if response.status_code != 200:
-        print(f"ERROR: Failed to fetch data from {jenkins_url} with status code {response.status_code}")
+        log.error("Failed to fetch data from %s with status code %s", jenkins_url, response.status_code)
         return []
 
     try:
         data = response.json()
     except json.JSONDecodeError as e:
-        print(f"ERROR: Failed to parse JSON from {jenkins_url}: {e}")
+        log.error("Failed to parse JSON from %s: %s", jenkins_url, e)
         return []
 
     silo = _silo_name(jenkins)
@@ -134,15 +139,15 @@ def list_clusters(os_cloud: str) -> None:
         clusters = cloud.list_coe_clusters()
 
         for cluster in clusters:
-            print(cluster.name)
+            echo(cluster.name)
 
     except OpenStackCloudException as e:
-        print(f"ERROR: Failed to list clusters: {e}")
+        log.error("Failed to list clusters: %s", e)
         sys.exit(1)
     except AttributeError:
         # Fallback if list_coe_clusters is not available
-        print("ERROR: COE cluster operations not supported by this OpenStack SDK version")
-        print("Please ensure openstacksdk >= 4.0.0 is installed")
+        log.error("COE cluster operations not supported by this OpenStack SDK version")
+        log.error("Please ensure openstacksdk >= 4.0.0 is installed")
         sys.exit(1)
 
 
@@ -161,13 +166,13 @@ def cleanup(os_cloud: str, jenkins_urls: str | None = None) -> None:
         jenkins_url_list = [url.strip() for url in jenkins_urls.split() if url.strip()]
 
     if not jenkins_url_list:
-        print("WARN: No Jenkins URLs provided, skipping cluster cleanup to be safe")
+        log.warning("No Jenkins URLs provided, skipping cluster cleanup to be safe")
         return
 
-    print(f"INFO: Checking Jenkins URLs for active builds: {' '.join(jenkins_url_list)}")
+    log.info("Checking Jenkins URLs for active builds: %s", " ".join(jenkins_url_list))
 
     active_builds = _fetch_jenkins_builds(jenkins_url_list)
-    print(f"INFO: Found {len(active_builds)} active builds in Jenkins")
+    log.info("Found %d active builds in Jenkins", len(active_builds))
 
     cloud = openstack.connection.from_config(cloud=os_cloud)
 
@@ -175,36 +180,36 @@ def cleanup(os_cloud: str, jenkins_urls: str | None = None) -> None:
         clusters = cloud.list_coe_clusters()
         cluster_names = [cluster.name for cluster in clusters]
 
-        print(f"INFO: Found {len(cluster_names)} COE clusters on cloud {os_cloud}")
+        log.info("Found %d COE clusters on cloud %s", len(cluster_names), os_cloud)
 
         deleted_count = 0
         for cluster_name in cluster_names:
             # Check if cluster is managed (long-lived)
             if "-managed-prod-k8s-" in cluster_name or "-managed-test-k8s-" in cluster_name:
-                print(f"INFO: Skipping managed cluster: {cluster_name}")
+                log.info("Skipping managed cluster: %s", cluster_name)
                 continue
 
             # Check if cluster is in active Jenkins builds
             if _cluster_in_jenkins(cluster_name, active_builds):
-                print(f"INFO: Cluster {cluster_name} is in use by active build, skipping")
+                log.info("Cluster %s is in use by active build, skipping", cluster_name)
                 continue
 
-            print(f"INFO: Deleting orphaned k8s cluster: {cluster_name}")
+            log.info("Deleting orphaned k8s cluster: %s", cluster_name)
             try:
                 cloud.delete_coe_cluster(cluster_name)
                 deleted_count += 1
-                print(f"INFO: Successfully deleted cluster: {cluster_name}")
+                log.info("Successfully deleted cluster: %s", cluster_name)
             except OpenStackCloudException as e:
-                print(f"ERROR: Failed to delete cluster {cluster_name}: {e}")
+                log.error("Failed to delete cluster %s: %s", cluster_name, e)
                 continue
 
-        print(f"INFO: Deleted {deleted_count} orphaned cluster(s)")
+        log.info("Deleted %d orphaned cluster(s)", deleted_count)
 
     except OpenStackCloudException as e:
-        print(f"ERROR: Failed to list clusters: {e}")
+        log.error("Failed to list clusters: %s", e)
         sys.exit(1)
     except AttributeError:
         # Fallback if COE operations are not available
-        print("ERROR: COE cluster operations not supported by this OpenStack SDK version")
-        print("Please ensure openstacksdk >= 4.0.0 is installed")
+        log.error("COE cluster operations not supported by this OpenStack SDK version")
+        log.error("Please ensure openstacksdk >= 4.0.0 is installed")
         sys.exit(1)

--- a/lftools_uv/openstack/cluster.py
+++ b/lftools_uv/openstack/cluster.py
@@ -80,7 +80,7 @@ def _fetch_builds_from(jenkins: str) -> list[str]:
         log.error("Request failed for %s: %s", jenkins_url, e)
         return []
     except Exception as e:
-        log.exception("Unexpected error fetching from %s: %s", jenkins_url, e)
+        log.error("Unexpected error fetching from %s: %s", jenkins_url, e)
         return []
 
     if response.status_code != 200:

--- a/lftools_uv/openstack/cluster.py
+++ b/lftools_uv/openstack/cluster.py
@@ -100,7 +100,7 @@ def _fetch_builds_from(jenkins: str) -> list[str]:
         # A syntactically valid reply can still have an unexpected shape, for
         # example {"computer": null}. Keep the documented fallback of treating
         # such a server as having no active builds.
-        print(f"ERROR: Unexpected response shape from {jenkins_url}: {e}")
+        log.error("Unexpected response shape from %s: %s", jenkins_url, e)
         return []
 
 

--- a/lftools_uv/openstack/cmd.py
+++ b/lftools_uv/openstack/cmd.py
@@ -13,6 +13,7 @@
 __author__ = "Thanh Ha"
 
 
+import logging
 import re
 import subprocess
 import sys
@@ -25,6 +26,8 @@ from lftools_uv.openstack import object as os_object
 from lftools_uv.openstack import server as os_server
 from lftools_uv.openstack import stack as os_stack
 from lftools_uv.openstack import volume as os_volume
+
+log = logging.getLogger(__name__)
 
 
 @click.group()
@@ -97,9 +100,9 @@ def upload(ctx, image, name, disk_format):
     pattern = disk_format
     result = re.search(pattern, disktype)
     if result:
-        print(f"PASS Image format matches {disk_format}")
+        log.info("PASS Image format matches %s", disk_format)
     else:
-        print(f"ERROR Image is not in {disk_format} format")
+        log.error("Image is not in %s format", disk_format)
         sys.exit(1)
 
     os_image.upload(ctx.obj["os_cloud"], image, name, disk_format)

--- a/lftools_uv/openstack/object.py
+++ b/lftools_uv/openstack/object.py
@@ -18,6 +18,8 @@ __author__ = "Thanh Ha"
 import openstack
 import openstack.connection
 
+from lftools_uv.output import echo
+
 
 def list_containers(os_cloud: str) -> None:
     """List volumes found according to parameters."""
@@ -25,4 +27,4 @@ def list_containers(os_cloud: str) -> None:
     containers = cloud.list_containers()
 
     for container in containers:
-        print(container)
+        echo(container)

--- a/lftools_uv/openstack/server.py
+++ b/lftools_uv/openstack/server.py
@@ -12,6 +12,7 @@
 
 __author__ = "Anil Belur"
 
+import logging
 import sys
 from datetime import UTC, datetime, timedelta
 
@@ -19,6 +20,10 @@ from datetime import UTC, datetime, timedelta
 import openstack
 import openstack.connection
 from openstack.cloud.exc import OpenStackCloudException
+
+from lftools_uv.output import echo
+
+log = logging.getLogger(__name__)
 
 
 def _filter_servers(servers, days=0):
@@ -41,7 +46,7 @@ def list(os_cloud, days=0):
 
     filtered_servers = _filter_servers(servers, days)
     for server in filtered_servers:
-        print(server.name)
+        echo(server.name)
 
 
 def cleanup(os_cloud, days=0):
@@ -52,7 +57,7 @@ def cleanup(os_cloud, days=0):
     """
 
     def _remove_servers_from_cloud(servers, cloud):
-        print(f"Removing {len(servers)} servers from {cloud.cloud_config.name}.")
+        log.info("Removing %d servers from %s.", len(servers), cloud.cloud_config.name)
         for server in servers:
             try:
                 # Delete by id, not name. Names are not unique, and a duplicate
@@ -66,19 +71,21 @@ def cleanup(os_cloud, days=0):
                 if error_msg.startswith("Multiple matches found for") or error_msg.startswith(
                     "More than one Server exists with the name"
                 ):
-                    print(f"WARNING: {error_msg}. Skipping server...")
+                    log.warning("%s. Skipping server...", error_msg)
                     continue
                 else:
-                    print(f"ERROR: Unexpected exception: {error_msg}")
+                    log.error("Unexpected exception: %s", error_msg)
                     raise
 
             if not result:
-                print(
-                    f'WARNING: Failed to remove "{server.name}" ({server.id}) from '
-                    f"{cloud.cloud_config.name}. Possibly already deleted."
+                log.warning(
+                    'Failed to remove "%s" (%s) from %s. Possibly already deleted.',
+                    server.name,
+                    server.id,
+                    cloud.cloud_config.name,
                 )
             else:
-                print(f'Removed "{server.name}" ({server.id}) from {cloud.cloud_config.name}.')
+                log.info('Removed "%s" (%s) from %s.', server.name, server.id, cloud.cloud_config.name)
 
     cloud = openstack.connection.from_config(cloud=os_cloud)
     servers = cloud.list_servers()
@@ -96,12 +103,12 @@ def remove(os_cloud, server_name, minutes=0):
     server = cloud.get_server(server_name)
 
     if not server:
-        print("ERROR: Server not found.")
+        log.error("Server not found.")
         sys.exit(1)
 
     if datetime.strptime(server.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC) >= datetime.now(UTC) - timedelta(
         minutes=minutes
     ):
-        print(f'WARN: Server "{server.name}" ({server.id}) is not older than {minutes} minutes.')
+        log.warning('Server "%s" (%s) is not older than %d minutes.', server.name, server.id, minutes)
     else:
         cloud.delete_server(server.id)

--- a/lftools_uv/openstack/stack.py
+++ b/lftools_uv/openstack/stack.py
@@ -29,6 +29,7 @@ import openstack.connection
 from openstack.cloud.exc import OpenStackCloudHTTPError
 
 from lftools_uv.jenkins import Jenkins
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ def create(
     stack_success = False
     stack = None
 
-    print(f"Creating stack {name}")
+    log.info("Creating stack %s", name)
     for _attempt in range(tries):
         try:
             stack = cloud.create_stack(
@@ -53,9 +54,9 @@ def create(
             )
         except OpenStackCloudHTTPError as e:
             if cloud.search_stacks(name):
-                print(f"Stack with name {name} already exists.")
+                log.error("Stack with name %s already exists.", name)
             else:
-                print(e)
+                log.error("%s", e)
             sys.exit(1)
 
         stack_id = stack.id  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
@@ -65,26 +66,26 @@ def create(
             stack = cloud.get_stack(stack_id)
 
             if stack.status == "CREATE_IN_PROGRESS":  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
-                print("Waiting to initialize infrastructure...")
+                log.info("Waiting to initialize infrastructure...")
             elif stack.status == "CREATE_COMPLETE":  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
-                print("Stack initialization successful.")
+                log.info("Stack initialization successful.")
                 stack_success = True
                 break
             elif stack.status == "CREATE_FAILED":  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
-                print(f"WARN: Failed to initialize stack. Reason: {stack.status_reason}")  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
+                log.warning("Failed to initialize stack. Reason: %s", stack.status_reason)  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
                 if delete(os_cloud, stack_id):
                     break
             else:
-                print(f"Unexpected status: {stack.status}")  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
+                log.warning("Unexpected status: %s", stack.status)  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
 
         if stack_success:
             break
 
-    print("------------------------------------")
-    print("Stack Details")
-    print("------------------------------------")
+    echo("------------------------------------")
+    echo("Stack Details")
+    echo("------------------------------------")
     cloud.pprint(stack)
-    print("------------------------------------")
+    echo("------------------------------------")
 
 
 def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
@@ -154,12 +155,12 @@ def cost(os_cloud: str, stack_name: str, timeout: int = 60) -> None:
 
         if not server_ids:
             log.info("No servers found in stack %s", stack_name)
-            print("total: 0.0")
+            echo("total: 0.0")
             return
 
         for server in server_ids:
             total_cost += get_server_cost(server)
-        print("total: " + str(total_cost))
+        echo("total: " + str(total_cost))
     except Exception:
         # The per-server pricing lookup above already falls back to 0.0 on a
         # flaky pricing API, so reaching here means stack enumeration itself
@@ -175,7 +176,7 @@ def delete(os_cloud: str, name_or_id: str, force: bool = False, timeout: int = 9
     Return True if delete was successful.
     """
     cloud = openstack.connection.from_config(cloud=os_cloud)
-    print(f"Deleting stack {name_or_id}")
+    log.info("Deleting stack %s", name_or_id)
     cloud.delete_stack(name_or_id)
 
     t_end = time.time() + timeout
@@ -184,20 +185,20 @@ def delete(os_cloud: str, name_or_id: str, force: bool = False, timeout: int = 9
         stack = cloud.get_stack(name_or_id)
 
         if not stack or stack.status == "DELETE_COMPLETE":  # pyright: ignore[reportAttributeAccessIssue]
-            print(f"Successfully deleted stack {name_or_id}")
+            log.info("Successfully deleted stack %s", name_or_id)
             return True
         elif stack.status == "DELETE_IN_PROGRESS":  # pyright: ignore[reportAttributeAccessIssue]
-            print("Waiting for stack to delete...")
+            log.info("Waiting for stack to delete...")
         elif stack.status == "DELETE_FAILED":  # pyright: ignore[reportAttributeAccessIssue]
-            print(f"WARN: Failed to delete $STACK_NAME. Reason: {stack.status_reason}")  # pyright: ignore[reportAttributeAccessIssue]
-            print("Retrying delete...")
+            log.warning("Failed to delete stack %s. Reason: %s", name_or_id, stack.status_reason)  # pyright: ignore[reportAttributeAccessIssue]
+            log.info("Retrying delete...")
             cloud.delete_stack(name_or_id)
         else:
-            print(f"WARN: Unexpected delete status: {stack.status}")  # pyright: ignore[reportAttributeAccessIssue]
-            print("Retrying delete...")
+            log.warning("Unexpected delete status: %s", stack.status)  # pyright: ignore[reportAttributeAccessIssue]
+            log.info("Retrying delete...")
             cloud.delete_stack(name_or_id)
 
-    print(f"Failed to delete stack {name_or_id}")
+    log.error("Failed to delete stack %s", name_or_id)
     if not force:
         return False
     return None

--- a/lftools_uv/openstack/volume.py
+++ b/lftools_uv/openstack/volume.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 __author__ = "Thanh Ha"
 
 import builtins
+import logging
 import sys
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -23,6 +24,10 @@ from typing import Any
 import openstack
 import openstack.connection
 from openstack.cloud.exc import OpenStackCloudException
+
+from lftools_uv.output import echo
+
+log = logging.getLogger(__name__)
 
 
 def _filter_volumes(volumes: builtins.list[Any], days: int = 0) -> builtins.list[Any]:
@@ -45,7 +50,7 @@ def list(os_cloud: str, days: int = 0) -> None:
 
     filtered_volumes = _filter_volumes(volumes, days)
     for volume in filtered_volumes:
-        print(volume.name)
+        echo(volume.name)
 
 
 def cleanup(os_cloud: str, days: int = 0) -> None:
@@ -56,7 +61,7 @@ def cleanup(os_cloud: str, days: int = 0) -> None:
     """
 
     def _remove_volumes_from_cloud(volumes: builtins.list[Any], cloud: Any) -> None:
-        print(f"Removing {len(volumes)} volumes from {cloud.cloud_config.name}.")
+        log.info("Removing %d volumes from %s.", len(volumes), cloud.cloud_config.name)
         for volume in volumes:
             try:
                 # Delete by id, not name. Names are not unique, and a duplicate
@@ -70,19 +75,21 @@ def cleanup(os_cloud: str, days: int = 0) -> None:
                 if error_msg.startswith("Multiple matches found for") or error_msg.startswith(
                     "More than one Volume exists with the name"
                 ):
-                    print(f"WARNING: {error_msg}. Skipping volume...")
+                    log.warning("%s. Skipping volume...", error_msg)
                     continue
                 else:
-                    print(f"ERROR: Unexpected exception: {error_msg}")
+                    log.error("Unexpected exception: %s", error_msg)
                     raise
 
             if not result:
-                print(
-                    f'WARNING: Failed to remove "{volume.name}" ({volume.id}) from '
-                    f"{cloud.cloud_config.name}. Possibly already deleted."
+                log.warning(
+                    'Failed to remove "%s" (%s) from %s. Possibly already deleted.',
+                    volume.name,
+                    volume.id,
+                    cloud.cloud_config.name,
                 )
             else:
-                print(f'Removed "{volume.name}" ({volume.id}) from {cloud.cloud_config.name}.')
+                log.info('Removed "%s" (%s) from %s.', volume.name, volume.id, cloud.cloud_config.name)
 
     cloud = openstack.connection.from_config(cloud=os_cloud)
     volumes = cloud.list_volumes()
@@ -101,12 +108,12 @@ def remove(os_cloud: str, volume_id: str, minutes: int = 0) -> None:
     volume = cloud.get_volume_by_id(volume_id)
 
     if not volume:
-        print("ERROR: volume not found.")
+        log.error("volume not found.")
         sys.exit(1)
 
     if datetime.strptime(volume.created_at, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=UTC) >= datetime.now(
         UTC
     ) - timedelta(minutes=minutes):
-        print(f'WARN: volume "{volume.name}" ({volume.id}) is not older than {minutes} minutes.')
+        log.warning('volume "%s" (%s) is not older than %d minutes.', volume.name, volume.id, minutes)
     else:
         cloud.delete_volume(volume.id)

--- a/lftools_uv/output.py
+++ b/lftools_uv/output.py
@@ -2,25 +2,26 @@
 # SPDX-FileCopyrightText: 2026 The Linux Foundation
 """Console output helpers.
 
-lftools-uv writes two different kinds of text, and they have different
-contracts with the caller.
-
-*Diagnostics* describe what a command is doing: progress, warnings and
-failures. They belong to the logging system, which gives them a level, a
-logger name and a timestamp when one is configured, and lets an operator
-raise or lower the verbosity without changing the code. Modules emit these
-through ``logging.getLogger(__name__)`` directly. The package configures a
-handler in ``lftools_uv/__init__.py`` that renders ``INFO`` records as a bare
-message and higher levels as ``LEVEL: message``.
+lftools-uv writes two different kinds of text on two different streams, and
+the split matters to anything parsing the output.
 
 *Results* are the answer the caller asked for: the names of the servers that
-were listed, the total cost of a stack. CI pipelines parse this text, so it
-must reach stdout whatever the log level, and must not gain a level prefix.
-:func:`echo` exists to write it.
+were listed, the total cost of a stack, a ``--json`` payload. These go to
+**stdout**, whatever the log level, and carry no level prefix. :func:`echo`
+writes them.
 
-Keeping the two apart means the verbosity of a command can be changed without
-silencing its output, and the output can be captured without also capturing
-the commentary.
+*Diagnostics* describe what a command is doing: progress, warnings and
+failures. These go to **stderr** through the logging system, which gives them
+a level and a logger name and lets an operator raise or lower the verbosity
+without silencing the result. Modules emit them through
+``logging.getLogger(__name__)`` directly; the handler configured in
+``lftools_uv/__init__.py`` renders ``INFO`` records as a bare message and
+higher levels as ``LEVEL: message``.
+
+Keeping the two on separate streams is what lets a caller run
+``lftools-uv ... --json | jq`` without a warning corrupting the payload. It is
+required by Principle VI of the project constitution and documented for
+callers in ``docs/commands/rtd.rst``.
 """
 
 from __future__ import annotations
@@ -32,7 +33,8 @@ def echo(message: object = "") -> None:
     """Write one line of command output to stdout.
 
     Use this for text the caller asked for and may parse. Use a module
-    logger instead for anything describing how the command is getting on.
+    logger instead for anything describing how the command is getting on;
+    that reaches stderr.
 
     :arg message: Value to write. Rendered with :func:`str`.
     """

--- a/lftools_uv/output.py
+++ b/lftools_uv/output.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: EPL-1.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Console output helpers.
+
+lftools-uv writes two different kinds of text, and they have different
+contracts with the caller.
+
+*Diagnostics* describe what a command is doing: progress, warnings and
+failures. They belong to the logging system, which gives them a level, a
+logger name and a timestamp when one is configured, and lets an operator
+raise or lower the verbosity without changing the code. Modules emit these
+through ``logging.getLogger(__name__)`` directly. The package configures a
+handler in ``lftools_uv/__init__.py`` that renders ``INFO`` records as a bare
+message and higher levels as ``LEVEL: message``.
+
+*Results* are the answer the caller asked for: the names of the servers that
+were listed, the total cost of a stack. CI pipelines parse this text, so it
+must reach stdout whatever the log level, and must not gain a level prefix.
+:func:`echo` exists to write it.
+
+Keeping the two apart means the verbosity of a command can be changed without
+silencing its output, and the output can be captured without also capturing
+the commentary.
+"""
+
+from __future__ import annotations
+
+__all__ = ["echo"]
+
+
+def echo(message: object = "") -> None:
+    """Write one line of command output to stdout.
+
+    Use this for text the caller asked for and may parse. Use a module
+    logger instead for anything describing how the command is getting on.
+
+    :arg message: Value to write. Rendered with :func:`str`.
+    """
+    # aislop-ignore-next-line python-print-debug -- deliberate result output; see module docstring
+    print(message)  # noqa: T201

--- a/lftools_uv/typer_apps/openstack.py
+++ b/lftools_uv/typer_apps/openstack.py
@@ -9,6 +9,7 @@
 ##############################################################################
 """Typer CLI configuration for openstack command."""
 
+import logging
 import re
 import subprocess
 
@@ -19,6 +20,8 @@ from lftools_uv.openstack import object as os_object
 from lftools_uv.openstack import server as os_server
 from lftools_uv.openstack import stack as os_stack
 from lftools_uv.openstack import volume as os_volume
+
+log = logging.getLogger(__name__)
 
 openstack_app = typer.Typer(
     name="openstack",
@@ -108,9 +111,9 @@ def image_upload(
     pattern = disk_format
     result = re.search(pattern, disktype)
     if result:
-        print(f"PASS Image format matches {disk_format}")
+        log.info("PASS Image format matches %s", disk_format)
     else:
-        print(f"ERROR Image is not in {disk_format} format")
+        log.error("Image is not in %s format", disk_format)
         raise typer.Exit(1)
 
     os_image.upload(state.os_cloud, image, name_str, disk_format)

--- a/tests/test_openstack_cluster.py
+++ b/tests/test_openstack_cluster.py
@@ -9,6 +9,7 @@
 ##############################################################################
 """Test OpenStack cluster operations."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -156,7 +157,7 @@ def test_fetch_jenkins_builds_malformed_shape(payload, capsys):
 
 
 @responses.activate
-def test_fetch_jenkins_builds_timeout(capsys):
+def test_fetch_jenkins_builds_timeout(caplog):
     """Test handling of timeout when fetching Jenkins builds."""
     jenkins_url = "https://jenkins.example.org"
     api_url = f"{jenkins_url}/computer/api/json"
@@ -170,12 +171,11 @@ def test_fetch_jenkins_builds_timeout(capsys):
     builds = os_cluster._fetch_jenkins_builds([jenkins_url])
 
     assert len(builds) == 0
-    captured = capsys.readouterr()
-    assert "ERROR" in captured.out
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 @responses.activate
-def test_fetch_jenkins_builds_invalid_json(capsys):
+def test_fetch_jenkins_builds_invalid_json(caplog):
     """Test handling of invalid JSON response."""
     jenkins_url = "https://jenkins.example.org"
     api_url = f"{jenkins_url}/computer/api/json"
@@ -190,8 +190,7 @@ def test_fetch_jenkins_builds_invalid_json(capsys):
     builds = os_cluster._fetch_jenkins_builds([jenkins_url])
 
     assert len(builds) == 0
-    captured = capsys.readouterr()
-    assert "ERROR" in captured.out
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 @responses.activate
@@ -277,7 +276,7 @@ def test_list_clusters(mock_from_config, capsys):
 
 
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_list_clusters_error(mock_from_config, capsys):
+def test_list_clusters_error(mock_from_config, caplog):
     """Test handling errors when listing clusters."""
     from openstack.cloud.exc import OpenStackCloudException
 
@@ -289,13 +288,12 @@ def test_list_clusters_error(mock_from_config, capsys):
         os_cluster.list_clusters("test-cloud")
 
     assert exc_info.value.code == 1
-    captured = capsys.readouterr()
-    assert "ERROR" in captured.out
-    assert "Failed to list clusters" in captured.out
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
+    assert "Failed to list clusters" in caplog.text
 
 
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_list_clusters_not_supported(mock_from_config, capsys):
+def test_list_clusters_not_supported(mock_from_config, caplog):
     """Test handling when COE operations are not supported."""
     mock_cloud = MagicMock()
     mock_from_config.return_value = mock_cloud
@@ -305,20 +303,18 @@ def test_list_clusters_not_supported(mock_from_config, capsys):
         os_cluster.list_clusters("test-cloud")
 
     assert exc_info.value.code == 1
-    captured = capsys.readouterr()
-    assert "ERROR" in captured.out
-    assert "not supported" in captured.out
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
+    assert "not supported" in caplog.text
 
 
 @patch("lftools_uv.openstack.cluster._fetch_jenkins_builds")
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_cleanup_no_jenkins_urls(mock_from_config, mock_fetch_builds, capsys):
+def test_cleanup_no_jenkins_urls(mock_from_config, mock_fetch_builds, caplog):
     """Test cleanup with no Jenkins URLs provided."""
     os_cluster.cleanup("test-cloud", jenkins_urls=None)
 
-    captured = capsys.readouterr()
-    assert "WARN" in captured.out
-    assert "No Jenkins URLs provided" in captured.out
+    assert any(record.levelno >= logging.WARNING for record in caplog.records)
+    assert "No Jenkins URLs provided" in caplog.text
 
     # Should not attempt to fetch builds or connect to OpenStack
     mock_fetch_builds.assert_not_called()
@@ -327,13 +323,12 @@ def test_cleanup_no_jenkins_urls(mock_from_config, mock_fetch_builds, capsys):
 
 @patch("lftools_uv.openstack.cluster._fetch_jenkins_builds")
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_cleanup_empty_jenkins_urls(mock_from_config, mock_fetch_builds, capsys):
+def test_cleanup_empty_jenkins_urls(mock_from_config, mock_fetch_builds, caplog):
     """Test cleanup with empty Jenkins URLs string."""
     os_cluster.cleanup("test-cloud", jenkins_urls="   ")
 
-    captured = capsys.readouterr()
-    assert "WARN" in captured.out
-    assert "No Jenkins URLs provided" in captured.out
+    assert any(record.levelno >= logging.WARNING for record in caplog.records)
+    assert "No Jenkins URLs provided" in caplog.text
 
     mock_fetch_builds.assert_not_called()
     mock_from_config.assert_not_called()
@@ -341,8 +336,10 @@ def test_cleanup_empty_jenkins_urls(mock_from_config, mock_fetch_builds, capsys)
 
 @patch("lftools_uv.openstack.cluster._fetch_jenkins_builds")
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_cleanup_orphaned_clusters(mock_from_config, mock_fetch_builds, capsys):
+def test_cleanup_orphaned_clusters(mock_from_config, mock_fetch_builds, caplog):
     """Test cleanup of orphaned clusters."""
+    caplog.set_level(logging.INFO)
+
     # Mock Jenkins builds
     mock_fetch_builds.return_value = ["production-active-job-123"]
 
@@ -364,11 +361,10 @@ def test_cleanup_orphaned_clusters(mock_from_config, mock_fetch_builds, capsys):
     os_cluster.cleanup("test-cloud", jenkins_urls="https://jenkins.example.org")
 
     # Verify orphaned clusters were deleted but active one was not
-    captured = capsys.readouterr()
-    assert "Deleting orphaned k8s cluster: orphaned-cluster-1" in captured.out
-    assert "Deleting orphaned k8s cluster: orphaned-cluster-2" in captured.out
-    assert "Cluster active-job-123 is in use by active build" in captured.out
-    assert "Deleted 2 orphaned cluster(s)" in captured.out
+    assert "Deleting orphaned k8s cluster: orphaned-cluster-1" in caplog.text
+    assert "Deleting orphaned k8s cluster: orphaned-cluster-2" in caplog.text
+    assert "Cluster active-job-123 is in use by active build" in caplog.text
+    assert "Deleted 2 orphaned cluster(s)" in caplog.text
 
     # Verify delete was called for orphaned clusters
     assert mock_cloud.delete_coe_cluster.call_count == 2
@@ -378,8 +374,10 @@ def test_cleanup_orphaned_clusters(mock_from_config, mock_fetch_builds, capsys):
 
 @patch("lftools_uv.openstack.cluster._fetch_jenkins_builds")
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_cleanup_preserves_managed_clusters(mock_from_config, mock_fetch_builds, capsys):
+def test_cleanup_preserves_managed_clusters(mock_from_config, mock_fetch_builds, caplog):
     """Test that managed clusters are preserved during cleanup."""
+    caplog.set_level(logging.INFO)
+
     # Mock Jenkins builds (empty - no active builds)
     mock_fetch_builds.return_value = []
 
@@ -401,11 +399,10 @@ def test_cleanup_preserves_managed_clusters(mock_from_config, mock_fetch_builds,
     os_cluster.cleanup("test-cloud", jenkins_urls="https://jenkins.example.org")
 
     # Verify managed clusters were skipped
-    captured = capsys.readouterr()
-    assert "Skipping managed cluster: project-managed-prod-k8s-cluster" in captured.out
-    assert "Skipping managed cluster: project-managed-test-k8s-cluster" in captured.out
-    assert "Deleting orphaned k8s cluster: orphaned-cluster" in captured.out
-    assert "Deleted 1 orphaned cluster(s)" in captured.out
+    assert "Skipping managed cluster: project-managed-prod-k8s-cluster" in caplog.text
+    assert "Skipping managed cluster: project-managed-test-k8s-cluster" in caplog.text
+    assert "Deleting orphaned k8s cluster: orphaned-cluster" in caplog.text
+    assert "Deleted 1 orphaned cluster(s)" in caplog.text
 
     # Verify delete was only called once
     mock_cloud.delete_coe_cluster.assert_called_once_with("orphaned-cluster")
@@ -413,9 +410,11 @@ def test_cleanup_preserves_managed_clusters(mock_from_config, mock_fetch_builds,
 
 @patch("lftools_uv.openstack.cluster._fetch_jenkins_builds")
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_cleanup_delete_error(mock_from_config, mock_fetch_builds, capsys):
+def test_cleanup_delete_error(mock_from_config, mock_fetch_builds, caplog):
     """Test handling of errors when deleting clusters."""
     from openstack.cloud.exc import OpenStackCloudException
+
+    caplog.set_level(logging.INFO)
 
     # Mock Jenkins builds
     mock_fetch_builds.return_value = []
@@ -435,15 +434,17 @@ def test_cleanup_delete_error(mock_from_config, mock_fetch_builds, capsys):
     # Call cleanup - should not exit, just log error
     os_cluster.cleanup("test-cloud", jenkins_urls="https://jenkins.example.org")
 
-    captured = capsys.readouterr()
-    assert "ERROR: Failed to delete cluster orphaned-cluster" in captured.out
-    assert "Deleted 0 orphaned cluster(s)" in captured.out
+    assert "Failed to delete cluster orphaned-cluster" in caplog.text
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
+    assert "Deleted 0 orphaned cluster(s)" in caplog.text
 
 
 @patch("lftools_uv.openstack.cluster._fetch_jenkins_builds")
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_cleanup_multiple_jenkins_urls(mock_from_config, mock_fetch_builds, capsys):
+def test_cleanup_multiple_jenkins_urls(mock_from_config, mock_fetch_builds, caplog):
     """Test cleanup with multiple Jenkins URLs."""
+    caplog.set_level(logging.INFO)
+
     # Mock Jenkins builds
     mock_fetch_builds.return_value = ["production-job-1", "sandbox-job-2"]
 
@@ -457,20 +458,18 @@ def test_cleanup_multiple_jenkins_urls(mock_from_config, mock_fetch_builds, caps
     os_cluster.cleanup("test-cloud", jenkins_urls=jenkins_urls)
 
     # Verify both URLs were processed
-    captured = capsys.readouterr()
-    # Check for the full INFO message to avoid CodeQL's incomplete URL substring sanitization warning
+    # Check for the full message to avoid CodeQL's incomplete URL substring sanitization warning
     # These are test assertions verifying output format, not security-related URL validation
     expected_info_line = (
-        "INFO: Checking Jenkins URLs for active builds: "
-        "https://jenkins1.example.org https://jenkins2.example.com/sandbox"
+        "Checking Jenkins URLs for active builds: https://jenkins1.example.org https://jenkins2.example.com/sandbox"
     )
-    assert expected_info_line in captured.out
-    assert "Found 2 active builds in Jenkins" in captured.out
+    assert expected_info_line in caplog.text
+    assert "Found 2 active builds in Jenkins" in caplog.text
 
 
 @patch("lftools_uv.openstack.cluster._fetch_jenkins_builds")
 @patch("lftools_uv.openstack.cluster.openstack.connection.from_config")
-def test_cleanup_list_clusters_error(mock_from_config, mock_fetch_builds, capsys):
+def test_cleanup_list_clusters_error(mock_from_config, mock_fetch_builds, caplog):
     """Test handling of errors when listing clusters during cleanup."""
     from openstack.cloud.exc import OpenStackCloudException
 
@@ -487,5 +486,5 @@ def test_cleanup_list_clusters_error(mock_from_config, mock_fetch_builds, capsys
         os_cluster.cleanup("test-cloud", jenkins_urls="https://jenkins.example.org")
 
     assert exc_info.value.code == 1
-    captured = capsys.readouterr()
-    assert "ERROR: Failed to list clusters" in captured.out
+    assert "Failed to list clusters" in caplog.text
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)

--- a/tests/test_openstack_cluster.py
+++ b/tests/test_openstack_cluster.py
@@ -135,7 +135,7 @@ def test_fetch_jenkins_builds_http_error():
     ids=["null-computer", "null-executors", "non-string-url", "top-level-list"],
 )
 @responses.activate
-def test_fetch_jenkins_builds_malformed_shape(payload, capsys):
+def test_fetch_jenkins_builds_malformed_shape(payload, caplog):
     """A valid JSON body with an unexpected shape yields no builds.
 
     Cluster cleanup treats an unusable Jenkins as having no active builds, so
@@ -153,7 +153,7 @@ def test_fetch_jenkins_builds_malformed_shape(payload, capsys):
     builds = os_cluster._fetch_jenkins_builds([jenkins_url])
 
     assert builds == []
-    assert "ERROR" in capsys.readouterr().out
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 @responses.activate

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: EPL-1.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Tests for the split between command results and diagnostics.
+
+Results must reach stdout so a caller can parse them; diagnostics must reach
+stderr so they cannot corrupt that stream. Principle VI of the constitution
+requires it, and docs/commands/rtd.rst promises it to callers.
+
+These run the CLI in a subprocess rather than in-process. The logging handler
+binds to the real ``sys.stderr`` when ``lftools_uv`` is first imported, so an
+in-process test using capsys would capture the wrong stream and prove nothing.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+PROGRAM = """
+import logging
+
+import lftools_uv  # noqa: F401  - installs the console handler
+from lftools_uv.output import echo
+
+log = logging.getLogger("lftools_uv.test")
+echo("result-line")
+log.info("info-diagnostic")
+log.warning("warning-diagnostic")
+log.error("error-diagnostic")
+"""
+
+
+def _run() -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", textwrap.dedent(PROGRAM)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_results_go_to_stdout_alone():
+    """stdout carries the result and nothing else."""
+    result = _run()
+
+    assert result.stdout == "result-line\n"
+
+
+def test_diagnostics_go_to_stderr():
+    """Every log level lands on stderr, keeping stdout parsable."""
+    result = _run()
+
+    assert "info-diagnostic" in result.stderr
+    assert "warning-diagnostic" in result.stderr
+    assert "error-diagnostic" in result.stderr
+
+
+def test_diagnostics_never_reach_stdout():
+    """The regression this guards: a warning corrupting a --json payload."""
+    result = _run()
+
+    for diagnostic in ("info-diagnostic", "warning-diagnostic", "error-diagnostic"):
+        assert diagnostic not in result.stdout
+
+
+def test_level_prefixes_are_applied_to_diagnostics_only():
+    """INFO renders bare; higher levels carry their level name."""
+    result = _run()
+
+    assert "WARNING: warning-diagnostic" in result.stderr
+    assert "ERROR: error-diagnostic" in result.stderr
+    assert "info-diagnostic\n" in result.stderr
+    assert "INFO: info-diagnostic" not in result.stderr


### PR DESCRIPTION
## Summary

PR 4 of the stacked series. Replaces all 71 `print()` calls flagged by
`ai-slop/python-print-debug` with a proper separation between **logging** and
**program output** — on **separate streams**.

Verified finding count: **108 → 37**. Everything remaining is `complexity/*`,
handled in PR 5+.

> **Stacked on #647.** Base is `fix/aislop-misc-findings`. Merge #645–#647 first.

## ⚠️ Behaviour change: diagnostics now go to stderr

**This is the one thing in this PR that needs a deliberate decision from you.**

`lftools_uv/__init__.py` installed the console logging handler on **stdout**. That
violated two things the project already states:

- **Constitution Principle VI** — *"Error messages MUST be clear, actionable, and
  directed to stderr."*
- **`docs/commands/rtd.rst`** — *"Every command accepts `--json` and emits a
  parsable payload on stdout. Diagnostics go to stderr, so a caller may parse
  stdout without a warning corrupting the stream."*

The newer Typer modules already honour this themselves (`typer_apps/zulip.py` and
`rtd.py` route through `emit_error`/`emit_warning`, which are
`typer.echo(..., err=True)`). The package-level handler was the outlier.

This PR moves it to stderr, so the promise is now actually kept:

| Stream | Carries |
|---|---|
| **stdout** | results only — listings, `total: 12.5`, `--json` payloads (via `echo()`) |
| **stderr** | all diagnostics — `INFO` progress, `WARNING`, `ERROR` |

Interactive callers see no difference; both streams reach the terminal. Callers
redirecting stdout to a file now get only the result — which is the point.

*(This was raised by Copilot, which correctly spotted that my original version
claimed a separation that did not actually exist, since both streams were stdout.)*

## The design

The codebase was building log levels out of hand-written string prefixes —
`print(f"ERROR: ...")`, `WARN:`, `INFO:`. Nothing could filter, redirect or
structure them, and the prefixes had drifted (the same severity appeared as both
`WARN` and `WARNING`).

New `lftools_uv/output.py` provides `echo()` for result output. It is the only
place in the package that writes to stdout directly, so the single audit
suppression and `noqa` live there instead of at 71 call sites. Diagnostics use
`logging.getLogger(__name__)` directly.

Other deliberate normalisations, per your "fine for the sake of consistency":

| Before | After |
|---|---|
| `WARN: ...` | `WARNING: ...` |
| `INFO: Found 3 clusters` | `Found 3 clusters` |

Log calls also move to deferred `%s` formatting, so arguments are only rendered
when a record is actually emitted.

## `github_helper.py` — an existing decision preserved

Those seven `print()` calls carried a repeated comment: *"Use print() for
user-facing output to avoid logging PII"*. They print usernames and organisation
names that should not reach log aggregation.

**That reasoning still holds**, so they keep going to stdout and *not* to a
logger — they now use `echo()`, which states the contract once in its own module
rather than repeating it at seven call sites.

## Test changes

Eleven cluster tests moved from `capsys` to `caplog`, asserting on **record
levels** rather than hand-written string prefixes — a stronger assertion than
before. `test_list_clusters` deliberately still uses `capsys`, keeping the
`echo()` stdout contract under test.

New `tests/test_output_streams.py` covers the stream split itself, including the
specific regression it guards against:

```python
def test_diagnostics_never_reach_stdout():
    """The regression this guards: a warning corrupting a --json payload."""
```

These run the CLI in a **subprocess**. An in-process test would prove nothing:
the handler binds to the real stream when `lftools_uv` is first imported, before
`capsys` swaps them — the same trap that forced the cluster tests onto `caplog`.

## Commits

1. `Feat: Add a console output helper` — new `lftools_uv/output.py`
2. `Refactor: Emit OpenStack output through logging` — code + its tests
3. `Refactor: Write GitHub helper output through echo`
4. `Refactor: Route the shape guard through logging` — picks up the guard added in #647
5. `Fix: Send diagnostics to stderr` — the stream split, plus dropping a stray
   `log.exception` traceback from a recovered path

## Verification

- `uv run pytest tests/` — **842 passed**
- `prek run --all-files` — clean
- `ruff check` / `ruff format` / `mypy` / `basedpyright` — clean
