### PR TITLE
Fix: Resolve parked Copilot and CodeQL findings

### DIFF
--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -34,3 +34,27 @@ It supports the following commands:
 Enable debugging via ``lftools-uv --debug`` preceding any commands or via
 environment variable ``DEBUG=True``, this will print extra information if
 available.
+
+Output streams
+==============
+
+Every command splits what it writes across two streams.
+
+**stdout** carries the result: the thing you asked for. Listings, tables,
+``--json`` payloads, generated INFO.yaml documents, API tokens and the
+staging repository id that ``deploy nexus-stage-repo-create`` returns all
+arrive here, with no level prefix, whatever the log level.
+
+**stderr** carries diagnostics: progress, warnings and failures. These
+carry a level and respond to ``--debug``.
+
+The split lets a pipeline consume a result without a warning corrupting
+it:
+
+.. code-block:: bash
+
+   lftools-uv openstack --os-cloud vex image list | grep ubuntu
+   lftools-uv rtd project-version-details onap-cps latest --json | jq '.active'
+
+Silencing diagnostics never silences the result, and raising the
+verbosity never contaminates it.

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -45,8 +45,10 @@ Every command splits what it writes across two streams.
 staging repository id that ``deploy nexus-stage-repo-create`` returns all
 arrive here, with no level prefix, whatever the log level.
 
-**stderr** carries diagnostics: progress, warnings and failures. These
-carry a level and respond to ``--debug``.
+**stderr** carries diagnostics: progress, warnings and failures. A
+warning or failure announces its level, as in ``WARNING: ...``;
+informational progress renders bare, so raising the verbosity with
+``--debug`` adds detail rather than noise.
 
 The split lets a pipeline consume a result without a warning corrupting
 it:

--- a/lftools_uv/cli/config.py
+++ b/lftools_uv/cli/config.py
@@ -18,6 +18,7 @@ import sys
 import click
 
 from lftools_uv import config
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -43,9 +44,9 @@ def get_setting(ctx, section, option):
 
     if isinstance(result, list):
         for i in result:
-            log.info(f"{i}: {config.get_setting(section, i)}")
+            echo(f"{i}: {config.get_setting(section, i)}")
     else:
-        log.info(result)
+        echo(result)
 
 
 @click.command(name="set")

--- a/lftools_uv/cli/deploy.py
+++ b/lftools_uv/cli/deploy.py
@@ -20,6 +20,7 @@ import click
 from requests.exceptions import HTTPError
 
 import lftools_uv.deploy as deploy_sys
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -288,7 +289,7 @@ def nexus_stage_repo_close(ctx, nexus_url, staging_profile_id, staging_repo_id):
 def nexus_stage_repo_create(ctx, nexus_url, staging_profile_id):
     """Create a Nexus staging repo."""
     staging_repo_id = deploy_sys.nexus_stage_repo_create(nexus_url, staging_profile_id)
-    log.info(staging_repo_id)
+    echo(staging_repo_id)
 
 
 @click.command(name="nexus-zip")

--- a/lftools_uv/cli/gerrit.py
+++ b/lftools_uv/cli/gerrit.py
@@ -16,6 +16,7 @@ import click
 
 from lftools_uv.api.endpoints import gerrit
 from lftools_uv.git.gerrit import Gerrit as git_gerrit
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ def addfile(ctx, gerrit_fqdn, gerrit_project, filename, issue_id, file_location)
     """
     g = gerrit.Gerrit(fqdn=gerrit_fqdn)
     data = g.add_file(gerrit_fqdn, gerrit_project, filename, issue_id, file_location)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="addinfojob")
@@ -117,7 +118,7 @@ def abandonchanges(ctx, gerrit_fqdn, gerrit_project):
     """
     g = gerrit.Gerrit(fqdn=gerrit_fqdn)
     data = g.abandon_changes(gerrit_fqdn, gerrit_project)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 # Creates a gerrit project if project does not exist and adds ldap group as owner.
@@ -144,7 +145,7 @@ def createproject(ctx, gerrit_fqdn, gerrit_project, ldap_group, description, che
     """
     g = gerrit.Gerrit(fqdn=gerrit_fqdn)
     data = g.create_project(gerrit_fqdn, gerrit_project, ldap_group, description, check)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="create-saml-group")
@@ -155,7 +156,7 @@ def create_saml_group(ctx, gerrit_fqdn, ldap_group):
     """Create saml group based on ldap group."""
     g = gerrit.Gerrit(fqdn=gerrit_fqdn)
     data = g.create_saml_group(gerrit_fqdn, ldap_group)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="list-project-permissions")
@@ -167,7 +168,7 @@ def list_project_permissions(ctx, gerrit_fqdn, project):
     g = gerrit.Gerrit(fqdn=gerrit_fqdn)
     data = g.list_project_permissions(project)
     for ldap_group in data:
-        log.info(pformat(ldap_group))
+        echo(pformat(ldap_group))
 
 
 @click.command(name="list-project-inherits-from")
@@ -178,7 +179,7 @@ def list_project_inherits_from(ctx, gerrit_fqdn, gerrit_project):
     """List who a project inherits from."""
     g = gerrit.Gerrit(fqdn=gerrit_fqdn)
     data = g.list_project_inherits_from(gerrit_project)
-    log.info(data)
+    echo(data)
 
 
 @click.command(name="addmavenconfig")

--- a/lftools_uv/cli/github_cli.py
+++ b/lftools_uv/cli/github_cli.py
@@ -19,6 +19,7 @@ from github import Github, GithubException
 
 from lftools_uv import config
 from lftools_uv.github_helper import helper_list, helper_user_github, prvotes
+from lftools_uv.output import echo
 
 _GITHUB_PREFIX = "github."
 
@@ -57,7 +58,7 @@ def submit_pr(ctx, organization, repo, pr):
     pr_mergable = repo.get_pull(pr).mergeable
 
     if pr_mergable:
-        log.info(pr_mergable)
+        echo(pr_mergable)
         repo.get_pull(pr).merge(commit_message="Vote Completed, merging INFO file")
     else:
         log.error(f"PR NOT MERGEABLE {pr_mergable}")
@@ -72,7 +73,7 @@ def submit_pr(ctx, organization, repo, pr):
 def votes(ctx, organization, repo, pr):
     """Helper for votes."""
     approval_list = prvotes(organization, repo, pr)
-    log.info(f"Approvals: {approval_list}")
+    echo(f"Approvals: {approval_list}")
 
 
 @click.command(name="list")
@@ -242,7 +243,7 @@ def createteam(ctx, organization, name, repo, privacy):
         my_repos = [repo]
         repos = [repo for repo in get_repos() if repo.name in my_repos]
         for repo in repos:
-            log.info(repo)
+            echo(repo)
         if repos:
             log.info("repo found")
         else:

--- a/lftools_uv/cli/github_cli.py
+++ b/lftools_uv/cli/github_cli.py
@@ -243,7 +243,7 @@ def createteam(ctx, organization, name, repo, privacy):
         my_repos = [repo]
         repos = [repo for repo in get_repos() if repo.name in my_repos]
         for repo in repos:
-            echo(repo)
+            log.info(repo)
         if repos:
             log.info("repo found")
         else:

--- a/lftools_uv/cli/infofile.py
+++ b/lftools_uv/cli/infofile.py
@@ -28,6 +28,7 @@ from lftools_uv import config
 from lftools_uv.cli.errors import error_handler
 from lftools_uv.github_helper import prvotes
 from lftools_uv.ldap_cli import helper_yaml4info
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ def create_info_file(ctx, gerrit_url, gerrit_project, directory, empty, tsc_appr
         if "inherits_from" in result:
             inherits = result["inherits_from"]["id"]
             if inherits != "All-Projects":
-                log.info("    Inherits from: %s", inherits)
+                echo(f"    Inherits from: {inherits}")
                 log.warning("Better Check this unconventional inherit")
 
         try:
@@ -154,21 +155,21 @@ tsc:
       id: ''
 """
     tsc_string = inspect.cleandoc(tsc_string)
-    log.info(long_string)
-    log.info("repositories:")
-    log.info("    - %s", gerrit_project)
-    log.info("committers:")
-    log.info("    - <<: *%s_%s_ptl", umbrella, project_underscored)
+    echo(long_string)
+    echo("repositories:")
+    echo(f"    - {gerrit_project}")
+    echo("committers:")
+    echo(f"    - <<: *{umbrella}_{project_underscored}_ptl")
     if not empty:
         this = helper_yaml4info(ldap_group)
-        # This already contains formatted YAML; log without additional formatting
+        # This already contains formatted YAML; echo without additional formatting
         for line in this.splitlines():
-            log.info(line)
+            echo(line)
     else:
         for line in empty_committer.splitlines():
-            log.info(line)
+            echo(line)
     for line in tsc_string.splitlines():
-        log.info(line)
+        echo(line)
 
 
 @click.command(name="get-committers")
@@ -182,12 +183,12 @@ def get_committers(ctx, file, full, id):
     with open(file) as yaml_file:
         project = yaml.safe_load(yaml_file)
 
-    def log_committer_info(committer, full):
-        """Log committers."""
+    def echo_committer_info(committer, full):
+        """Write one committer to stdout."""
         if full:
-            log.info("    - name: %s", committer.get("name", ""))
-            log.info("      email: %s", committer.get("email", ""))
-        log.info("      id: %s", committer.get("id", ""))
+            echo(f"    - name: {committer.get('name', '')}")
+            echo(f"      email: {committer.get('email', '')}")
+        echo(f"      id: {committer.get('id', '')}")
 
     def list_committers(full, id, project):
         """List committers from the INFO.yaml file."""
@@ -195,11 +196,11 @@ def get_committers(ctx, file, full, id):
         for item in lookup:
             if id:
                 if item.get("id") == id:
-                    log_committer_info(item, full)
+                    echo_committer_info(item, full)
                     break
                 else:
                     continue
-            log_committer_info(item, full)
+            echo_committer_info(item, full)
 
     list_committers(full, id, project)
 

--- a/lftools_uv/cli/infofile.py
+++ b/lftools_uv/cli/infofile.py
@@ -84,7 +84,7 @@ def create_info_file(ctx, gerrit_url, gerrit_project, directory, empty, tsc_appr
         if "inherits_from" in result:
             inherits = result["inherits_from"]["id"]
             if inherits != "All-Projects":
-                echo(f"    Inherits from: {inherits}")
+                log.info("    Inherits from: %s", inherits)
                 log.warning("Better Check this unconventional inherit")
 
         try:

--- a/lftools_uv/cli/jenkins/__init__.py
+++ b/lftools_uv/cli/jenkins/__init__.py
@@ -23,6 +23,7 @@ from lftools_uv.cli.jenkins.nodes import nodes
 from lftools_uv.cli.jenkins.plugins import plugins_init
 from lftools_uv.cli.jenkins.token import token
 from lftools_uv.jenkins import Jenkins
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ for (c in creds) {
 }
 """
     result = jenkins.server.run_script(groovy_script)
-    log.info(result)
+    echo(result)
 
 
 @click.command()
@@ -99,7 +100,7 @@ for (c in creds) {
 }
 """
     result = jenkins.server.run_script(groovy_script)
-    log.info(result)
+    echo(result)
 
 
 @click.command()
@@ -129,7 +130,7 @@ for (c in creds) {
 }
 """
     result = jenkins.server.run_script(groovy_script)
-    log.info(result)
+    echo(result)
 
 
 @click.command()
@@ -142,7 +143,7 @@ def groovy(ctx, groovy_file):
 
     jenkins = ctx.obj["jenkins"]
     result = jenkins.server.run_script(data)
-    log.info(result)
+    echo(result)
 
 
 @click.command()
@@ -229,7 +230,7 @@ for (node in Jenkins.instance.computers) {
         result = jenkins.server.run_script(force_script)
     else:
         result = jenkins.server.run_script(groovy_script)
-    log.info(result)
+    echo(result)
 
 
 jenkins_cli.add_command(plugins_init, name="plugins")

--- a/lftools_uv/cli/jenkins/builds.py
+++ b/lftools_uv/cli/jenkins/builds.py
@@ -11,11 +11,9 @@
 
 __author__ = "Trevor Bramwell"
 
-import logging
-
 import click
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,7 +31,7 @@ def running(ctx):
     running_builds = jenkins.server.get_running_builds()
 
     for build in running_builds:
-        log.info("- %s on %s", build["name"], build["node"])
+        echo(f"- {build['name']} on {build['node']}")
 
 
 @click.command()
@@ -44,14 +42,14 @@ def queued(ctx):
     queue = jenkins.server.get_queue_info()
 
     queue_length = len(queue)
-    log.info("Build Queue (%s)", queue_length)
+    echo(f"Build Queue ({queue_length})")
     for build in queue:
         status_flags = []
         if build.get("stuck"):
             status_flags.append("[Stuck]")
         if build.get("blocked"):
             status_flags.append("[Blocked]")
-        log.info(" - %s%s", build["task"]["name"], (" " + " ".join(status_flags)) if status_flags else "")
+        echo(f" - {build['task']['name']}{(' ' + ' '.join(status_flags)) if status_flags else ''}")
 
 
 builds.add_command(running)

--- a/lftools_uv/cli/jenkins/jobs.py
+++ b/lftools_uv/cli/jenkins/jobs.py
@@ -11,11 +11,9 @@
 
 __author__ = "Anil Belur"
 
-import logging
-
 import click
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 enable_disable_jobs = """
 import jenkins.*
@@ -54,7 +52,7 @@ def enable(ctx, regex):
     jenkins = ctx.obj["jenkins"]
 
     result = jenkins.server.run_script(enable_disable_jobs.format(regex, "enable"))
-    log.info(result)
+    echo(result)
 
 
 @click.command()
@@ -65,7 +63,7 @@ def disable(ctx, regex):
     jenkins = ctx.obj["jenkins"]
 
     result = jenkins.server.run_script(enable_disable_jobs.format(regex, "disable"))
-    log.info(result)
+    echo(result)
 
 
 jobs.add_command(enable)

--- a/lftools_uv/cli/jenkins/nodes.py
+++ b/lftools_uv/cli/jenkins/nodes.py
@@ -11,11 +11,9 @@
 
 __author__ = "Trevor Bramwell"
 
-import logging
-
 import click
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 def offline_str(status):
@@ -40,7 +38,7 @@ def list_nodes(ctx):
     node_list = ctx.obj["nodes"]
 
     for node in node_list:
-        log.info("%s [%s]", node["name"], offline_str(node["offline"]))
+        echo(f"{node['name']} [{offline_str(node['offline'])}]")
 
 
 nodes.add_command(list_nodes, name="list")

--- a/lftools_uv/cli/jenkins/plugins.py
+++ b/lftools_uv/cli/jenkins/plugins.py
@@ -11,12 +11,10 @@
 
 __author__ = "Trevor Bramwell"
 
-import logging
-
 import click
 import requests
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 def checkmark(truthy):
@@ -27,8 +25,8 @@ def checkmark(truthy):
 
 
 def print_plugin(plugin, namefield="longName"):
-    """Log the plugin longName and version."""
-    log.info("%s:%s", plugin[namefield], plugin["version"])
+    """Print the plugin longName and version to stdout."""
+    echo(f"{plugin[namefield]}:{plugin['version']}")
 
 
 @click.group()
@@ -180,7 +178,7 @@ def sec(ctx):
                 for version in w["versions"]:
                     lastversion = version.get("lastVersion")
                 if name == key and secdict[key] == lastversion:
-                    log.info(f"{key}:{secdict[key]}\t{key}:{activedict[key]}\t{url}")
+                    echo(f"{key}:{secdict[key]}\t{key}:{activedict[key]}\t{url}")
 
 
 plugins_init.add_command(list_plugins, name="list")

--- a/lftools_uv/cli/jenkins/plugins.py
+++ b/lftools_uv/cli/jenkins/plugins.py
@@ -145,7 +145,6 @@ def sec(ctx):
     secdict = {}
     for w in warn:
         name = w["name"]
-        url = w["url"]
         lastversion = None
         for version in w["versions"]:
             lastversion = version.get("lastVersion")

--- a/lftools_uv/cli/jenkins/token.py
+++ b/lftools_uv/cli/jenkins/token.py
@@ -21,6 +21,7 @@ import requests
 
 from lftools_uv import config as lftools_cfg
 from lftools_uv.jenkins.token import get_token
+from lftools_uv.output import echo
 
 _MSG_CREDS_NOT_SET = "Username or password not set."
 
@@ -47,7 +48,7 @@ def change(ctx, name):
         log.error(_MSG_CREDS_NOT_SET)
         sys.exit(1)
 
-    log.info(get_token(name=name, url=jenkins.url, change=True, username=username, password=password))
+    echo(get_token(name=name, url=jenkins.url, change=True, username=username, password=password))
 
 
 @click.command()
@@ -96,7 +97,7 @@ def print_token(ctx):
         log.error(_MSG_CREDS_NOT_SET)
         sys.exit(1)
 
-    log.info(get_token(name="token-created-by-lftools", url=jenkins.url, username=username, password=password))
+    echo(get_token(name="token-created-by-lftools", url=jenkins.url, username=username, password=password))
 
 
 @click.command()
@@ -147,7 +148,7 @@ def reset(ctx, servers):
         cfg_sections = config.sections()
     elif len(servers) == 1:
         key = _reset_key(config, servers[0])
-        log.info(key)
+        echo(key)
         return
     else:
         cfg_sections = list(servers)

--- a/lftools_uv/cli/ldap_cli.py
+++ b/lftools_uv/cli/ldap_cli.py
@@ -21,6 +21,8 @@ import sys
 import click
 import ldap  # pyright: ignore[reportMissingImports]
 
+from lftools_uv.output import echo
+
 log = logging.getLogger(__name__)
 
 
@@ -173,7 +175,7 @@ def csv(ctx, ldap_server, ldap_group_base, ldap_user_base, groups):
                     user = user.decode("utf-8")
                     user_info = ldap_query(ldap_obj, ldap_user_base, user, ["uid", "cn", "mail"])
                     try:
-                        log.info("%s,%s", group_name, user_to_csv(user_info))
+                        echo(f"{group_name},{user_to_csv(user_info)}")
                     except Exception:
                         log.error("Error parsing user: %s", user)
                         continue

--- a/lftools_uv/cli/nexus2/privilege.py
+++ b/lftools_uv/cli/nexus2/privilege.py
@@ -12,12 +12,10 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,7 +31,7 @@ def list(ctx):
     """List privileges."""
     r = ctx.obj["nexus2"]
     data = r.privilege_list()
-    log.info(tabulate(data, headers=["Name", "ID"]))
+    echo(tabulate(data, headers=["Name", "ID"]))
 
 
 @privilege.command(name="create")
@@ -45,7 +43,7 @@ def create(ctx, name, description, repo):
     """Create a new privilege."""
     r = ctx.obj["nexus2"]
     data = r.privilege_create(name, description, repo)
-    log.info(data)
+    echo(data)
 
 
 @privilege.command(name="delete")
@@ -55,4 +53,4 @@ def delete(ctx, privilege_id):
     """Delete a privilege."""
     r = ctx.obj["nexus2"]
     data = r.privilege_delete(privilege_id)
-    log.info(data)
+    echo(data)

--- a/lftools_uv/cli/nexus2/repository.py
+++ b/lftools_uv/cli/nexus2/repository.py
@@ -12,12 +12,10 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,7 +31,7 @@ def repo_list(ctx):
     """List repositories."""
     r = ctx.obj["nexus2"]
     data = r.repo_list()
-    log.info(tabulate(data, headers=["Name", "Type", "Provider", "ID"]))
+    echo(tabulate(data, headers=["Name", "Type", "Provider", "ID"]))
 
 
 @repo.command(name="create")
@@ -49,7 +47,7 @@ def create(ctx, repo_type, repo_id, repo_name, repo_provider, repo_policy, repo_
     """Create a new repository."""
     r = ctx.obj["nexus2"]
     data = r.repo_create(repo_type, repo_id, repo_name, repo_provider, repo_policy, repo_upstream_url)
-    log.info(data)
+    echo(data)
 
 
 @repo.command(name="delete")
@@ -59,4 +57,4 @@ def delete(ctx, repo_id):
     """Permanently delete a repo."""
     r = ctx.obj["nexus2"]
     data = r.repo_delete(repo_id)
-    log.info(data)
+    echo(data)

--- a/lftools_uv/cli/nexus2/role.py
+++ b/lftools_uv/cli/nexus2/role.py
@@ -12,12 +12,10 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,7 +31,7 @@ def role_list(ctx):
     """List users."""
     r = ctx.obj["nexus2"]
     data = r.role_list()
-    log.info(tabulate(data, headers=["ID", "Name", "Roles", "Privileges"], tablefmt="grid"))
+    echo(tabulate(data, headers=["ID", "Name", "Roles", "Privileges"], tablefmt="grid"))
 
 
 @role.command(name="create")
@@ -47,7 +45,7 @@ def role_create(ctx, role_id, role_name, role_description, roles_list, privilege
     """Create a new role."""
     r = ctx.obj["nexus2"]
     data = r.role_create(role_id, role_name, role_description, roles_list, privileges_list)
-    log.info(data)
+    echo(data)
 
 
 @role.command(name="delete")
@@ -57,4 +55,4 @@ def role_delete(ctx, role_id):
     """Delete a role."""
     r = ctx.obj["nexus2"]
     data = r.role_delete(role_id)
-    log.info(data)
+    echo(data)

--- a/lftools_uv/cli/nexus2/user.py
+++ b/lftools_uv/cli/nexus2/user.py
@@ -12,12 +12,10 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,7 +31,7 @@ def user_list(ctx):
     """List users."""
     r = ctx.obj["nexus2"]
     data = r.user_list()
-    log.info(tabulate(data, headers=["ID", "First Name", "Last Name", "Status", "Roles"]))
+    echo(tabulate(data, headers=["ID", "First Name", "Last Name", "Status", "Roles"]))
 
 
 @user.command(name="add")
@@ -49,7 +47,7 @@ def user_create(ctx, username, firstname, lastname, email, roles, password):
     """Add a new user."""
     r = ctx.obj["nexus2"]
     data = r.user_create(username, firstname, lastname, email, roles, password)
-    log.info(data)
+    echo(data)
 
 
 @user.command(name="delete")
@@ -59,4 +57,4 @@ def user_details(ctx, username):
     """Delete a user."""
     r = ctx.obj["nexus2"]
     data = r.user_delete(username)
-    log.info(data)
+    echo(data)

--- a/lftools_uv/cli/nexus3/asset.py
+++ b/lftools_uv/cli/nexus3/asset.py
@@ -12,12 +12,11 @@
 
 __author__ = "DW Talton"
 
-import logging
 from pprint import pformat
 
 import click
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -35,7 +34,7 @@ def asset_list(ctx, repository):
     r = ctx.obj["nexus3"]
     data = r.list_assets(repository)
     for item in data:
-        log.info(pformat(item))
+        echo(pformat(item))
 
 
 @asset.command(name="search")
@@ -49,7 +48,7 @@ def asset_search(ctx, query_string, repository, details):
     data = r.search_asset(query_string, repository, details)
 
     if details:
-        log.info(data)
+        echo(data)
     else:
         for item in data:
-            log.info(item)
+            echo(item)

--- a/lftools_uv/cli/nexus3/privilege.py
+++ b/lftools_uv/cli/nexus3/privilege.py
@@ -12,12 +12,10 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,4 +31,4 @@ def list_privileges(ctx):
     """List privileges."""
     r = ctx.obj["nexus3"]
     data = r.list_privileges()
-    log.info(tabulate(data, headers=["Type", "Name", "Description", "Read Only"]))
+    echo(tabulate(data, headers=["Type", "Name", "Description", "Read Only"]))

--- a/lftools_uv/cli/nexus3/repository.py
+++ b/lftools_uv/cli/nexus3/repository.py
@@ -12,12 +12,11 @@
 
 __author__ = "DW Talton"
 
-import logging
 from pprint import pformat
 
 import click
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,4 +32,4 @@ def list_repositories(ctx):
     """List repositories."""
     r = ctx.obj["nexus3"]
     data = r.list_repositories()
-    log.info(pformat(data))
+    echo(pformat(data))

--- a/lftools_uv/cli/nexus3/role.py
+++ b/lftools_uv/cli/nexus3/role.py
@@ -12,13 +12,12 @@
 
 __author__ = "DW Talton"
 
-import logging
 from pprint import pformat
 
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -34,7 +33,7 @@ def list_roles(ctx):
     """List roles."""
     r = ctx.obj["nexus3"]
     data = r.list_roles()
-    log.info(tabulate(data, headers=["Roles"]))
+    echo(tabulate(data, headers=["Roles"]))
 
 
 @role.command(name="create")
@@ -47,4 +46,4 @@ def create_role(ctx, name, description, privileges, roles):
     """Create roles."""
     r = ctx.obj["nexus3"]
     data = r.create_role(name, description, privileges, roles)
-    log.info(pformat(data))
+    echo(pformat(data))

--- a/lftools_uv/cli/nexus3/script.py
+++ b/lftools_uv/cli/nexus3/script.py
@@ -12,11 +12,9 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -34,7 +32,7 @@ def create_script(ctx, name, filename):
     """Create a new script."""
     r = ctx.obj["nexus3"]
     data = r.create_script(name, filename)
-    log.info(data)
+    echo(data)
 
 
 @script.command(name="delete")
@@ -44,7 +42,7 @@ def delete_script(ctx, name):
     """Delete a script."""
     r = ctx.obj["nexus3"]
     data = r.delete_script(name)
-    log.info(data)
+    echo(data)
 
 
 @script.command(name="list")
@@ -53,7 +51,7 @@ def list_scripts(ctx):
     """List all scripts."""
     r = ctx.obj["nexus3"]
     data = r.list_scripts()
-    log.info(data)
+    echo(data)
 
 
 @script.command(name="read")
@@ -63,7 +61,7 @@ def read_script(ctx, name):
     """Get script contents."""
     r = ctx.obj["nexus3"]
     data = r.read_script(name)
-    log.info(data)
+    echo(data)
 
 
 @script.command(name="run")
@@ -73,7 +71,7 @@ def run_script(ctx, name):
     """Run a script."""
     r = ctx.obj["nexus3"]
     data = r.run_script(name)
-    log.info(data)
+    echo(data)
 
 
 @script.command(name="update")
@@ -84,4 +82,4 @@ def update_script(ctx, name, content):
     """Update script contents."""
     r = ctx.obj["nexus3"]
     data = r.update_script(name, content)
-    log.info(data)
+    echo(data)

--- a/lftools_uv/cli/nexus3/tag.py
+++ b/lftools_uv/cli/nexus3/tag.py
@@ -12,12 +12,11 @@
 
 __author__ = "DW Talton"
 
-import logging
 from pprint import pformat
 
 import click
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -35,7 +34,7 @@ def add_tag(ctx, name, attributes):
     """Add a tag."""
     r = ctx.obj["nexus3"]
     data = r.create_tag(name, attributes)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @tag.command(name="delete")
@@ -45,7 +44,7 @@ def delete_tag(ctx, name):
     """Delete a tag."""
     r = ctx.obj["nexus3"]
     data = r.delete_tag(name)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @tag.command(name="list")
@@ -54,7 +53,7 @@ def list_tags(ctx):
     """List tags."""
     r = ctx.obj["nexus3"]
     data = r.list_tags()
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @tag.command(name="show")
@@ -64,4 +63,4 @@ def show_tag(ctx, name):
     """Show tags."""
     r = ctx.obj["nexus3"]
     data = r.show_tag(name)
-    log.info(pformat(data))
+    echo(pformat(data))

--- a/lftools_uv/cli/nexus3/task.py
+++ b/lftools_uv/cli/nexus3/task.py
@@ -12,12 +12,10 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -33,7 +31,7 @@ def list_tasks(ctx):
     """List tasks."""
     r = ctx.obj["nexus3"]
     data = r.list_tasks()
-    log.info(
+    echo(
         tabulate(
             data,
             headers=["Name", "Message", "Current State", "Last Run Result"],

--- a/lftools_uv/cli/nexus3/user.py
+++ b/lftools_uv/cli/nexus3/user.py
@@ -12,12 +12,10 @@
 
 __author__ = "DW Talton"
 
-import logging
-
 import click
 from tabulate import tabulate
 
-log = logging.getLogger(__name__)
+from lftools_uv.output import echo
 
 
 @click.group()
@@ -34,7 +32,7 @@ def search_user(ctx, username):
     """Search users."""
     r = ctx.obj["nexus3"]
     data = r.list_user(username)
-    log.info(
+    echo(
         tabulate(
             data,
             headers=[
@@ -62,7 +60,7 @@ def user_create(ctx, username, first_name, last_name, email_address, roles, pass
     """Create a new user account."""
     r = ctx.obj["nexus3"]
     data = r.create_user(username, first_name, last_name, email_address, roles, password)
-    log.info(data)
+    echo(data)
 
 
 @user.command(name="delete")
@@ -72,4 +70,4 @@ def user_delete(ctx, username):
     """Delete a user account."""
     r = ctx.obj["nexus3"]
     data = r.delete_user(username)
-    log.info(data)
+    echo(data)

--- a/lftools_uv/cli/rtd.py
+++ b/lftools_uv/cli/rtd.py
@@ -30,6 +30,7 @@ import click
 
 from lftools_uv.api.endpoints import readthedocs
 from lftools_uv.api.endpoints.readthedocs import ReadTheDocsError, ReadTheDocsNotFoundError
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ _DEPRECATION_NOTICE = (
 
 def _emit_json(data: object) -> None:
     """Print a payload as JSON, matching the historical output format."""
-    log.info(json.dumps(data, indent=2))
+    echo(json.dumps(data, indent=2))
 
 
 @click.group()
@@ -63,7 +64,7 @@ def project_list(ctx):
     """
     r = readthedocs.ReadTheDocs()
     for project in r.project_list():
-        log.info(project)
+        echo(project)
 
 
 @click.command(name="project-details")
@@ -73,7 +74,7 @@ def project_details(ctx, project_slug):
     """Retrieve project details."""
     r = readthedocs.ReadTheDocs()
     data = r.project_details(project_slug)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="project-version-list")
@@ -84,7 +85,7 @@ def project_version_list(ctx, project_slug):
     r = readthedocs.ReadTheDocs()
     data = r.project_version_list(project_slug)
     for version in data:
-        log.info(version)
+        echo(version)
 
 
 @click.command(name="project-version-update")
@@ -99,7 +100,7 @@ def project_version_update(ctx, project_slug, version_slug, active):
     """
     r = readthedocs.ReadTheDocs()
     data = r.project_version_update(project_slug, version_slug, active)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="project-version-details")
@@ -126,7 +127,7 @@ def project_create(ctx, project_name, repository_url, repository_type, homepage,
     """Create a new project."""
     r = readthedocs.ReadTheDocs()
     data = r.project_create(project_name, repository_url, repository_type, homepage, programming_language, language)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(
@@ -146,7 +147,7 @@ def project_update(ctx, project_name):
         key, value = item.split("=", 1)
         d[key] = value
     data = r.project_update(project_name, d)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="project-build-list")
@@ -159,7 +160,7 @@ def project_build_list(ctx, project_slug):
     if data:
         _emit_json({"count": len(data), "results": data})
     else:
-        log.info("There are no active builds.")
+        echo("There are no active builds.")
 
 
 @click.command(name="project-build-details")
@@ -195,7 +196,7 @@ def subproject_list(ctx, project_slug):
     """
     r = readthedocs.ReadTheDocs()
     for subproject in r.subproject_list(project_slug):
-        log.info(subproject)
+        echo(subproject)
 
 
 @click.command(name="subproject-details")
@@ -206,7 +207,7 @@ def subproject_details(ctx, project_slug, subproject_slug):
     """Retrieve subproject's details."""
     r = readthedocs.ReadTheDocs()
     data = r.subproject_details(project_slug, subproject_slug)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="subproject-create")
@@ -217,7 +218,7 @@ def subproject_create(ctx, project_slug, subproject_slug):
     """Create a project-subproject relationship."""
     r = readthedocs.ReadTheDocs()
     data = r.subproject_create(project_slug, subproject_slug)
-    log.info(pformat(data))
+    echo(pformat(data))
 
 
 @click.command(name="subproject-delete")

--- a/lftools_uv/github_helper.py
+++ b/lftools_uv/github_helper.py
@@ -71,43 +71,38 @@ def helper_list(  # noqa: C901, PLR0912
         echo(f"All repos for organization:  {organization}")
         all_repos = org.get_repos()
         for repo in all_repos:
-            log.info(repo.name)
+            echo(repo.name)
 
     if audit:
-        log.info("%s members without 2fa:", organization)
+        echo(f"{organization} members without 2fa:")
         try:
             members: PaginatedList[NamedUser] = org.get_members(filter_="2fa_disabled")
         except GithubException as ghe:
             log.error(ghe)
             sys.exit(1)
         for member in members:
-            log.info(member.login)
-        log.info("%s outside collaborators without 2fa:", organization)
+            echo(member.login)
+        echo(f"{organization} outside collaborators without 2fa:")
         try:
             collaborators: PaginatedList[NamedUser] = org.get_outside_collaborators(filter_="2fa_disabled")
         except GithubException as ghe:
             log.error(ghe)
             sys.exit(1)
         for collaborator in collaborators:
-            log.info(collaborator.login)
+            echo(collaborator.login)
 
     if repofeatures:
         feat_repos = org.get_repos()
         for repo in feat_repos:
-            log.info(
-                "%s wiki:%s issues:%s",
-                repo.name,
-                repo.has_wiki,
-                repo.has_issues,
-            )
+            echo(f"{repo.name} wiki:{repo.has_wiki} issues:{repo.has_issues}")
             issues = repo.get_issues
             for issue in issues():
-                log.info("%s", issue)
+                echo(issue)
 
     if full:
-        log.info("---")
-        log.info("#  All owners for %s:", organization)
-        log.info("%s-owners:", organization)
+        echo("---")
+        echo(f"#  All owners for {organization}:")
+        echo(f"{organization}-owners:")
 
         try:
             admin_members: PaginatedList[NamedUser] = org.get_members(role="admin")
@@ -115,9 +110,9 @@ def helper_list(  # noqa: C901, PLR0912
             log.error(ghe)
             sys.exit(1)
         for member in admin_members:
-            log.info(_YAML_LIST_ITEM_FMT, member.login)
-        log.info("#  All members for %s", organization)
-        log.info("%s-members:", organization)
+            echo(_YAML_LIST_ITEM_FMT % member.login)
+        echo(f"#  All members for {organization}")
+        echo(f"{organization}-members:")
 
         try:
             all_members: PaginatedList[NamedUser] = org.get_members()
@@ -125,8 +120,8 @@ def helper_list(  # noqa: C901, PLR0912
             log.error(ghe)
             sys.exit(1)
         for member in all_members:
-            log.info(_YAML_LIST_ITEM_FMT, member.login)
-        log.info("#  All members and all teams for %s", organization)
+            echo(_YAML_LIST_ITEM_FMT % member.login)
+        echo(f"#  All members and all teams for {organization}")
 
         try:
             get_teams_fn = org.get_teams
@@ -134,10 +129,10 @@ def helper_list(  # noqa: C901, PLR0912
             log.error(ghe)
             sys.exit(1)
         for org_team in get_teams_fn():
-            log.info("%s:", org_team.name)
+            echo(f"{org_team.name}:")
             for user in org_team.get_members():
-                log.info(_YAML_LIST_ITEM_FMT, user.login)
-            log.info("")
+                echo(_YAML_LIST_ITEM_FMT % user.login)
+            echo()
 
     if teams:
         try:
@@ -146,7 +141,7 @@ def helper_list(  # noqa: C901, PLR0912
             log.error(ghe)
             sys.exit(1)
         for org_team in get_teams_fn2():
-            log.info("%s", org_team.name)
+            echo(org_team.name)
 
     if team:
         try:
@@ -159,10 +154,10 @@ def helper_list(  # noqa: C901, PLR0912
 
         for t in get_teams_fn3():
             if t.name == team:
-                log.info("%s", t.name)
+                echo(t.name)
                 for user in t.get_members():
                     team_members.append(user.login)
-                    log.info(_YAML_LIST_ITEM_FMT, user.login)
+                    echo(_YAML_LIST_ITEM_FMT % user.login)
 
         return team_members
 
@@ -181,7 +176,7 @@ def prvotes(organization: str, repo: str, pr: int) -> list[str]:
     approval_list.append(author)
 
     pr_mergable = gh_repo.get_pull(pr).mergeable
-    log.info("MERGEABLE: %s", pr_mergable)
+    echo(f"MERGEABLE: {pr_mergable}")
 
     approvals = gh_repo.get_pull(pr).get_reviews()
     for approve in approvals:

--- a/lftools_uv/github_helper.py
+++ b/lftools_uv/github_helper.py
@@ -165,7 +165,13 @@ def helper_list(  # noqa: C901, PLR0912
 
 
 def prvotes(organization: str, repo: str, pr: int) -> list[str]:
-    """Get votes on a github pr."""
+    """Get votes on a github pr.
+
+    Shared by ``github votes`` and ``infofile check-votes``, so the
+    mergeability observation stays on the diagnostic stream: the two
+    commands disagree about what their result is, and only the caller
+    knows which stream a line belongs on.
+    """
     token: str = config.get_setting("github", "token")
     g: Github = Github(token)
     org: Organization = _get_org(g, organization)
@@ -176,7 +182,7 @@ def prvotes(organization: str, repo: str, pr: int) -> list[str]:
     approval_list.append(author)
 
     pr_mergable = gh_repo.get_pull(pr).mergeable
-    echo(f"MERGEABLE: {pr_mergable}")
+    log.info("MERGEABLE: %s", pr_mergable)
 
     approvals = gh_repo.get_pull(pr).get_reviews()
     for approve in approvals:

--- a/lftools_uv/nexus/cmd.py
+++ b/lftools_uv/nexus/cmd.py
@@ -26,6 +26,7 @@ import yaml
 
 from lftools_uv import config
 from lftools_uv.nexus import Nexus, util
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -366,7 +367,7 @@ def output_images(images: list[dict[str, Any]], csv_path: str | None = None) -> 
                 dw.writerow({k: v for k, v in image.items() if k in included_keys})
 
     for image in images:
-        log.info("Name: {}\nVersion: {}\nID: {}\n\n".format(image["name"], image["version"], image["id"]))
+        echo("Name: {}\nVersion: {}\nID: {}\n\n".format(image["name"], image["version"], image["id"]))
     log.info(f"Found {count} images matching the query")
 
 

--- a/lftools_uv/nexus/release_docker_hub/__init__.py
+++ b/lftools_uv/nexus/release_docker_hub/__init__.py
@@ -63,6 +63,7 @@ from lftools_uv.nexus.release_docker_hub.util import (
     get_docker_name_from_file,
     repo_is_in_file,
 )
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -237,28 +238,28 @@ def copy_from_nexus_to_docker(progbar: bool = False) -> None:
 def print_nexus_docker_proj_names() -> None:
     """Print Nexus3 - Docker Hub repositories."""
     fmt_str = "{:<" + str(project_max_len_chars) + "} : "
-    log.info("")
+    echo()
     log_str = fmt_str.format(settings.nexus3_proj_name_header)
     log_str = f"{log_str}{settings.docker_proj_name_header}"
-    log.info(log_str)
-    log.info("-" * project_max_len_chars * 2)
+    echo(log_str)
+    echo("-" * project_max_len_chars * 2)
     docker_i = 0
     for proj in projects:
         log_str = fmt_str.format(proj.nexus_repo_name)
         log_str = f"{log_str}{proj.docker_repo_name}"
-        log.info(log_str)
+        echo(log_str)
         docker_i = docker_i + 1
-    log.info("")
+    echo()
 
 
 def print_tags_header(header_str: str, col_1_str: str) -> None:
     """Print simple header."""
     fmt_str = "{:<" + str(project_max_len_chars) + "} : "
-    log.info(header_str)
+    echo(header_str)
     log_str = fmt_str.format(col_1_str)
     log_str = "{}{}".format(log_str, "Tags")
-    log.info(log_str)
-    log.info("-" * project_max_len_chars * 2)
+    echo(log_str)
+    echo("-" * project_max_len_chars * 2)
 
 
 def print_tags_data(proj_name: str, tags: list[str]) -> None:
@@ -272,7 +273,7 @@ def print_tags_data(proj_name: str, tags: list[str]) -> None:
                 log_str = f"{log_str}, "
             log_str = f"{log_str}{tag}"
             tag_i = tag_i + 1
-        log.info(log_str)
+        echo(log_str)
 
 
 def print_nexus_valid_tags() -> None:
@@ -280,7 +281,7 @@ def print_nexus_valid_tags() -> None:
     print_tags_header("Nexus Valid Tags", settings.nexus3_proj_name_header)
     for proj in projects:
         print_tags_data(proj.nexus_repo_name, proj.nexus_tags.valid)
-    log.info("")
+    echo()
 
 
 def print_nexus_invalid_tags() -> None:
@@ -288,7 +289,7 @@ def print_nexus_invalid_tags() -> None:
     print_tags_header("Nexus InValid Tags", settings.nexus3_proj_name_header)
     for proj in projects:
         print_tags_data(proj.nexus_repo_name, proj.nexus_tags.invalid)
-    log.info("")
+    echo()
 
 
 def print_docker_valid_tags() -> None:
@@ -296,7 +297,7 @@ def print_docker_valid_tags() -> None:
     print_tags_header("Docker Valid Tags", settings.docker_proj_name_header)
     for proj in projects:
         print_tags_data(proj.docker_repo_name, proj.docker_tags.valid)
-    log.info("")
+    echo()
 
 
 def print_docker_invalid_tags() -> None:
@@ -304,7 +305,7 @@ def print_docker_invalid_tags() -> None:
     print_tags_header("Docker InValid Tags", settings.docker_proj_name_header)
     for proj in projects:
         print_tags_data(proj.docker_repo_name, proj.docker_tags.invalid)
-    log.info("")
+    echo()
 
 
 def print_stats() -> None:
@@ -312,40 +313,40 @@ def print_stats() -> None:
     print_tags_header("Tag statistics (V=Valid, I=InValid)", settings.nexus3_proj_name_header)
     fmt_str = "{:<" + str(project_max_len_chars) + "} : "
     for proj in projects:
-        log.info(
+        echo(
             f"{fmt_str.format(proj.nexus_repo_name)}Nexus V:{len(proj.nexus_tags.valid)} I:{len(proj.nexus_tags.invalid)} -- Docker V:{len(proj.docker_tags.valid)} I:{len(proj.docker_tags.invalid)}"
         )
-    log.info("")
+    echo()
 
 
 def print_missing_docker_proj() -> None:
     """Print missing docker repos."""
-    log.info("Missing corresponding Docker Project")
+    echo("Missing corresponding Docker Project")
     fmt_str = "{:<" + str(project_max_len_chars) + "} : "
     log_str = fmt_str.format(settings.nexus3_proj_name_header)
     log_str = f"{log_str}{settings.docker_proj_name_header}"
-    log.info(log_str)
-    log.info("-" * project_max_len_chars * 2)
+    echo(log_str)
+    echo("-" * project_max_len_chars * 2)
     all_docker_repos_found = True
     for proj in projects:
         if not proj.docker_tags.repository_exist:
             log_str = fmt_str.format(proj.nexus_repo_name)
             log_str = f"{log_str}{proj.docker_repo_name}"
-            log.info(log_str)
+            echo(log_str)
             all_docker_repos_found = False
     if all_docker_repos_found:
-        log.info("All Docker Hub repos found.")
-    log.info("")
+        echo("All Docker Hub repos found.")
+    echo()
 
 
 def print_nexus_tags_to_copy() -> None:
     """Print tags that needs to be copied."""
-    log.info("Nexus project tags to copy to docker")
+    echo("Nexus project tags to copy to docker")
     fmt_str = "{:<" + str(project_max_len_chars) + "} : "
     log_str = fmt_str.format(settings.nexus3_proj_name_header)
     log_str = "{}{}".format(log_str, "Tags to copy")
-    log.info(log_str)
-    log.info("-" * project_max_len_chars * 2)
+    echo(log_str)
+    echo("-" * project_max_len_chars * 2)
     for proj in projects:
         if len(proj.tags_2_copy.valid) > 0:
             log_str = ""
@@ -356,8 +357,8 @@ def print_nexus_tags_to_copy() -> None:
                     log_str = f"{log_str}, "
                 log_str = f"{log_str}{tag}"
                 tag_i = tag_i + 1
-            log.info(log_str)
-    log.info("")
+            echo(log_str)
+    echo()
 
 
 def print_nbr_tags_to_copy() -> None:
@@ -365,7 +366,7 @@ def print_nbr_tags_to_copy() -> None:
     _tot_tags = 0
     for proj in projects:
         _tot_tags = _tot_tags + len(proj.tags_2_copy.valid)
-    log.info(f"Summary: {_tot_tags} tags that should be copied from Nexus3 to Docker Hub.")
+    echo(f"Summary: {_tot_tags} tags that should be copied from Nexus3 to Docker Hub.")
 
 
 def start_point(

--- a/lftools_uv/nexus/release_docker_hub/__init__.py
+++ b/lftools_uv/nexus/release_docker_hub/__init__.py
@@ -68,7 +68,6 @@ log = logging.getLogger(__name__)
 
 NexusCatalog: list[list[str]] = []
 projects: list[ProjectClass] = []
-TotTagsToBeCopied: int = 0
 project_max_len_chars: int = 0
 
 

--- a/lftools_uv/openstack/image.py
+++ b/lftools_uv/openstack/image.py
@@ -28,6 +28,8 @@ import openstack
 import openstack.connection
 from openstack.cloud.exc import OpenStackCloudException
 
+from lftools_uv.output import echo
+
 log = logging.getLogger(__name__)
 
 
@@ -62,7 +64,7 @@ def list(os_cloud, days=0, hide_public=False, ci_managed=True):
 
     filtered_images = _filter_images(images, days, hide_public, ci_managed)
     for image in filtered_images:
-        log.info(image.name)
+        echo(image.name)
 
 
 def cleanup(os_cloud, days=0, hide_public=False, ci_managed=True, clouds=None):

--- a/lftools_uv/shell/dco.py
+++ b/lftools_uv/shell/dco.py
@@ -19,6 +19,8 @@ import subprocess
 import sys
 from os import chdir, getcwd
 
+from lftools_uv.output import echo
+
 log = logging.getLogger(__name__)
 
 
@@ -87,7 +89,7 @@ def check(path=getcwd(), signoffs_dir="dco_signoffs"):
 
             if missing_list:
                 for commit in missing_list:
-                    log.info(f"{commit}")
+                    echo(f"{commit}")
                 sys.exit(1)
     except subprocess.CalledProcessError as e:
         log.exception(e)
@@ -133,7 +135,7 @@ def match(path=getcwd(), signoffs_dir="dco_signoffs"):
                     ):
                         continue
 
-                log.info(
+                echo(
                     f"For commit ID {commit_id}: \n\tCommitter is {commit_author_email}\n\tbut commit is signed off by {sob_results}\n"
                 )
                 exit_code = 1

--- a/lftools_uv/typer_apps/config.py
+++ b/lftools_uv/typer_apps/config.py
@@ -17,6 +17,7 @@ import logging
 import typer
 
 from lftools_uv import config
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -43,9 +44,9 @@ def get_setting(
 
     if isinstance(result, list):
         for i in result:
-            log.info(f"{i}: {config.get_setting(section, i)}")
+            echo(f"{i}: {config.get_setting(section, i)}")
     else:
-        log.info(result)
+        echo(result)
 
 
 @config_app.command(name="set")

--- a/lftools_uv/typer_apps/deploy.py
+++ b/lftools_uv/typer_apps/deploy.py
@@ -18,6 +18,7 @@ import typer
 from requests.exceptions import HTTPError
 
 import lftools_uv.deploy as deploy_sys
+from lftools_uv.output import echo
 
 _HELP_NEXUS_STAGING_ID = "Nexus staging profile ID"
 _HELP_NEXUS_URL = "Nexus server URL"
@@ -253,7 +254,7 @@ def nexus_stage_repo_create(
 ) -> None:
     """Create a Nexus staging repo."""
     staging_repo_id = deploy_sys.nexus_stage_repo_create(nexus_url, staging_profile_id)
-    log.info(staging_repo_id)
+    echo(staging_repo_id)
 
 
 @deploy_app.command(name="nexus-zip")

--- a/lftools_uv/typer_apps/gerrit.py
+++ b/lftools_uv/typer_apps/gerrit.py
@@ -16,6 +16,7 @@ import typer
 
 from lftools_uv.api.endpoints import gerrit
 from lftools_uv.git.gerrit import Gerrit as git_gerrit
+from lftools_uv.output import echo
 
 _HELP_ISSUE_ID = "For projects that enforce an issue id for changesets"
 _HELP_GERRIT_FQDN = "Gerrit FQDN"
@@ -47,7 +48,7 @@ def addfile(
     try:
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.add_file(gerrit_fqdn, gerrit_project, filename, issue_id or "", file_location or "")
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to add file")
         raise typer.Exit(1) from None
@@ -133,7 +134,7 @@ def abandonchanges(
     try:
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.abandon_changes(gerrit_fqdn, gerrit_project)
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to abandon changes")
         raise typer.Exit(1) from None
@@ -161,7 +162,7 @@ def createproject(
     try:
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.create_project(gerrit_fqdn, gerrit_project, ldap_group, description, check)
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to create project")
         raise typer.Exit(1) from None
@@ -176,7 +177,7 @@ def create_saml_group(
     try:
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.create_saml_group(gerrit_fqdn, ldap_group)
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to create SAML group")
         raise typer.Exit(1) from None
@@ -192,7 +193,7 @@ def list_project_permissions(
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.list_project_permissions(project)
         for ldap_group in data:
-            log.info(pformat(ldap_group))
+            echo(pformat(ldap_group))
     except Exception:
         log.exception("Failed to list project permissions")
         raise typer.Exit(1) from None
@@ -207,7 +208,7 @@ def list_project_inherits_from(
     try:
         g = gerrit.Gerrit(fqdn=gerrit_fqdn)
         data = g.list_project_inherits_from(gerrit_project)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to list project inheritance")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/github_cli.py
+++ b/lftools_uv/typer_apps/github_cli.py
@@ -20,6 +20,7 @@ from github import Github, GithubException
 
 from lftools_uv import config
 from lftools_uv.github_helper import helper_list, helper_user_github, prvotes
+from lftools_uv.output import echo
 
 _HELP_GITHUB_ORG = "GitHub organization name"
 
@@ -54,7 +55,7 @@ def submit_pr(
         pr_mergeable = repo_obj.get_pull(pr).mergeable
 
         if pr_mergeable:
-            log.info("PR is mergeable: %s", pr_mergeable)
+            echo(f"PR is mergeable: {pr_mergeable}")
             repo_obj.get_pull(pr).merge(commit_message="Vote Completed, merging INFO file")
             log.info("PR merged successfully")
         else:
@@ -73,7 +74,7 @@ def votes(
 ) -> None:
     """Helper for votes."""
     approval_list = prvotes(organization, repo, pr)
-    log.info("Approvals: %s", approval_list)
+    echo(f"Approvals: {approval_list}")
 
 
 @github_app.command(name="list")

--- a/lftools_uv/typer_apps/jenkins/builds.py
+++ b/lftools_uv/typer_apps/jenkins/builds.py
@@ -6,6 +6,8 @@ import logging
 
 import typer
 
+from lftools_uv.output import echo
+
 log = logging.getLogger(__name__)
 
 builds_app = typer.Typer(help="Information regarding current builds and the queue.")
@@ -19,7 +21,7 @@ def builds_running(ctx: typer.Context) -> None:
         running_builds = jenkins.server.get_running_builds()
 
         for build in running_builds:
-            log.info("- %s on %s", build["name"], build["node"])
+            echo(f"- {build['name']} on {build['node']}")
     except Exception:
         log.exception("Failed to get running builds")
         raise typer.Exit(1) from None
@@ -33,14 +35,14 @@ def builds_queued(ctx: typer.Context) -> None:
         queue = jenkins.server.get_queue_info()
 
         queue_length = len(queue)
-        log.info("Build Queue (%s)", queue_length)
+        echo(f"Build Queue ({queue_length})")
         for build in queue:
             status_flags = []
             if build.get("stuck"):
                 status_flags.append("[Stuck]")
             if build.get("blocked"):
                 status_flags.append("[Blocked]")
-            log.info(" - %s%s", build["task"]["name"], (" " + " ".join(status_flags)) if status_flags else "")
+            echo(f" - {build['task']['name']}{(' ' + ' '.join(status_flags)) if status_flags else ''}")
     except Exception:
         log.exception("Failed to get queued builds")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/jenkins/jobs.py
+++ b/lftools_uv/typer_apps/jenkins/jobs.py
@@ -6,6 +6,8 @@ import logging
 
 import typer
 
+from lftools_uv.output import echo
+
 log = logging.getLogger(__name__)
 
 jobs_app = typer.Typer(help="Command to update Jenkins Jobs.")
@@ -41,7 +43,7 @@ def jobs_enable(ctx: typer.Context, regex: str = typer.Argument(..., help="Regex
     try:
         jenkins = ctx.obj["jenkins"]
         result = jenkins.server.run_script(enable_disable_jobs.format(regex, "enable"))
-        log.info(result)
+        echo(result)
     except Exception:
         log.exception("Failed to enable jobs")
         raise typer.Exit(1) from None
@@ -53,7 +55,7 @@ def jobs_disable(ctx: typer.Context, regex: str = typer.Argument(..., help="Rege
     try:
         jenkins = ctx.obj["jenkins"]
         result = jenkins.server.run_script(enable_disable_jobs.format(regex, "disable"))
-        log.info(result)
+        echo(result)
     except Exception:
         log.exception("Failed to disable jobs")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/jenkins/nodes.py
+++ b/lftools_uv/typer_apps/jenkins/nodes.py
@@ -6,6 +6,8 @@ import logging
 
 import typer
 
+from lftools_uv.output import echo
+
 log = logging.getLogger(__name__)
 
 nodes_app = typer.Typer(help="Find information about builders connected to Jenkins Master.")
@@ -27,7 +29,7 @@ def nodes_list(ctx: typer.Context) -> None:
         node_list = jenkins.server.get_nodes()
 
         for node in node_list:
-            log.info("%s [%s]", node["name"], offline_str(node["offline"]))
+            echo(f"{node['name']} [{offline_str(node['offline'])}]")
     except Exception:
         log.exception("Failed to list nodes")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/jenkins/plugins.py
+++ b/lftools_uv/typer_apps/jenkins/plugins.py
@@ -158,7 +158,6 @@ def plugins_sec(ctx: typer.Context) -> None:
         secdict = {}
         for w in warn:
             name = w["name"]
-            url = w["url"]
             lastversion = None
             for version in w["versions"]:
                 lastversion = version.get("lastVersion")

--- a/lftools_uv/typer_apps/jenkins/plugins.py
+++ b/lftools_uv/typer_apps/jenkins/plugins.py
@@ -7,6 +7,8 @@ import logging
 import requests
 import typer
 
+from lftools_uv.output import echo
+
 log = logging.getLogger(__name__)
 
 plugins_app = typer.Typer(help="Inspect Jenkins plugins on the server.")
@@ -21,8 +23,8 @@ def checkmark(truthy):
 
 
 def print_plugin(plugin, namefield="longName"):
-    """Log the plugin longName and version."""
-    log.info("%s:%s", plugin[namefield], plugin["version"])
+    """Print the plugin longName and version to stdout."""
+    echo(f"{plugin[namefield]}:{plugin['version']}")
 
 
 @plugins_app.command("list")
@@ -194,7 +196,7 @@ def plugins_sec(ctx: typer.Context) -> None:
                     if name == key and secdict[key] == lastversion:
                         # Tab-separated columns: vulnerable version,
                         # installed version, then the advisory URL.
-                        log.info("%s:%s\t%s:%s\t%s", key, secdict[key], key, activedict[key], url)
+                        echo(f"{key}:{secdict[key]}\t{key}:{activedict[key]}\t{url}")
     except Exception:
         log.exception("Failed to check plugin security")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/jenkins/server.py
+++ b/lftools_uv/typer_apps/jenkins/server.py
@@ -8,6 +8,7 @@ from urllib.error import HTTPError
 import typer
 
 from lftools_uv.jenkins import Jenkins
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ for (c in creds) {
 }
 """
         result = jenkins.server.run_script(groovy_script)
-        log.info(result)
+        echo(result)
     except Exception:
         log.exception("Failed to get credentials")
         raise typer.Exit(1) from None
@@ -107,7 +108,7 @@ for (c in creds) {
 }
 """
         result = jenkins.server.run_script(groovy_script)
-        log.info(result)
+        echo(result)
     except Exception:
         log.exception("Failed to get secrets")
         raise typer.Exit(1) from None
@@ -140,7 +141,7 @@ for (c in creds) {
 }
 """
         result = jenkins.server.run_script(groovy_script)
-        log.info(result)
+        echo(result)
     except Exception:
         log.exception("Failed to get private keys")
         raise typer.Exit(1) from None
@@ -155,7 +156,7 @@ def groovy(ctx: typer.Context, groovy_file: str = typer.Argument(..., help="Path
 
         jenkins = ctx.obj["jenkins"]
         result = jenkins.server.run_script(data)
-        log.info(result)
+        echo(result)
     except FileNotFoundError:
         log.error(f"Groovy file not found: {groovy_file}")
         raise typer.Exit(1) from None
@@ -264,7 +265,7 @@ for (node in Jenkins.instance.computers) {
             result = jenkins.server.run_script(force_script)
         else:
             result = jenkins.server.run_script(groovy_script)
-        log.info(result)
+        echo(result)
     except Exception:
         log.exception("Failed to remove offline nodes")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/jenkins/token.py
+++ b/lftools_uv/typer_apps/jenkins/token.py
@@ -11,6 +11,7 @@ import typer
 
 from lftools_uv import config as lftools_cfg
 from lftools_uv.jenkins.token import get_token
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ def token_change(
             log.error(_MSG_CREDS_NOT_SET)
             raise typer.Exit(1)
 
-        log.info(get_token(name, jenkins.url, username=username, password=password, change=True))
+        echo(get_token(name, jenkins.url, username=username, password=password, change=True))
     except Exception:
         log.exception("Failed to change token")
         raise typer.Exit(1) from None
@@ -102,7 +103,7 @@ def token_print(ctx: typer.Context) -> None:
             log.error(_MSG_CREDS_NOT_SET)
             raise typer.Exit(1)
 
-        log.info(get_token("token", jenkins.url, username, password))
+        echo(get_token("token", jenkins.url, username, password))
     except Exception:
         log.exception("Failed to print token")
         raise typer.Exit(1) from None
@@ -156,7 +157,7 @@ def token_reset(
             cfg_sections = config.sections()
         elif len(servers) == 1:
             key = _reset_key(config, servers[0])
-            log.info(key)
+            echo(key)
             return
         else:
             cfg_sections = list(servers)

--- a/lftools_uv/typer_apps/nexus2.py
+++ b/lftools_uv/typer_apps/nexus2.py
@@ -15,6 +15,7 @@ import typer
 from tabulate import tabulate
 
 from lftools_uv.api.endpoints import nexus2
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ def privilege_list(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus2"]
         data = r.privilege_list()
-        log.info(tabulate(data, headers=["Name", "ID"]))
+        echo(tabulate(data, headers=["Name", "ID"]))
     except Exception:
         log.exception("Failed to list privileges")
         raise typer.Exit(1) from None
@@ -82,7 +83,7 @@ def privilege_create(
     try:
         r = ctx.obj["nexus2"]
         data = r.privilege_create(name, description, repo)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to create privilege")
         raise typer.Exit(1) from None
@@ -97,7 +98,7 @@ def privilege_delete(
     try:
         r = ctx.obj["nexus2"]
         data = r.privilege_delete(privilege_id)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to delete privilege")
         raise typer.Exit(1) from None
@@ -110,7 +111,7 @@ def repo_list(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus2"]
         data = r.repo_list()
-        log.info(tabulate(data, headers=["Name", "Type", "Provider", "ID"]))
+        echo(tabulate(data, headers=["Name", "Type", "Provider", "ID"]))
     except Exception:
         log.exception("Failed to list repositories")
         raise typer.Exit(1) from None
@@ -130,7 +131,7 @@ def repo_create(
     try:
         r = ctx.obj["nexus2"]
         data = r.repo_create(repo_type, repo_id, repo_name, repo_provider, repo_policy, repo_upstream_url)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to create repository")
         raise typer.Exit(1) from None
@@ -145,7 +146,7 @@ def repo_delete(
     try:
         r = ctx.obj["nexus2"]
         data = r.repo_delete(repo_id)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to delete repository")
         raise typer.Exit(1) from None
@@ -158,7 +159,7 @@ def role_list(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus2"]
         data = r.role_list()
-        log.info(tabulate(data, headers=["ID", "Name", "Roles", "Privileges"], tablefmt="grid"))
+        echo(tabulate(data, headers=["ID", "Name", "Roles", "Privileges"], tablefmt="grid"))
     except Exception:
         log.exception("Failed to list roles")
         raise typer.Exit(1) from None
@@ -177,7 +178,7 @@ def role_create(
     try:
         r = ctx.obj["nexus2"]
         data = r.role_create(role_id, role_name, role_description, roles_list, privileges_list)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to create role")
         raise typer.Exit(1) from None
@@ -192,7 +193,7 @@ def role_delete(
     try:
         r = ctx.obj["nexus2"]
         data = r.role_delete(role_id)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to delete role")
         raise typer.Exit(1) from None
@@ -205,7 +206,7 @@ def user_list(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus2"]
         data = r.user_list()
-        log.info(tabulate(data, headers=["ID", "First Name", "Last Name", "Status", "Roles"]))
+        echo(tabulate(data, headers=["ID", "First Name", "Last Name", "Status", "Roles"]))
     except Exception:
         log.exception("Failed to list users")
         raise typer.Exit(1) from None
@@ -225,7 +226,7 @@ def user_create(
     try:
         r = ctx.obj["nexus2"]
         data = r.user_create(username, firstname, lastname, email, roles, password)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to create user")
         raise typer.Exit(1) from None
@@ -240,7 +241,7 @@ def user_delete(
     try:
         r = ctx.obj["nexus2"]
         data = r.user_delete(username)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to delete user")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/nexus3.py
+++ b/lftools_uv/typer_apps/nexus3.py
@@ -16,6 +16,7 @@ import typer
 from tabulate import tabulate
 
 from lftools_uv.api.endpoints import nexus3
+from lftools_uv.output import echo
 
 log = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ def asset_list(ctx: typer.Context, repository: str = typer.Argument(..., help="R
         r = ctx.obj["nexus3"]
         data = r.list_assets(repository)
         for item in data:
-            log.info(pformat(item))
+            echo(pformat(item))
     except Exception:
         log.exception("Failed to list assets")
         raise typer.Exit(1) from None
@@ -95,10 +96,10 @@ def asset_search(
         data = r.search_asset(query_string, repository, details)
 
         if details:
-            log.info(data)
+            echo(data)
         else:
             for item in data:
-                log.info(item)
+                echo(item)
     except Exception:
         log.exception("Failed to search assets")
         raise typer.Exit(1) from None
@@ -111,7 +112,7 @@ def list_privileges(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus3"]
         data = r.list_privileges()
-        log.info(tabulate(data, headers=["Type", "Name", "Description", "Read Only"]))
+        echo(tabulate(data, headers=["Type", "Name", "Description", "Read Only"]))
     except Exception:
         log.exception("Failed to list privileges")
         raise typer.Exit(1) from None
@@ -124,7 +125,7 @@ def list_repositories(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus3"]
         data = r.list_repositories()
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to list repositories")
         raise typer.Exit(1) from None
@@ -137,7 +138,7 @@ def list_roles(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus3"]
         data = r.list_roles()
-        log.info(tabulate(data, headers=["Roles"]))
+        echo(tabulate(data, headers=["Roles"]))
     except Exception:
         log.exception("Failed to list roles")
         raise typer.Exit(1) from None
@@ -155,7 +156,7 @@ def create_role(
     try:
         r = ctx.obj["nexus3"]
         data = r.create_role(name, description, privileges, roles)
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to create role")
         raise typer.Exit(1) from None
@@ -172,7 +173,7 @@ def create_script(
     try:
         r = ctx.obj["nexus3"]
         data = r.create_script(name, filename)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to create script")
         raise typer.Exit(1) from None
@@ -187,7 +188,7 @@ def delete_script(
     try:
         r = ctx.obj["nexus3"]
         data = r.delete_script(name)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to delete script")
         raise typer.Exit(1) from None
@@ -199,7 +200,7 @@ def list_scripts(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus3"]
         data = r.list_scripts()
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to list scripts")
         raise typer.Exit(1) from None
@@ -214,7 +215,7 @@ def read_script(
     try:
         r = ctx.obj["nexus3"]
         data = r.read_script(name)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to read script")
         raise typer.Exit(1) from None
@@ -229,7 +230,7 @@ def run_script(
     try:
         r = ctx.obj["nexus3"]
         data = r.run_script(name)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to run script")
         raise typer.Exit(1) from None
@@ -245,7 +246,7 @@ def update_script(
     try:
         r = ctx.obj["nexus3"]
         data = r.update_script(name, content)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to update script")
         raise typer.Exit(1) from None
@@ -262,7 +263,7 @@ def add_tag(
     try:
         r = ctx.obj["nexus3"]
         data = r.create_tag(name, attributes)
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to add tag")
         raise typer.Exit(1) from None
@@ -277,7 +278,7 @@ def delete_tag(
     try:
         r = ctx.obj["nexus3"]
         data = r.delete_tag(name)
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to delete tag")
         raise typer.Exit(1) from None
@@ -289,7 +290,7 @@ def list_tags(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus3"]
         data = r.list_tags()
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to list tags")
         raise typer.Exit(1) from None
@@ -304,7 +305,7 @@ def show_tag(
     try:
         r = ctx.obj["nexus3"]
         data = r.show_tag(name)
-        log.info(pformat(data))
+        echo(pformat(data))
     except Exception:
         log.exception("Failed to show tag")
         raise typer.Exit(1) from None
@@ -317,7 +318,7 @@ def list_tasks(ctx: typer.Context) -> None:
     try:
         r = ctx.obj["nexus3"]
         data = r.list_tasks()
-        log.info(
+        echo(
             tabulate(
                 data,
                 headers=["Name", "Message", "Current State", "Last Run Result"],
@@ -338,7 +339,7 @@ def search_user(
     try:
         r = ctx.obj["nexus3"]
         data = r.list_user(username)
-        log.info(
+        echo(
             tabulate(
                 data,
                 headers=[
@@ -370,7 +371,7 @@ def user_create(
     try:
         r = ctx.obj["nexus3"]
         data = r.create_user(username, first_name, last_name, email_address, roles, password)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to create user")
         raise typer.Exit(1) from None
@@ -385,7 +386,7 @@ def user_delete(
     try:
         r = ctx.obj["nexus3"]
         data = r.delete_user(username)
-        log.info(data)
+        echo(data)
     except Exception:
         log.exception("Failed to delete user")
         raise typer.Exit(1) from None

--- a/lftools_uv/typer_apps/zulip/folders.py
+++ b/lftools_uv/typer_apps/zulip/folders.py
@@ -264,4 +264,4 @@ def folder_move(
             }
         )
     else:
-        typer.echo(f"Moved folder {folder_id} {position} folder {reference_id}", err=True)
+        typer.echo(f"Moved folder {folder_id} {position} folder {reference_id}")

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -70,3 +70,190 @@ def test_level_prefixes_are_applied_to_diagnostics_only():
     assert "ERROR: error-diagnostic" in result.stderr
     assert "info-diagnostic\n" in result.stderr
     assert "INFO: info-diagnostic" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Real commands
+#
+# The contract above is only worth anything if the commands themselves honour
+# it. Sending every log record to stderr moved the *results* of any command
+# that still announced them with log.info() onto the wrong stream, so these
+# drive real commands end to end through the CLI entry point with their
+# backends stubbed, and assert where each stream's content lands.
+# ---------------------------------------------------------------------------
+
+_COMMAND_PROGRAM = """
+import sys
+from unittest import mock
+
+import lftools_uv  # noqa: F401  - installs the console handler
+from lftools_uv.cli import main
+
+{setup}
+
+sys.argv = {argv!r}
+main()
+"""
+
+
+def _run_command(setup: str, argv: list[str], legacy_cli: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run one real CLI command in a subprocess against stubbed backends.
+
+    :arg setup: Python source installing the mocks, run before the command.
+        Patches must be started rather than entered as context managers so
+        they stay live for the duration of the command.
+    :arg argv: Full argument vector, including the program name.
+    :arg legacy_cli: Run the deprecated Click CLI instead of the Typer one.
+    """
+    program = _COMMAND_PROGRAM.format(setup=textwrap.dedent(setup), argv=argv)
+    env = {"LEGACY_CLI": "1"} if legacy_cli else {}
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**_base_env(), **env},
+    )
+
+
+def _base_env() -> dict[str, str]:
+    """Environment for a command subprocess, minus any CLI selection."""
+    import os
+
+    return {key: value for key, value in os.environ.items() if key != "LEGACY_CLI"}
+
+
+_NEXUS3_SETUP = """
+from lftools_uv.api.endpoints import nexus3 as nexus3_api
+
+client = mock.Mock()
+client.list_roles.return_value = [["nx-admin"], ["nx-anonymous"]]
+_ = mock.patch.object(nexus3_api, "Nexus3", return_value=client).start()
+"""
+
+
+def test_nexus3_role_list_writes_its_table_to_stdout():
+    """``nexus3 role list`` puts the role table where a pipe can read it."""
+    result = _run_command(_NEXUS3_SETUP, ["lftools-uv", "nexus3", "nexus.example.org", "role", "list"])
+
+    assert "Roles" in result.stdout
+    assert "nx-admin" in result.stdout
+    assert "nx-anonymous" in result.stdout
+
+
+def test_nexus3_role_list_keeps_its_table_off_stderr():
+    """The same table must not be duplicated onto the diagnostic stream."""
+    result = _run_command(_NEXUS3_SETUP, ["lftools-uv", "nexus3", "nexus.example.org", "role", "list"])
+
+    assert "nx-admin" not in result.stderr
+
+
+_RTD_SETUP = """
+from lftools_uv.api.endpoints import readthedocs
+
+client = mock.Mock()
+client.project_list.return_value = ["onap-cps", "onap-doc"]
+_ = mock.patch.object(readthedocs, "ReadTheDocs", return_value=client).start()
+"""
+
+_RTD_ARGV = ["lftools-uv", "rtd", "project-list"]
+
+
+def test_legacy_rtd_project_list_emits_only_slugs_on_stdout():
+    """The legacy Click command still writes a clean, parsable list."""
+    result = _run_command(_RTD_SETUP, _RTD_ARGV, legacy_cli=True)
+
+    assert result.stdout == "onap-cps\nonap-doc\n"
+
+
+def test_legacy_rtd_deprecation_notice_stays_on_stderr():
+    """A command emitting both a result and a diagnostic separates them.
+
+    ``rtd`` warns that the legacy group is deprecated on every call. That
+    warning must not land in the middle of the project list.
+    """
+    result = _run_command(_RTD_SETUP, _RTD_ARGV, legacy_cli=True)
+
+    assert "deprecated" in result.stderr
+    assert "deprecated" not in result.stdout
+
+
+_GITHUB_SETUP = """
+from lftools_uv import github_helper
+
+first = mock.Mock()
+first.name = "repo-a"
+second = mock.Mock()
+second.name = "repo-b"
+
+org = mock.Mock()
+org.get_repos.return_value = [first, second]
+client = mock.Mock()
+client.get_organization.return_value = org
+
+_ = mock.patch.object(github_helper, "Github", return_value=client).start()
+_ = mock.patch.object(github_helper.config, "has_section", return_value=True).start()
+_ = mock.patch.object(github_helper.config, "get_setting", return_value="a-token").start()
+"""
+
+_GITHUB_ARGV = ["lftools-uv", "github", "list", "example-org", "--repos"]
+
+
+def test_github_list_repos_keeps_heading_and_names_together():
+    """``github list --repos`` must not straddle the two streams.
+
+    The heading already went to stdout while the repository names went to
+    the logger; a caller redirecting stdout got the heading and nothing
+    else.
+    """
+    result = _run_command(_GITHUB_SETUP, _GITHUB_ARGV)
+
+    assert "All repos for organization:  example-org" in result.stdout
+    assert "repo-a" in result.stdout
+    assert "repo-b" in result.stdout
+
+
+def test_github_list_repos_writes_no_names_to_stderr():
+    """None of the listing leaks onto the diagnostic stream."""
+    result = _run_command(_GITHUB_SETUP, _GITHUB_ARGV)
+
+    assert "repo-a" not in result.stderr
+    assert "repo-b" not in result.stderr
+
+
+_OPENSTACK_SETUP = """
+from types import SimpleNamespace
+
+import openstack.connection
+
+images = [
+    SimpleNamespace(
+        name="ubuntu-2204",
+        visibility="private",
+        properties={"ci_managed": "yes"},
+        is_protected=False,
+        created_at="2026-01-01T00:00:00Z",
+    ),
+    SimpleNamespace(
+        name="ubuntu-2404",
+        visibility="private",
+        properties={"ci_managed": "yes"},
+        is_protected=False,
+        created_at="2026-01-02T00:00:00Z",
+    ),
+]
+
+cloud = mock.Mock()
+cloud.list_images.return_value = images
+_ = mock.patch.object(openstack.connection, "from_config", return_value=cloud).start()
+"""
+
+
+def test_openstack_image_list_emits_only_names_on_stdout():
+    """``openstack image list`` stays pipeable into grep or xargs."""
+    result = _run_command(
+        _OPENSTACK_SETUP,
+        ["lftools-uv", "openstack", "--os-cloud", "test-cloud", "image", "list"],
+    )
+
+    assert result.stdout == "ubuntu-2204\nubuntu-2404\n"

--- a/tests/unit/test_zulip_cli.py
+++ b/tests/unit/test_zulip_cli.py
@@ -278,6 +278,19 @@ def test_folder_move_after_by_bare_id(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.last_order == [11, 12, 10]
 
 
+def test_folder_move_confirmation_goes_to_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The table-mode confirmation shares the stream its ``--json`` twin uses.
+
+    ``folder move`` was the only mutation in the folder group writing its
+    confirmation to stderr, so a caller reading stdout saw nothing unless
+    it passed ``--json``.
+    """
+    _patched_folder_move_client(monkeypatch)
+    result = CliRunner().invoke(zulip_app, ["folder", "move", "--folder-id", "12", "--before", "Projects"])
+    assert result.exit_code == 0, result.output
+    assert "Moved folder 12 before folder 10" in result.stdout
+
+
 @pytest.mark.parametrize(
     "args",
     [


### PR DESCRIPTION
Closes #654.

Four commits: the three parked findings, plus one carrying the Copilot review feedback on this PR.

## `Fix(jenkins): Drop dead url assignment in plugins sec`

CodeQL flagged `url = w["url"]` in the first warnings loop of `plugins_sec` as a value that is never read. That loop only builds a name-to-version mapping; the delta loop further down rebinds `url` from the same warning before the advisory line is emitted. Removed from the Typer command and from its legacy Click counterpart, which carries the same dead binding.

## `Fix(nexus): Drop unused TotTagsToBeCopied global`

CodeQL flagged the module-level `TotTagsToBeCopied` in the Docker Hub release package as never read. Nothing declares it `global` and nothing reads it — the running total lives in a local inside the copy routine.

## `Fix(output): Route command results to stdout`

The substantive one, addressing the Copilot review on #648.

Sending the package-wide log handler to stderr fixed diagnostics corrupting a parsable stream, but it also moved the *results* of every command that still announced them with `log.info()`. A caller redirecting stdout got nothing back:

- `nexus3 role list` lost its table
- `openstack image list` lost its names
- the legacy `rtd` commands lost their JSON
- `github list --repos` was split, its heading on stdout and the repository names on stderr

### What moved

Result-producing calls now go through `lftools_uv.output.echo`, across both command layers and the library helpers that exist purely to print a report:

| Area | Files |
| --- | --- |
| Nexus 2/3 | `cli/nexus2/*`, `cli/nexus3/*`, `typer_apps/nexus2.py`, `typer_apps/nexus3.py`, `nexus/cmd.py`, `nexus/release_docker_hub/__init__.py` |
| Jenkins | `cli/jenkins/*`, `typer_apps/jenkins/*` |
| Read the Docs / Gerrit / config | `cli/rtd.py`, `cli/gerrit.py`, `typer_apps/gerrit.py`, `cli/config.py`, `typer_apps/config.py` |
| GitHub | `github_helper.py`, `cli/github_cli.py`, `typer_apps/github_cli.py` |
| Other | `openstack/image.py`, `cli/infofile.py`, `cli/ldap_cli.py`, `cli/deploy.py`, `typer_apps/deploy.py`, `shell/dco.py` |

`%`-style logging calls became f-strings producing byte-identical text, so no output format changes. Tabs in the `plugins sec` advisory lines and the significant leading whitespace in generated INFO.yaml are preserved. Twelve Nexus CLI modules ended up with no logging calls at all and lost their now-dead logger.

### What deliberately stayed

Progress, status and verdict messages stay on the logger — that is what the second stream is for. Examples left alone: `"Archives upload complete."`, `"Resetting API key for {section}"`, `"Success: {n}"` / `"Failed: {n}"`, `"Repository 'x' created successfully"`, `"PASS: No rules have failed"`, `"Still waiting..."`, the `rtd` deprecation warning, and the INFO.yaml vote tally. For those commands the exit code carries the outcome.

Shared helpers stay off stdout too, since only the caller knows what its result is.

### Regression tests

`tests/test_output_streams.py` grows seven tests that drive **real commands** end to end through `lftools_uv.cli.main` in a subprocess against stubbed backends, so the handler binds the real `sys.stderr` and the streams are genuinely separate:

- `nexus3 role list` — table on stdout, absent from stderr
- `rtd project-list` under `LEGACY_CLI=1` — slugs on stdout, the deprecation warning on stderr and nowhere else, covering a single invocation that emits both kinds of output
- `github list --repos` — heading and repository names together on stdout
- `openstack image list` — names and nothing else on stdout

Each was verified to fail against the pre-fix code.

### Docs

`docs/commands/index.rst` now describes the stdout/stderr contract for every command rather than leaving it documented only under `rtd`.

## `Fix(output): Address Copilot review feedback`

Five findings across two review rounds on this PR. Three were over-reach on my part, pulled back:

- **`prvotes()`** no longer writes to stdout. It is shared with `infofile check-votes`, which deliberately keeps its tally and verdict on the diagnostic stream; a shared helper cannot know which stream its caller considers a result. Docstring records the reasoning.
- **`create-info-file`'s unconventional-inherit notice** goes back to the logger. It precedes the generated document and pairs with a warning, so treating it as a result put an indented scalar ahead of the `---` marker and made a redirected INFO.yaml unparsable.
- **The repository lookup in the legacy `create-team`** goes back to the logger. It validates the `--repo` argument and pairs with a `repo found` progress line; `create-team` mutates rather than reports, so it has no result payload.

One was a documentation correction:

- The output-stream section implied every diagnostic carries a level prefix. INFO records render bare; only a warning or failure announces its level.

And one turned up a genuine pre-existing bug:

- **`zulip folder move`** confirmed on stderr via `typer.echo(..., err=True)` while its own `--json` branch and every sibling mutation in the folder group (`folder create`, `folder update`, `folder archive`, `channel archive`, `channel create`) confirm on stdout. Dropped the `err=True` and added `test_folder_move_confirmation_goes_to_stdout`, verified to fail beforehand. The remaining `err=True` sites in the zulip package are all genuine error-path diagnostics and stay put.

## Validation

```
uv run pytest tests/ -q      → 850 passed
uv run ruff check lftools_uv tests    → All checks passed!
uv run ruff format --check            → 181 files already formatted
prek (full hook set, incl. mypy, basedpyright, reuse, codespell, write-good) → Passed
aislop ci --changes                   → 0 errors, 0 warnings
aislop scan . vs upstream/main        → score 100 → 100, findings 0 → 0
```

Copilot's third pass over `15b7ed5` reviewed 46 of 46 files and generated no new comments. All five review threads are answered and resolved.

### Known unrelated CI failure

`Functional Tests (nexus, ...)` fails on `nexus3.repository.list` with:

```
ERROR: Failed to list repositories
ValueError: Expected JSON list body in API response
```

Reproduced identically from a clean worktree at `upstream/main`, so it predates this branch and is not caused by these changes. Left alone.
